### PR TITLE
Basis for discussion about what linter rules to enable

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -116,7 +116,6 @@ linter:
     - library_names
     - library_prefixes
     - lines_longer_than_80_chars
-# Too annoying when long strings with interpolations are broken into multiple lines which we do often
     - missing_whitespace_between_adjacent_strings
     - no_default_cases             # experimental
     - no_runtimeType_toString

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,9 +31,9 @@ linter:
     - avoid_slow_async_io
     - avoid_types_as_parameter_names
     - avoid_web_libraries_in_flutter
-    # subject to false positives, perhaps worth supressing in code in such cases
+    # subject to false positives, perhaps worth suppressing in code in such cases
     - cancel_subscriptions
-    # subject to false positives, perhaps worth supressing in code in such cases
+    # subject to false positives, perhaps worth suppressing in code in such cases
     - close_sinks
     - comment_references
     - control_flow_in_finally
@@ -53,8 +53,6 @@ linter:
     - throw_in_finally
     - unnecessary_statements
     - unrelated_type_equality_checks
-    - unsafe_html
-    - use_key_in_widget_constructors
     - valid_regexps
 
 ## Style Rules
@@ -63,7 +61,7 @@ linter:
 #    - always_put_control_body_on_new_line # works against dartfmt
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
-#    - always_specify_types        # this works agains general Dart style guides
+#    - always_specify_types        # this works against general Dart style guides
     - annotate_overrides
     - avoid_annotating_with_dynamic
 #    - avoid_as                    # obsolete - this was considered good practice in Dart 1
@@ -91,10 +89,9 @@ linter:
     - avoid_returning_null_for_void
     - avoid_returning_this
     - avoid_setters_without_getters
-    - avoid_shadowing_type_parameters # personal preference
+    - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_types_on_closure_parameters
-    - avoid_unnecessary_containers
     - avoid_unused_constructor_parameters
     - avoid_void_async
     - await_only_futures
@@ -102,14 +99,13 @@ linter:
     - camel_case_types
     - cascade_invocations
     - constant_identifier_names
-    - curly_braces_in_flow_control_structures # personal preference
+    - curly_braces_in_flow_control_structures
     - directives_ordering
-    - do_not_use_environment # depends on project requirements
+    - do_not_use_environment
     - empty_catches
     - empty_constructor_bodies
     - exhaustive_cases
     - file_names
-#    - flutter_style_todos         # I find the required ":" annoying and pointless
     - implementation_imports
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
@@ -122,8 +118,6 @@ linter:
     - non_constant_identifier_names
     - null_closures
     - omit_local_variable_types
-# annoying when introducing a class to be used as interface that has only one member
-#    - one_member_abstracts
     - only_throw_errors
     - overridden_fields
     - package_api_docs
@@ -132,7 +126,6 @@ linter:
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
 #    - prefer_asserts_with_message # personal preference
-#    - prefer_bool_in_asserts # obsolete in Dart 2
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -20,10 +20,10 @@ analyzer:
 
 linter:
   rules:
-## Error Rules
+    ## Error Rules
 
-# personal preference this conflicts with prefer_relative_imports
-#    - always_use_package_imports
+    # personal preference this conflicts with prefer_relative_imports
+    #    - always_use_package_imports
     - avoid_empty_else
     - avoid_print
     - avoid_relative_lib_imports
@@ -37,7 +37,8 @@ linter:
     - close_sinks
     - comment_references
     - control_flow_in_finally
-    - diagnostic_describe_all_properties
+    # This seems to be a lint for debugging widgets, not applicable to this plugin
+    #    - diagnostic_describe_all_properties
     - empty_statements
     - hash_and_equals
     - invariant_booleans
@@ -55,22 +56,22 @@ linter:
     - unrelated_type_equality_checks
     - valid_regexps
 
-## Style Rules
+    ## Style Rules
 
     - always_declare_return_types
-#    - always_put_control_body_on_new_line # works against dartfmt
+    #    - always_put_control_body_on_new_line # works against dartfmt
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
-#    - always_specify_types        # this works against general Dart style guides
+    #    - always_specify_types        # this works against general Dart style guides
     - annotate_overrides
     - avoid_annotating_with_dynamic
-#    - avoid_as                    # obsolete - this was considered good practice in Dart 1
+    #    - avoid_as                    # obsolete - this was considered good practice in Dart 1
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
-# Annoying rule when using classes as namespaces for constants which is discouraged by the Dart
-# style guide, but I prefer it over aliases in imports for disambiguation.
-#    - avoid_classes_with_only_static_members
+    # Annoying rule when using classes as namespaces for constants which is discouraged by the Dart
+    # style guide, but I prefer it over aliases in imports for disambiguation.
+    #    - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
     - avoid_equals_and_hash_code_on_mutable_classes
     - avoid_escaping_inner_quotes  # TODO(zoechi) not yet available
@@ -92,7 +93,9 @@ linter:
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_types_on_closure_parameters
-    - avoid_unused_constructor_parameters
+    # This is annoying as it shows hints to remove arguments from un-implemented spec
+    # Can be enabled once the spec is completely implemented
+    #    - avoid_unused_constructor_parameters
     - avoid_void_async
     - await_only_futures
     - camel_case_extensions
@@ -125,7 +128,7 @@ linter:
     - parameter_assignments        # personal preference
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-#    - prefer_asserts_with_message # personal preference
+    #    - prefer_asserts_with_message # personal preference
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -134,7 +137,7 @@ linter:
     - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
-#    - prefer_double_quotes # I think Dart style guide prefers single quotes
+    #    - prefer_double_quotes # I think Dart style guide prefers single quotes
     - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields          # personal preference
@@ -160,23 +163,23 @@ linter:
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables
     - provide_deprecation_message
-#    - public_member_api_docs      # personal preference
+    #    - public_member_api_docs      # personal preference
     - recursive_getters
     - sized_box_for_whitespace
     - slash_for_doc_comments
     - sort_child_properties_last
-#      - sort_constructors_first           # personal preference
-#      - sort_unnamed_constructors_first   # personal preference
-#    - super_goes_last # this is covered by the analyzer already in Dart 2
+    #      - sort_constructors_first           # personal preference
+    #      - sort_unnamed_constructors_first   # personal preference
+    #    - super_goes_last # this is covered by the analyzer already in Dart 2
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
-# personal preference
-# should be alingned with prefer_final_fields, prefer_final_in_for_each, prefer_final_locals
-#    - unnecessary_final
+    # personal preference
+    # should be aligned with prefer_final_fields, prefer_final_in_for_each, prefer_final_locals
+    #    - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_new
@@ -200,6 +203,6 @@ linter:
     - use_to_and_as_if_applicable
     - void_checks
 
-## Pub Rules
+    ## Pub Rules
     - package_names
     - sort_pub_dependencies

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -5,8 +5,6 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
-  enable-experiment:
-    - non-nullable
 
   strong-mode:
     implicit-casts: false

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,215 @@
+# Updated according to
+# https://dart-lang.github.io/linter/lints/index.html
+# at 2020-08-10
+
 include: package:pedantic/analysis_options.yaml
 
+analyzer:
+  enable-experiment:
+    - non-nullable
+
+  strong-mode:
+    implicit-casts: false
+# TODO(zoechi) conflicts with some other rules and is subject to be reworked
+# https://github.com/dart-lang/sdk/issues/33749
+# but in general a useful setting to be enabled eventually
+#    implicit-dynamic: false
+
+#  language:
+# TODO(zoechi) check if this is already available
+# https://github.com/dart-lang/language/blob/master/resources/type-system/strict-raw-types.md
+#    strict-raw-types: true
+
+linter:
+  rules:
+## Error Rules
+
+# personal preference this conflicts with prefer_relative_imports
+#    - always_use_package_imports
+    - avoid_empty_else
+    - avoid_print
+    - avoid_relative_lib_imports
+    - avoid_returning_null_for_future
+    - avoid_slow_async_io
+    - avoid_types_as_parameter_names
+    - avoid_web_libraries_in_flutter
+    # subject to false positives, perhaps worth supressing in code in such cases
+    - cancel_subscriptions
+    # subject to false positives, perhaps worth supressing in code in such cases
+    - close_sinks
+    - comment_references
+    - control_flow_in_finally
+    - diagnostic_describe_all_properties
+    - empty_statements
+    - hash_and_equals
+    - invariant_booleans
+    - iterable_contains_unrelated_type
+    - list_remove_unrelated_type
+    - literal_only_boolean_expressions
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - no_logic_in_create_state
+    - prefer_relative_imports      # personal preference
+    - prefer_void_to_null
+    - test_types_in_equals
+    - throw_in_finally
+    - unnecessary_statements
+    - unrelated_type_equality_checks
+    - unsafe_html
+    - use_key_in_widget_constructors
+    - valid_regexps
+
+## Style Rules
+
+    - always_declare_return_types
+#    - always_put_control_body_on_new_line # works against dartfmt
+    - always_put_required_named_parameters_first
+    - always_require_non_null_named_parameters
+#    - always_specify_types        # this works agains general Dart style guides
+    - annotate_overrides
+    - avoid_annotating_with_dynamic
+#    - avoid_as                    # obsolete - this was considered good practice in Dart 1
+    - avoid_bool_literals_in_conditional_expressions
+    - avoid_catches_without_on_clauses
+    - avoid_catching_errors
+# Annoying rule when using classes as namespaces for constants which is discouraged by the Dart
+# style guide, but I prefer it over aliases in imports for disambiguation.
+#    - avoid_classes_with_only_static_members
+    - avoid_double_and_int_checks
+    - avoid_equals_and_hash_code_on_mutable_classes
+    - avoid_escaping_inner_quotes  # TODO(zoechi) not yet available
+    - avoid_field_initializers_in_const_classes
+    - avoid_function_literals_in_foreach_calls
+    - avoid_implementing_value_types
+    - avoid_init_to_null
+    - avoid_js_rounded_ints
+    - avoid_null_checks_in_equality_operators
+    - avoid_positional_boolean_parameters
+    - avoid_private_typedef_functions
+    - avoid_redundant_argument_values
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    - avoid_returning_null
+    - avoid_returning_null_for_void
+    - avoid_returning_this
+    - avoid_setters_without_getters
+    - avoid_shadowing_type_parameters # personal preference
+    - avoid_single_cascade_in_expression_statements
+    - avoid_types_on_closure_parameters
+    - avoid_unnecessary_containers
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    - await_only_futures
+    - camel_case_extensions
+    - camel_case_types
+    - cascade_invocations
+    - constant_identifier_names
+    - curly_braces_in_flow_control_structures # personal preference
+    - directives_ordering
+    - do_not_use_environment # depends on project requirements
+    - empty_catches
+    - empty_constructor_bodies
+    - exhaustive_cases
+    - file_names
+#    - flutter_style_todos         # I find the required ":" annoying and pointless
+    - implementation_imports
+    - join_return_with_assignment
+    - leading_newlines_in_multiline_strings
+    - library_names
+    - library_prefixes
+    - lines_longer_than_80_chars
+# Too annoying when long strings with interpolations are broken into multiple lines which we do often
+#    - missing_whitespace_between_adjacent_strings
+    - no_default_cases             # experimental
+    - no_runtimeType_toString
+    - non_constant_identifier_names
+    - null_closures
+    - omit_local_variable_types
+# annoying when introducing a class to be used as interface that has only one member
+#    - one_member_abstracts
+    - only_throw_errors
+    - overridden_fields
+    - package_api_docs
+    - package_prefixed_library_names
+    - parameter_assignments        # personal preference
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+#    - prefer_asserts_with_message # personal preference
+#    - prefer_bool_in_asserts # obsolete in Dart 2
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    - prefer_constructors_over_static_methods
+    - prefer_contains
+#    - prefer_double_quotes # I think Dart style guide prefers single quotes
+    - prefer_equal_for_default_values
+    - prefer_expression_function_bodies
+    - prefer_final_fields          # personal preference
+    - prefer_final_in_for_each     # personal preference
+    - prefer_final_locals          # personal preference
+    - prefer_for_elements_to_map_fromIterable
+    - prefer_foreach
+    - prefer_function_declarations_over_variables
+    - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    - prefer_if_null_operators
+    - prefer_initializing_formals
+    - prefer_inlined_adds
+    - prefer_int_literals
+    - prefer_interpolation_to_compose_strings
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_is_not_operator
+    - prefer_iterable_whereType
+    - prefer_mixin
+    - prefer_null_aware_operators
+    - prefer_single_quotes
+    - prefer_spread_collections
+    - prefer_typing_uninitialized_variables
+    - provide_deprecation_message
+#    - public_member_api_docs      # personal preference
+    - recursive_getters
+    - sized_box_for_whitespace
+    - slash_for_doc_comments
+    - sort_child_properties_last
+#      - sort_constructors_first           # personal preference
+#      - sort_unnamed_constructors_first   # personal preference
+#    - super_goes_last # this is covered by the analyzer already in Dart 2
+    - type_annotate_public_apis
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_await_in_return
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+# personal preference
+# should be alingned with prefer_final_fields, prefer_final_in_for_each, prefer_final_locals
+#    - unnecessary_final
+    - unnecessary_getters_setters
+    - unnecessary_lambdas
+    - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_overrides
+    - unnecessary_parenthesis
+    - unnecessary_raw_strings
+    - unnecessary_string_escapes
+    - unnecessary_string_interpolations
+    - unnecessary_this
+    - use_full_hex_values_for_flutter_colors
+    - use_function_type_syntax_for_parameters
+    - use_is_even_rather_than_modulo
+    - use_late_for_private_fields_and_variables
+    - use_raw_strings
+    - use_rethrow_when_possible
+    - use_setters_to_change_properties
+    - use_string_buffers
+    - use_to_and_as_if_applicable
+    - void_checks
+
+## Pub Rules
+    - package_names
+    - sort_pub_dependencies

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -117,7 +117,7 @@ linter:
     - library_prefixes
     - lines_longer_than_80_chars
 # Too annoying when long strings with interpolations are broken into multiple lines which we do often
-#    - missing_whitespace_between_adjacent_strings
+    - missing_whitespace_between_adjacent_strings
     - no_default_cases             # experimental
     - no_runtimeType_toString
     - non_constant_identifier_names


### PR DESCRIPTION
Especially the rules with a comment`personal preference` need to be decided per project/team,
but others might as well need adjustment to specific requirements in this project or preferences of the team.

Some of the enabled rules might not yet be supported in the Dart version you are using.

The easiest way is to check out the branch and open a Dart file.
Then the DartAnalyzer should start analyzing and show all violations in the error list.

I think a good way for a discussion would be to link to code examples where you think the suggestions
make the code worse and if possible some rationale.

Many linter rules (but far from all) provide quick fixes that make it easy to adjust the code to conform to the rules. Most IDEs should support this as they are usually all driven by DartAnalyzer.