### PR TITLE
Fix: iOS hot-restart issue with active listeners

### DIFF
--- a/ios/Classes/AblyStreamsChannel.m
+++ b/ios/Classes/AblyStreamsChannel.m
@@ -99,7 +99,7 @@
 }
 
 - (void) reset{
-    for (NSString* key in _streams) {
+    for (NSString* key in [_streams mutableCopy]) {
         AblyStreamsChannelStream *stream = _streams[key];
         [stream.handler onCancelWithArguments:nil];
         [_streams removeObjectForKey:key];


### PR DESCRIPTION
Dropping key from streams dict while enumerating - [err: Collection was mutated while being enumerated]
Fixed by using a `mutableCopy` of `_streams`