### PR TITLE
realtime authcallback

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -26,6 +26,7 @@ final public class PlatformConstants {
         public static final String getVersion = "getVersion";
         public static final String registerAbly = "registerAbly";
         public static final String authCallback = "authCallback";
+        public static final String realtimeAuthCallback = "realtimeAuthCallback";
         public static final String createRestWithOptions = "createRestWithOptions";
         public static final String publish = "publish";
         public static final String createRealtimeWithOptions = "createRealtimeWithOptions";

--- a/bin/codegencontext.dart
+++ b/bin/codegencontext.dart
@@ -36,6 +36,7 @@ List<Map<String, dynamic>> _platformMethods = [
 
   // Auth
   {"name": "authCallback", "value": "authCallback"},
+  {"name": "realtimeAuthCallback", "value": "realtimeAuthCallback"},
 
   // Rest
   {"name": "createRestWithOptions", "value": "createRestWithOptions"},

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -30,7 +30,7 @@ app.get('/auth', function (req, res) {
        and configure the token without an identity (anonymous) */
     tokenParams = {
       'capability': { '*': ['publish', 'subscribe'] },
-      'ttl': 30000
+      'ttl': 15000
     };
   }
   rest.auth.createTokenRequest(tokenParams, function(err, tokenRequest) {

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -30,6 +30,7 @@ app.get('/auth', function (req, res) {
        and configure the token without an identity (anonymous) */
     tokenParams = {
       'capability': { '*': ['publish', 'subscribe'] },
+      'ttl': 30000
     };
   }
   rest.auth.createTokenRequest(tokenParams, function(err, tokenRequest) {

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -111,8 +111,6 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
     READ_VALUE(o, authHeaders, dictionary, TxClientOptions_authHeaders);
     READ_VALUE(o, authParams, dictionary, TxClientOptions_authParams);
     READ_VALUE(o, queryTime, dictionary, TxClientOptions_queryTime);
-    READ_VALUE(o, hasAuthCallback, dictionary, TxClientOptions_hasAuthCallback);
-    ON_VALUE(^(const id value) { o.hasAuthCallback = value; }, dictionary, TxClientOptions_hasAuthCallback);
 
     // ClientOptions
     READ_VALUE(o, clientId, dictionary, TxClientOptions_clientId);

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -102,7 +102,7 @@ ON_VALUE(^(const id number) { OBJECT.PROPERTY = [number boolValue]; }, DICTIONAR
 
 static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDictionary *const dictionary) {
     ARTClientOptions *const o = [ARTClientOptions new];
-    
+
     // AuthOptions (super class of ClientOptions)
     READ_VALUE(o, authUrl, dictionary, TxClientOptions_authUrl);
     READ_VALUE(o, authMethod, dictionary, TxClientOptions_authMethod);
@@ -111,7 +111,9 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
     READ_VALUE(o, authHeaders, dictionary, TxClientOptions_authHeaders);
     READ_VALUE(o, authParams, dictionary, TxClientOptions_authParams);
     READ_VALUE(o, queryTime, dictionary, TxClientOptions_queryTime);
-    
+    READ_VALUE(o, hasAuthCallback, dictionary, TxClientOptions_hasAuthCallback);
+    ON_VALUE(^(const id value) { o.hasAuthCallback = value; }, dictionary, TxClientOptions_hasAuthCallback);
+
     // ClientOptions
     READ_VALUE(o, clientId, dictionary, TxClientOptions_clientId);
     ON_VALUE(^(const id value) { o.logLevel = _logLevel(value); }, dictionary, TxClientOptions_logLevel);
@@ -199,11 +201,11 @@ static AblyCodecDecoder readTokenRequest = ^ARTTokenRequest*(NSDictionary *const
     __block NSString *mac = nil;
     __block NSString *nonce = nil;
     __block NSString *keyName = nil;
-    
+
     ON_VALUE(^(const id value) { mac = value; }, dictionary, TxTokenRequest_mac);
     ON_VALUE(^(const id value) { nonce = value; }, dictionary, TxTokenRequest_nonce);
     ON_VALUE(^(const id value) { keyName = value; }, dictionary, TxTokenRequest_keyName);
-    
+
     ARTTokenParams *const params = [AblyFlutterReader tokenParamsFromDictionary: dictionary];
     return [[ARTTokenRequest new] initWithTokenParams:params
                                               keyName:keyName

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -24,6 +24,7 @@ extern NSString *const AblyPlatformMethod_getPlatformVersion;
 extern NSString *const AblyPlatformMethod_getVersion;
 extern NSString *const AblyPlatformMethod_registerAbly;
 extern NSString *const AblyPlatformMethod_authCallback;
+extern NSString *const AblyPlatformMethod_realtimeAuthCallback;
 extern NSString *const AblyPlatformMethod_createRestWithOptions;
 extern NSString *const AblyPlatformMethod_publish;
 extern NSString *const AblyPlatformMethod_createRealtimeWithOptions;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -11,6 +11,7 @@ NSString *const AblyPlatformMethod_getPlatformVersion= @"getPlatformVersion";
 NSString *const AblyPlatformMethod_getVersion= @"getVersion";
 NSString *const AblyPlatformMethod_registerAbly= @"registerAbly";
 NSString *const AblyPlatformMethod_authCallback= @"authCallback";
+NSString *const AblyPlatformMethod_realtimeAuthCallback= @"realtimeAuthCallback";
 NSString *const AblyPlatformMethod_createRestWithOptions= @"createRestWithOptions";
 NSString *const AblyPlatformMethod_publish= @"publish";
 NSString *const AblyPlatformMethod_createRealtimeWithOptions= @"createRealtimeWithOptions";

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -412,13 +412,16 @@ class Codec extends StandardMessageCodec {
 
     Message decodeChannelMessage(Map<String, dynamic> jsonMap){
       if(jsonMap==null) return null;
-      Message message = Message(
+      var message = Message(
         name: readFromJson<String>(jsonMap, TxMessage.name),
         clientId: readFromJson<String>(jsonMap, TxMessage.clientId),
         data: readFromJson<dynamic>(jsonMap, TxMessage.data),
       );
       message.id = readFromJson<String>(jsonMap, TxMessage.id);
-      message.timestamp = DateTime.fromMillisecondsSinceEpoch(readFromJson<int>(jsonMap, TxMessage.timestamp));
+      var timestamp = readFromJson<int>(jsonMap, TxMessage.timestamp);
+      if(timestamp!=null) {
+        message.timestamp = DateTime.fromMillisecondsSinceEpoch(timestamp);
+      }
       message.connectionId = readFromJson<String>(jsonMap, TxMessage.connectionId);
       message.encoding = readFromJson<String>(jsonMap, TxMessage.encoding);
       message.extras = readFromJson<Map>(jsonMap, TxMessage.extras);

--- a/lib/src/generated/platformconstants.dart
+++ b/lib/src/generated/platformconstants.dart
@@ -21,6 +21,7 @@ class PlatformMethod {
     static const String getVersion = 'getVersion';
     static const String registerAbly = 'registerAbly';
     static const String authCallback = 'authCallback';
+    static const String realtimeAuthCallback = 'realtimeAuthCallback';
     static const String createRestWithOptions = 'createRestWithOptions';
     static const String publish = 'publish';
     static const String createRealtimeWithOptions = 'createRealtimeWithOptions';

--- a/lib/src/impl/platform_object.dart
+++ b/lib/src/impl/platform_object.dart
@@ -3,21 +3,20 @@ import 'dart:async';
 import 'package:ably_flutter_plugin/src/impl/message.dart';
 import 'package:ably_flutter_plugin/src/platform.dart' as platform;
 import 'package:flutter/services.dart';
+import 'package:meta/meta.dart';
 
 import 'streams_channel.dart';
-
 
 /// An object which has a live counterpart in the Platform client library SDK,
 /// where that live counterpart is held as a strong reference by the plugin
 /// implementation.
 abstract class PlatformObject {
-
   static const _acquireHandleTimeout = Duration(seconds: 2);
   Future<int> _handle;
-  int _handleValue;  // Only for logging. Otherwise use _handle instead.
+  int _handleValue; // Only for logging. Otherwise use _handle instead.
 
-  PlatformObject(){
-    this._handle = _acquireHandle();
+  PlatformObject() {
+    _handle = _acquireHandle();
   }
 
   @override
@@ -27,45 +26,45 @@ abstract class PlatformObject {
 
   Future<int> get handle async => _handle ??= _acquireHandle();
 
-  Future<int> _acquireHandle() => createPlatformInstance().timeout(
-    _acquireHandleTimeout, onTimeout: () {
-    _handle = null;
-    throw TimeoutException('Acquiring handle timed out.', _acquireHandleTimeout);
-  }).then((value) => _handleValue=value);
+  Future<int> _acquireHandle() =>
+      createPlatformInstance().timeout(_acquireHandleTimeout, onTimeout: () {
+        _handle = null;
+        throw TimeoutException(
+            'Acquiring handle timed out.', _acquireHandleTimeout);
+      }).then((value) => _handleValue = value);
 
   MethodChannel get methodChannel => platform.methodChannel;
+
   StreamsChannel get eventChannel => platform.streamsChannel;
 
-  static Future<int> dispose() async {
-    //TODO implement or convert to abstract!
-    return null;
-  }
-
   /// invoke platform method channel without AblyMessage encapsulation
+  @protected
   Future<T> invokeRaw<T>(final String method, [final Object arguments]) async {
     return await platform.invoke<T>(method, arguments);
   }
 
   /// invoke platform method channel with AblyMessage encapsulation
+  @protected
   Future<T> invoke<T>(final String method, [final Object argument]) async {
-    int _handle = await handle;
+    var _handle = await handle;
     final message = (null != argument)
-      ? AblyMessage(AblyMessage(argument, handle: _handle))
-      : AblyMessage(_handle);
+        ? AblyMessage(AblyMessage(argument, handle: _handle))
+        : AblyMessage(_handle);
     return await invokeRaw<T>(method, message);
   }
 
-  Future<Stream<dynamic>> _listen(final String eventName, [final Object payload]) async {
-    return eventChannel.receiveBroadcastStream(
-      AblyMessage(AblyEventMessage(eventName, payload), handle: await handle)
-    );
+  Future<Stream<dynamic>> _listen(final String eventName,
+      [final Object payload]) async {
+    return eventChannel.receiveBroadcastStream(AblyMessage(
+        AblyEventMessage(eventName, payload),
+        handle: await handle));
   }
 
   /// Listen for events
-  Stream<dynamic> listen(final String method, [final Object payload]){
-    StreamController<dynamic> controller = StreamController<dynamic>();
+  @protected
+  Stream<dynamic> listen(final String method, [final Object payload]) {
+    var controller = StreamController<dynamic>();
     _listen(method, payload).then(controller.addStream);
     return controller.stream;
   }
-
 }

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -49,8 +49,10 @@ class RealtimePlatformChannel extends PlatformObject
 
   Map<String, dynamic> __payload;
 
-  Map<String, dynamic> get _payload =>
-      __payload ??= {'channel': name, if (options != null) 'options': options};
+  Map<String, dynamic> get _payload => __payload ??= {
+        'channel': name,
+        if (options != null) 'options': options
+      };
 
   final _publishQueue = Queue<_RealtimePublishQueueItem>();
   Completer<void> _authCallbackCompleter;

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
+import 'dart:collection';
 
 import 'package:ably_flutter_plugin/ably.dart';
 import 'package:ably_flutter_plugin/src/impl/realtime/realtime.dart';
 import 'package:ably_flutter_plugin/src/spec/push/channels.dart';
 import 'package:ably_flutter_plugin/src/spec/spec.dart' as spec;
 import 'package:flutter/services.dart';
+import 'package:pedantic/pedantic.dart';
 
 import '../platform_object.dart';
 
@@ -50,42 +52,94 @@ class RealtimePlatformChannel extends PlatformObject
   Map<String, dynamic> get _payload =>
       __payload ??= {'channel': name, if (options != null) 'options': options};
 
+  final _publishQueue = Queue<_RealtimePublishQueueItem>();
+  Completer<void> _authCallbackCompleter;
+
   @override
   Future<void> publish(
       {spec.Message message,
       List<spec.Message> messages,
       String name,
       dynamic data}) async {
-    var hasAuthCallback = ably.options.authCallback != null;
-    while (hasAuthCallback && realtimePlatformObject.authCallbackInProgress) {
-      await Future.delayed(Duration(milliseconds: 100));
+    if(messages == null){
+      if (message != null) {
+        messages = [message];
+      } else {
+        messages ??= [
+          spec.Message(
+            name: name,
+            data: data
+          )
+        ];
+      }
     }
-    try {
-      if(messages == null){
-        if (message != null) {
-          messages = [message];
+    final queueItem = _RealtimePublishQueueItem(
+        Completer<void>(), message, messages);
+    _publishQueue.add(queueItem);
+    unawaited(_publishInternal());
+    return queueItem.completer.future;
+  }
+
+  bool _publishInternalRunning = false;
+
+  Future<void> _publishInternal() async {
+    if (_publishInternalRunning) {
+      return;
+    }
+    _publishInternalRunning = true;
+
+    while (_publishQueue.isNotEmpty) {
+      final item = _publishQueue.first;
+      // This is the only place where failed items are removed from the queue.
+      // In all other places (timeout exceptions) only the Completer is
+      // completed with an error but left in the queue.  Other attempts became a
+      // bit unwieldy.
+      if (item.completer.isCompleted) {
+        _publishQueue.remove(item);
+        continue;
+      }
+
+      try {
+        await invoke(PlatformMethod.publishRealtimeChannelMessage, {
+          ..._payload,
+          'messages': item.messages,
+        });
+
+        _publishQueue.remove(item);
+
+        // The Completer could have timed out in the meantime and completing a
+        // completed Completer would cause an exception, so we check first.
+        if (!item.completer.isCompleted) {
+          item.completer.complete();
+        }
+      } on PlatformException catch (pe) {
+        if (pe.code == ErrorCodes.authCallbackFailure.toString()) {
+          if (_authCallbackCompleter != null) {
+            return;
+          }
+          _authCallbackCompleter = Completer<void>();
+          try {
+            await _authCallbackCompleter.future.timeout(
+                Timeouts.retryOperationOnAuthFailure,
+                onTimeout: () => _publishQueue
+                    .where((e) => !e.completer.isCompleted)
+                    .forEach((e) => e.completer.completeError(TimeoutException(
+                        'Timed out', Timeouts.retryOperationOnAuthFailure))));
+          } finally {
+            _authCallbackCompleter = null;
+          }
         } else {
-          messages ??= [
-            spec.Message(
-              name: name,
-              data: data
-            )
-          ];
+          _publishQueue.where((e) => !e.completer.isCompleted).forEach((e) =>
+              e.completer.completeError(
+                  spec.AblyException(pe.code, pe.message, pe.details)));
         }
       }
-      await invoke(PlatformMethod.publishRealtimeChannelMessage, {
-        ..._payload,
-        'messages': messages,
-      });
-    } on PlatformException catch (pe) {
-      if (hasAuthCallback &&
-          pe.code == ErrorCodes.authCallbackFailure.toString()) {
-        realtimePlatformObject.authCallbackInProgress = true;
-        await publish(name: name, data: data);
-      } else {
-        throw spec.AblyException(pe.code, pe.message, pe.details);
-      }
     }
+    _publishInternalRunning = false;
+  }
+
+  void authUpdateComplete() {
+    _authCallbackCompleter?.complete();
   }
 
   @override
@@ -153,4 +207,15 @@ class RealtimePlatformChannels
   RealtimePlatformChannel createChannel(name, options) {
     return RealtimePlatformChannel(ably, name, options);
   }
+}
+
+/// An item for used to enqueue a message to be published after an ongoing
+/// authCallback is completed
+class _RealtimePublishQueueItem {
+  spec.Message message;
+  List<spec.Message> messages;
+  final Completer<void> completer;
+
+  _RealtimePublishQueueItem(
+      this.completer, this.message, this.messages);
 }

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -58,12 +58,13 @@ class RealtimePlatformChannel extends PlatformObject
   Completer<void> _authCallbackCompleter;
 
   @override
-  Future<void> publish(
-      {spec.Message message,
-      List<spec.Message> messages,
-      String name,
-      dynamic data}) async {
-    if(messages == null){
+  Future<void> publish({
+    spec.Message message,
+    List<spec.Message> messages,
+    String name,
+    dynamic data,
+  }) async {
+    if (messages == null) {
       if (message != null) {
         messages = [message];
       } else {

--- a/lib/src/impl/realtime/connection.dart
+++ b/lib/src/impl/realtime/connection.dart
@@ -13,9 +13,7 @@ class ConnectionPlatformObject extends PlatformObject implements Connection {
     state = ConnectionState.initialized;
     on().listen((ConnectionStateChange event) {
       if (event.reason?.code == ErrorCodes.authCallbackFailure) {
-        realtimePlatformObject.authCallbackInProgress = true;
-        realtimePlatformObject
-            .connect(); //try connecting immediately which waits for authCallback completion
+        realtimePlatformObject.awaitAuthUpdateAndReconnect();
       }
       state = event.current;
     });

--- a/lib/src/impl/realtime/connection.dart
+++ b/lib/src/impl/realtime/connection.dart
@@ -6,25 +6,24 @@ import 'package:ably_flutter_plugin/src/impl/realtime/realtime.dart';
 import '../../spec/spec.dart' show Connection, ConnectionState, ErrorInfo;
 import '../platform_object.dart';
 
-
 class ConnectionPlatformObject extends PlatformObject implements Connection {
-
   Realtime realtimePlatformObject;
 
-  ConnectionPlatformObject(this.realtimePlatformObject) {
-    this.handle;  //proactively acquiring handle
-    this.state = ConnectionState.initialized;
-    this.on().listen((ConnectionStateChange event) {
+  ConnectionPlatformObject(this.realtimePlatformObject) : super() {
+    state = ConnectionState.initialized;
+    on().listen((ConnectionStateChange event) {
       if (event.reason?.code == ErrorCodes.authCallbackFailure) {
-        this.realtimePlatformObject.authCallbackInProgress = true;
-        this.realtimePlatformObject.connect();  //try connecting immediately which waits for authCallback completion
+        realtimePlatformObject.authCallbackInProgress = true;
+        realtimePlatformObject
+            .connect(); //try connecting immediately which waits for authCallback completion
       }
-      this.state = event.current;
+      state = event.current;
     });
   }
 
   @override
-  Future<int> createPlatformInstance() async => await realtimePlatformObject.handle;
+  Future<int> createPlatformInstance() async =>
+      await realtimePlatformObject.handle;
 
   @override
   ErrorInfo errorReason;
@@ -47,9 +46,10 @@ class ConnectionPlatformObject extends PlatformObject implements Connection {
   @override
   Stream<ConnectionStateChange> on([ConnectionEvent connectionEvent]) {
     return listen(PlatformMethod.onRealtimeConnectionStateChanged)
-      .map((connectionEvent) => connectionEvent as ConnectionStateChange)
-      .where((connectionStateChange) =>
-        connectionEvent==null || connectionStateChange.event==connectionEvent);
+        .map((connectionEvent) => connectionEvent as ConnectionStateChange)
+        .where((connectionStateChange) =>
+            connectionEvent == null ||
+            connectionStateChange.event == connectionEvent);
   }
 
   @override
@@ -67,5 +67,4 @@ class ConnectionPlatformObject extends PlatformObject implements Connection {
     // TODO: implement ping
     return null;
   }
-
 }

--- a/lib/src/impl/realtime/connection.dart
+++ b/lib/src/impl/realtime/connection.dart
@@ -15,6 +15,10 @@ class ConnectionPlatformObject extends PlatformObject implements Connection {
     this.handle;  //proactively acquiring handle
     this.state = ConnectionState.initialized;
     this.on().listen((ConnectionStateChange event) {
+      if (event.reason?.code == ErrorCodes.authCallbackFailure) {
+        this.realtimePlatformObject.authCallbackInProgress = true;
+        this.realtimePlatformObject.connect();  //try connecting immediately which waits for authCallback completion
+      }
       this.state = event.current;
     });
   }

--- a/lib/src/impl/realtime/realtime.dart
+++ b/lib/src/impl/realtime/realtime.dart
@@ -10,7 +10,12 @@ import '../../spec/spec.dart' as spec;
 import '../platform_object.dart';
 import 'connection.dart';
 
-Map<int, Realtime> realtimeInstances = {};
+Map<int, Realtime> _realtimeInstances = {};
+Map<int, Realtime> _realtimeInstancesUnmodifiableView;
+
+Map<int, Realtime> get realtimeInstances =>
+    _realtimeInstancesUnmodifiableView ??=
+        UnmodifiableMapView(_realtimeInstances);
 
 class Realtime extends PlatformObject
     implements spec.RealtimeInterface<RealtimePlatformChannels> {
@@ -26,7 +31,7 @@ class Realtime extends PlatformObject
   Future<int> createPlatformInstance() async {
     var handle = await invokeRaw<int>(
         PlatformMethod.createRealtimeWithOptions, AblyMessage(options));
-    realtimeInstances[handle] = this;
+    _realtimeInstances[handle] = this;
     return handle;
   }
 

--- a/lib/src/impl/realtime/realtime.dart
+++ b/lib/src/impl/realtime/realtime.dart
@@ -10,26 +10,20 @@ import 'connection.dart';
 
 Map<int, Realtime> realtimeInstances = {};
 
-class Realtime extends PlatformObject implements spec.RealtimeInterface<RealtimePlatformChannels> {
-
-  Realtime({
-    ClientOptions options,
-    final String key
-  }) :
-      assert(options!=null || key!=null),
-      this.options = (options==null)?ClientOptions.fromKey(key):options,
-      super()
-  {
+class Realtime extends PlatformObject
+    implements spec.RealtimeInterface<RealtimePlatformChannels> {
+  Realtime({ClientOptions options, final String key})
+      : assert(options != null || key != null),
+        options = (options == null) ? ClientOptions.fromKey(key) : options,
+        super() {
     connection = ConnectionPlatformObject(this);
     channels = RealtimePlatformChannels(this);
   }
 
   @override
   Future<int> createPlatformInstance() async {
-    int handle = await invokeRaw<int>(
-      PlatformMethod.createRealtimeWithOptions,
-      AblyMessage(options)
-    );
+    var handle = await invokeRaw<int>(
+        PlatformMethod.createRealtimeWithOptions, AblyMessage(options));
     realtimeInstances[handle] = this;
     return handle;
   }
@@ -62,19 +56,24 @@ class Realtime extends PlatformObject implements spec.RealtimeInterface<Realtime
 
   @override
   Future<void> connect() async {
-    bool hasAuthCallback = this.options.authCallback!=null;
+    var hasAuthCallback = options.authCallback != null;
     while (hasAuthCallback && authCallbackInProgress) {
       await Future.delayed(Duration(milliseconds: 100));
     }
     await invoke(PlatformMethod.connectRealtime);
   }
 
-  authUpdateComplete() {
+  void authUpdateComplete() {
     authCallbackInProgress = false;
   }
 
   @override
-  Future<HttpPaginatedResponse> request({String method, String path, Map<String, dynamic> params, body, Map<String, String> headers}) {
+  Future<HttpPaginatedResponse> request(
+      {String method,
+      String path,
+      Map<String, dynamic> params,
+      body,
+      Map<String, String> headers}) {
     // TODO: implement request
     return null;
   }

--- a/lib/src/impl/realtime/realtime.dart
+++ b/lib/src/impl/realtime/realtime.dart
@@ -16,7 +16,7 @@ class Realtime extends PlatformObject
     implements spec.RealtimeInterface<RealtimePlatformChannels> {
   Realtime({ClientOptions options, final String key})
       : assert(options != null || key != null),
-        options = (options == null) ? ClientOptions.fromKey(key) : options,
+        options = options ?? ClientOptions.fromKey(key),
         super() {
     connection = ConnectionPlatformObject(this);
     channels = RealtimePlatformChannels(this);

--- a/lib/src/impl/realtime/realtime.dart
+++ b/lib/src/impl/realtime/realtime.dart
@@ -23,8 +23,8 @@ class Realtime extends PlatformObject
       : assert(options != null || key != null),
         options = options ?? ClientOptions.fromKey(key),
         super() {
-    connection = ConnectionPlatformObject(this);
-    channels = RealtimePlatformChannels(this);
+    _connection = ConnectionPlatformObject(this);
+    _channels = RealtimePlatformChannels(this);
   }
 
   @override
@@ -38,8 +38,10 @@ class Realtime extends PlatformObject
   // The _connection instance keeps a reference to this platform object.
   // Ideally connection would be final, but that would need 'late final' which is coming.
   // https://stackoverflow.com/questions/59449666/initialize-a-final-variable-with-this-in-dart#comment105082936_59450231
+  Connection _connection;
+
   @override
-  Connection connection;
+  Connection get connection => _connection;
 
   @override
   Auth auth;
@@ -53,8 +55,10 @@ class Realtime extends PlatformObject
   @override
   Push push;
 
+  RealtimePlatformChannels _channels;
+
   @override
-  RealtimePlatformChannels channels;
+  RealtimePlatformChannels get channels => _channels;
 
   @override
   Future<void> close() async => await invoke(PlatformMethod.closeRealtime);

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -25,7 +25,7 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
 
   RestPlatformChannel(this.ably, this.name, this.options);
 
-  Rest get restPlatformObject => this.ably as Rest;
+  Rest get restPlatformObject => ably as Rest;
 
   /// createPlatformInstance will return restPlatformObject's handle
   /// as that is what will be required in platforms end to find rest instance
@@ -43,7 +43,7 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
   final _publishQueue = Queue<_PublishQueueItem>();
   Completer<void> _authCallbackCompleter;
 
-  static const defaultPublishTimout = Duration(seconds: 30);
+  static const defaultPublishTimeout = Duration(seconds: 30);
 
   @override
   Future<void> publish({
@@ -111,11 +111,11 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
           }
           _authCallbackCompleter = Completer<void>();
           try {
-            await _authCallbackCompleter.future.timeout(defaultPublishTimout,
+            await _authCallbackCompleter.future.timeout(defaultPublishTimeout,
               onTimeout: () => _publishQueue
                 .where((e) => !e.completer.isCompleted)
                 .forEach((e) => e.completer.completeError(
-                TimeoutException('Timed out', defaultPublishTimout))));
+                TimeoutException('Timed out', defaultPublishTimeout))));
           } finally {
             _authCallbackCompleter = null;
           }
@@ -138,9 +138,8 @@ class RestPlatformChannels extends spec.RestChannels<RestPlatformChannel> {
   RestPlatformChannels(Rest ably) : super(ably);
 
   @override
-  RestPlatformChannel createChannel(name, options) {
-    return RestPlatformChannel(ably, name, options);
-  }
+  RestPlatformChannel createChannel(name, options) =>
+    RestPlatformChannel(ably, name, options);
 }
 
 /// An item for used to enqueue a message to be published after an ongoing

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -43,8 +43,6 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
   final _publishQueue = Queue<_PublishQueueItem>();
   Completer<void> _authCallbackCompleter;
 
-  static const defaultPublishTimeout = Duration(seconds: 30);
-
   @override
   Future<void> publish({
     Message message,
@@ -111,11 +109,12 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
           }
           _authCallbackCompleter = Completer<void>();
           try {
-            await _authCallbackCompleter.future.timeout(defaultPublishTimeout,
-              onTimeout: () => _publishQueue
-                .where((e) => !e.completer.isCompleted)
-                .forEach((e) => e.completer.completeError(
-                TimeoutException('Timed out', defaultPublishTimeout))));
+            await _authCallbackCompleter.future.timeout(
+                Timeouts.retryOperationOnAuthFailure,
+                onTimeout: () => _publishQueue
+                    .where((e) => !e.completer.isCompleted)
+                    .forEach((e) => e.completer.completeError(TimeoutException(
+                        'Timed out', Timeouts.retryOperationOnAuthFailure))));
           } finally {
             _authCallbackCompleter = null;
           }

--- a/lib/src/impl/rest/rest.dart
+++ b/lib/src/impl/rest/rest.dart
@@ -16,7 +16,7 @@ class Rest extends PlatformObject
     implements spec.RestInterface<RestPlatformChannels> {
   Rest({ClientOptions options, final String key})
       : assert(options != null || key != null),
-        options = (options == null) ? ClientOptions.fromKey(key) : options,
+        options = options ?? ClientOptions.fromKey(key),
         super() {
     channels = RestPlatformChannels(this);
   }

--- a/lib/src/impl/rest/rest.dart
+++ b/lib/src/impl/rest/rest.dart
@@ -10,7 +10,9 @@ import 'channels.dart';
 
 Map<int, Rest> _restInstances = {};
 Map<int, Rest> _restInstancesUnmodifiableView;
-Map<int, Rest> get restInstances => _restInstancesUnmodifiableView ??= UnmodifiableMapView(_restInstances);
+
+Map<int, Rest> get restInstances =>
+    _restInstancesUnmodifiableView ??= UnmodifiableMapView(_restInstances);
 
 class Rest extends PlatformObject
     implements spec.RestInterface<RestPlatformChannels> {

--- a/lib/src/impl/rest/rest.dart
+++ b/lib/src/impl/rest/rest.dart
@@ -12,29 +12,24 @@ Map<int, Rest> _restInstances = {};
 Map<int, Rest> _restInstancesUnmodifiableView;
 Map<int, Rest> get restInstances => _restInstancesUnmodifiableView ??= UnmodifiableMapView(_restInstances);
 
-class Rest extends PlatformObject implements spec.RestInterface<RestPlatformChannels> {
-
-  Rest({
-    ClientOptions options,
-    final String key
-  }) :
-      assert(options!=null || key!=null),
-      this.options = (options==null)?ClientOptions.fromKey(key):options,
-      super()
-  {
+class Rest extends PlatformObject
+    implements spec.RestInterface<RestPlatformChannels> {
+  Rest({ClientOptions options, final String key})
+      : assert(options != null || key != null),
+        options = (options == null) ? ClientOptions.fromKey(key) : options,
+        super() {
     channels = RestPlatformChannels(this);
   }
 
+  @override
   Future<int> createPlatformInstance() async {
-    int handle = await invokeRaw<int>(
-      PlatformMethod.createRestWithOptions,
-      AblyMessage(options)
-    );
+    var handle = await invokeRaw<int>(
+        PlatformMethod.createRestWithOptions, AblyMessage(options));
     _restInstances[handle] = this;
     return handle;
   }
 
-  authUpdateComplete() {
+  void authUpdateComplete() {
     channels.all.forEach((c) => c.authUpdateComplete());
   }
 
@@ -45,7 +40,12 @@ class Rest extends PlatformObject implements spec.RestInterface<RestPlatformChan
   ClientOptions options;
 
   @override
-  Future<HttpPaginatedResponse> request({String method, String path, Map<String, dynamic> params, body, Map<String, String> headers}) {
+  Future<HttpPaginatedResponse> request(
+      {String method,
+      String path,
+      Map<String, dynamic> params,
+      body,
+      Map<String, String> headers}) {
     // TODO: implement request
     return null;
   }

--- a/lib/src/impl/rest/rest.dart
+++ b/lib/src/impl/rest/rest.dart
@@ -22,7 +22,7 @@ class Rest extends PlatformObject implements spec.RestInterface<RestPlatformChan
       this.options = (options==null)?ClientOptions.fromKey(key):options,
       super()
   {
-    this.channels = RestPlatformChannels(this);
+    channels = RestPlatformChannels(this);
   }
 
   Future<int> createPlatformInstance() async {
@@ -32,6 +32,10 @@ class Rest extends PlatformObject implements spec.RestInterface<RestPlatformChan
     );
     _restInstances[handle] = this;
     return handle;
+  }
+
+  authUpdateComplete() {
+    channels.all.forEach((c) => c.authUpdateComplete());
   }
 
   @override

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -26,18 +26,18 @@ class AblyMethodCallHandler {
     return callbackResponse;
   }
 
-  bool realtimeAuthInProgress = false;
+  bool _realtimeAuthInProgress = false;
 
   Future<Object> onRealtimeAuthCallback(AblyMessage message) async {
-    if (realtimeAuthInProgress) {
+    if (_realtimeAuthInProgress) {
       return null;
     }
-    realtimeAuthInProgress = true;
+    _realtimeAuthInProgress = true;
     var tokenParams = message.message as ably.TokenParams;
     var realtime = ably.realtimeInstances[message.handle];
     Object callbackResponse = await realtime.options.authCallback(tokenParams);
     Future.delayed(Duration.zero, realtime.authUpdateComplete);
-    realtimeAuthInProgress = false;
+    _realtimeAuthInProgress = false;
     return callbackResponse;
   }
 }

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -18,30 +18,26 @@ class AblyMethodCallHandler {
     });
   }
 
-  Future<dynamic> onAuthCallback(AblyMessage message) async {
+  Future<Object> onAuthCallback(AblyMessage message) async {
     ably.TokenParams tokenParams = message.message as ably.TokenParams;
     ably.Rest rest = ably.restInstances[message.handle];
     final callbackResponse = await rest.options.authCallback(tokenParams);
-    Future.delayed(Duration.zero, () {
-      rest.channels.all.forEach((c) => c.authUpdateComplete());
-    });
+    Future.delayed(Duration.zero, () => rest.authUpdateComplete());
     return callbackResponse;
   }
 
   bool realtimeAuthInProgress = false;
-  onRealtimeAuthCallback(AblyMessage message) async {
-    if(realtimeAuthInProgress){
+
+  Future<Object> onRealtimeAuthCallback(AblyMessage message) async {
+    if (realtimeAuthInProgress) {
       return null;
     }
     realtimeAuthInProgress = true;
     ably.TokenParams tokenParams = message.message as ably.TokenParams;
     ably.Realtime realtime = ably.realtimeInstances[message.handle];
     Object callbackResponse = await realtime.options.authCallback(tokenParams);
-    Future.delayed(Duration.zero, (){
-      realtime.authUpdateComplete();
-    });
+    Future.delayed(Duration.zero, () => realtime.authUpdateComplete());
     realtimeAuthInProgress = false;
     return callbackResponse;
   }
-
 }

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -19,8 +19,8 @@ class AblyMethodCallHandler {
   }
 
   Future<Object> onAuthCallback(AblyMessage message) async {
-    ably.TokenParams tokenParams = message.message as ably.TokenParams;
-    ably.Rest rest = ably.restInstances[message.handle];
+    var tokenParams = message.message as ably.TokenParams;
+    var rest = ably.restInstances[message.handle];
     final callbackResponse = await rest.options.authCallback(tokenParams);
     Future.delayed(Duration.zero, () => rest.authUpdateComplete());
     return callbackResponse;
@@ -33,8 +33,8 @@ class AblyMethodCallHandler {
       return null;
     }
     realtimeAuthInProgress = true;
-    ably.TokenParams tokenParams = message.message as ably.TokenParams;
-    ably.Realtime realtime = ably.realtimeInstances[message.handle];
+    var tokenParams = message.message as ably.TokenParams;
+    var realtime = ably.realtimeInstances[message.handle];
     Object callbackResponse = await realtime.options.authCallback(tokenParams);
     Future.delayed(Duration.zero, () => realtime.authUpdateComplete());
     realtimeAuthInProgress = false;

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -22,7 +22,7 @@ class AblyMethodCallHandler {
     var tokenParams = message.message as ably.TokenParams;
     var rest = ably.restInstances[message.handle];
     final callbackResponse = await rest.options.authCallback(tokenParams);
-    Future.delayed(Duration.zero, () => rest.authUpdateComplete());
+    Future.delayed(Duration.zero, rest.authUpdateComplete);
     return callbackResponse;
   }
 
@@ -36,7 +36,7 @@ class AblyMethodCallHandler {
     var tokenParams = message.message as ably.TokenParams;
     var realtime = ably.realtimeInstances[message.handle];
     Object callbackResponse = await realtime.options.authCallback(tokenParams);
-    Future.delayed(Duration.zero, () => realtime.authUpdateComplete());
+    Future.delayed(Duration.zero, realtime.authUpdateComplete);
     realtimeAuthInProgress = false;
     return callbackResponse;
   }

--- a/lib/src/spec/constants.dart
+++ b/lib/src/spec/constants.dart
@@ -15,3 +15,8 @@ class ErrorCodes {
   /// call triggered from platform side
   static const int authCallbackFailure = 80019;
 }
+
+
+class Timeouts {
+  static const retryOperationOnAuthFailure = Duration(seconds: 30);
+}

--- a/lib/src/spec/realtime/realtime.dart
+++ b/lib/src/spec/realtime/realtime.dart
@@ -3,19 +3,17 @@ import '../rest/ably_base.dart';
 import '../rest/options.dart';
 import 'channels.dart';
 
-
 abstract class RealtimeInterface<C extends RealtimeChannels> extends AblyBase {
-
-  RealtimeInterface({
-    ClientOptions options,
-    final String key
-  }): connection=null,  //To be assigned as required on implementation
-      super(options: options, key: key);
+  RealtimeInterface({ClientOptions options, final String key})
+      : super(options: options, key: key);
 
   String clientId;
-  void close();
-  void connect();
-  final Connection connection;
-  C channels;
 
+  void close();
+
+  void connect();
+
+  Connection get connection;
+
+  C get channels;
 }

--- a/lib/src/spec/realtime/realtime.dart
+++ b/lib/src/spec/realtime/realtime.dart
@@ -4,7 +4,7 @@ import '../rest/options.dart';
 import 'channels.dart';
 
 
-abstract class RealtimeInterface extends AblyBase {
+abstract class RealtimeInterface<C extends RealtimeChannels> extends AblyBase {
 
   RealtimeInterface({
     ClientOptions options,
@@ -16,6 +16,6 @@ abstract class RealtimeInterface extends AblyBase {
   void close();
   void connect();
   final Connection connection;
-  RealtimeChannels channels;
+  C channels;
 
 }

--- a/test/realtime/channel_test.dart
+++ b/test/realtime/channel_test.dart
@@ -1,0 +1,203 @@
+import 'dart:async';
+
+import 'package:ably_flutter_plugin/ably.dart';
+import 'package:ably_flutter_plugin/src/impl/message.dart';
+import 'package:ably_flutter_plugin/src/method_call_handler.dart';
+import 'package:ably_flutter_plugin/src/platform.dart' as platform;
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pedantic/pedantic.dart';
+
+void main() {
+  final methodChannel = platform.methodChannel;
+
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Used to generate unique handle ids
+  var handleCounter;
+
+  // Keep created channel instances associated with its handle.
+  final channels = <int, AblyMessage>{};
+
+  var publishedMessages = <AblyMessage>[];
+
+  setUp(() {
+    channels.clear();
+    publishedMessages.clear();
+    handleCounter = 0;
+    var isAuthenticated = false;
+
+    methodChannel.setMockMethodCallHandler((MethodCall methodCall) async {
+
+      switch (methodCall.method) {
+        case PlatformMethod.registerAbly:
+          return true;
+
+        case PlatformMethod.createRealtimeWithOptions:
+          final handle = ++handleCounter;
+          channels[handle] = methodCall.arguments as AblyMessage;
+          return handle;
+
+        case PlatformMethod.publishRealtimeChannelMessage:
+          final message = methodCall.arguments as AblyMessage;
+          final handle = (message.message as AblyMessage).handle;
+          final ablyChannel = channels[handle];
+          final clientOptions = ablyChannel.message as ClientOptions;
+
+          // `authUrl` is used to indicate the presence of an authCallback,
+          // because function references (in `authCallback`) get dropped by the
+          // PlatformChannel.
+          if (!isAuthenticated && clientOptions.authUrl == 'hasAuthCallback') {
+            await AblyMethodCallHandler(methodChannel).onRealtimeAuthCallback(
+              AblyMessage(TokenParams(timestamp: DateTime.now()),
+                handle: handle));
+            isAuthenticated = true;
+            throw PlatformException(
+              code: ErrorCodes.authCallbackFailure.toString());
+          }
+
+          publishedMessages.add(message);
+          return null;
+
+        default:
+          return throw 'Unexpected channel method call: ${methodCall.method}'
+            ' args: ${methodCall.arguments}';
+      }
+    });
+  });
+
+  tearDown(() {
+    methodChannel.setMockMethodCallHandler(null);
+  });
+
+  test('publish realtime message without authCallback', () async {
+    // setup
+    final realtime = Realtime(key: 'TEST-KEY');
+    final channel = await realtime.channels.get('test');
+
+    // exercise
+    await channel.publish(name: 'name', data: 'data1');
+    await channel.publish(message: Message(name: 'name', data: 'data'));
+    await channel.publish(messages: [Message(name: 'name', data: 'data')]);
+
+    // verification
+    expect(publishedMessages.length, 3);
+    final firstMessage = publishedMessages.first.message as AblyMessage;
+    final messageData = firstMessage.message as Map<dynamic, dynamic>;
+    print("messageData $messageData");
+    expect(messageData['channel'], 'test');
+    expect(messageData['name'], 'name');
+    expect(messageData['data'], 'data1');
+  });
+
+  test('publish message with authCallback', () async {
+    // setup
+    final authCallback = expectAsync1((token) async {}, max: 2);
+
+    final options = ClientOptions()
+      ..authCallback = authCallback
+      ..authUrl = 'hasAuthCallback';
+    final realtime = Realtime(options: options, key: 'TEST-KEY');
+
+    final channel = realtime.channels.get('test');
+
+    // exercise
+    await channel.publish(name: 'name', data: 'data2');
+
+    // verification
+
+    expect(publishedMessages.length, 1);
+    final firstMessage = publishedMessages.first.message as AblyMessage;
+    final messageData = firstMessage.message as Map<dynamic, dynamic>;
+    expect(messageData['channel'], 'test');
+    expect(messageData['name'], 'name');
+    expect(messageData['data'], 'data2');
+  });
+
+  test('publish realtime message with authCallback timing out', () async {
+    // setup
+    final tooMuchDelay =
+      Timeouts.retryOperationOnAuthFailure + Duration(seconds: 2);
+    var authCallbackCounter = 0;
+
+    Future timingOutOnceThenSucceedsAuthCallback(TokenParams token) {
+      if (authCallbackCounter == 0) {
+        authCallbackCounter++;
+        throw TimeoutException('Timed out');
+      }
+      return Future.value();
+    }
+
+    unawaited(
+      fakeAsync((async) async {
+        final options = ClientOptions()
+          ..authCallback = timingOutOnceThenSucceedsAuthCallback
+          ..authUrl = 'hasAuthCallback';
+        final realtime = Realtime(options: options, key: 'TEST-KEY');
+        final channel = realtime.channels.get('test');
+
+        // exercise
+        final future1 = channel.publish(name: 'name', data: 'data3-1');
+        final future2 = channel.publish(name: 'name', data: 'data3-2');
+
+        // verification
+        expect(future1, throwsA(isA<AblyException>()));
+        expect(future2, throwsA(isA<AblyException>()));
+
+        async.elapse(tooMuchDelay);
+
+        expect(publishedMessages.length, 0);
+
+        // Send another message after timeout with authCallback succeeding
+
+        // setup
+        // exercise
+        final future3 = channel.publish(name: 'name', data: 'data3-3');
+
+        // verification
+        async.elapse(Duration.zero);
+        await future3;
+
+        expect(publishedMessages.length, 1);
+
+        final firstMessage = publishedMessages.first.message as AblyMessage;
+        final messageData = firstMessage.message as Map<dynamic, dynamic>;
+        expect(messageData['channel'], 'test');
+        expect(messageData['name'], 'name');
+        expect(messageData['data'], 'data3-2');
+      }),
+    );
+  });
+
+  test('publish 2 realtime messages with authCallback', () async {
+    // setup
+    final authCallback = expectAsync1((token) async {});
+
+    final options = ClientOptions()
+      ..authCallback = authCallback
+      ..authUrl = 'hasAuthCallback';
+    final realtime = Realtime(options: options, key: 'TEST-KEY');
+    final channel = realtime.channels.get('test');
+
+    // exercise
+    await channel.publish(name: 'name', data: 'data4');
+    await channel.publish(name: 'name', data: 'data5');
+
+    // verification
+    expect(publishedMessages.length, 2);
+    final message0 = publishedMessages[0].message as AblyMessage;
+    final messageData0 = message0.message as Map<dynamic, dynamic>;
+    expect(messageData0['channel'], 'test');
+    expect(messageData0['name'], 'name');
+    expect(messageData0['data'], 'data4');
+
+    final message1 = publishedMessages[1].message as AblyMessage;
+    final messageData1 = message1.message as Map<dynamic, dynamic>;
+    expect(messageData1['channel'], 'test');
+    expect(messageData1['name'], 'name');
+    expect(messageData1['data'], 'data5');
+
+    // });
+  }, timeout: Timeout.none);
+}

--- a/test/rest/channel_test.dart
+++ b/test/rest/channel_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:ably_flutter_plugin/ably.dart';
 import 'package:ably_flutter_plugin/src/impl/message.dart';
-import 'package:ably_flutter_plugin/src/impl/rest/channels.dart';
 import 'package:ably_flutter_plugin/src/method_call_handler.dart';
 import 'package:ably_flutter_plugin/src/platform.dart' as platform;
 import 'package:fake_async/fake_async.dart';
@@ -116,7 +115,7 @@ void main() {
   test('publish message with authCallback timing out', () async {
     // setup
     final tooMuchDelay =
-        RestPlatformChannel.defaultPublishTimout + Duration(seconds: 2);
+        Timeouts.retryOperationOnAuthFailure + Duration(seconds: 2);
     var authCallbackCounter = 0;
 
     Future timingOutOnceThenSucceedsAuthCallback(TokenParams token) {

--- a/test_integration/lib/test/realtime_publish_test.dart
+++ b/test_integration/lib/test/realtime_publish_test.dart
@@ -25,30 +25,7 @@ class RealtimePublishTestState extends TestWidgetState<RealtimePublishTest> {
         ..logHandler =
             ({msg, exception}) => logMessages.add([msg, '$exception']),
     );
-
-    final name = 'Hello';
-    final messageData = [
-      null, //null
-      'Ably', //string
-      [1, 2, 3], //numeric list
-      ['hello', 'ably'], //string list
-      {
-        'hello': 'ably',
-        'items': ['1', 2.2, true]
-      }, //map
-      [
-        {'hello': 'ably'},
-        'ably',
-        'realtime'
-      ] //list of map
-    ];
-
-    final channel = await realtime.channels.get('test');
-    await channel.publish(); //publish without name and data
-    await channel.publish(data: messageData[1]); //publish without name
-    for (var data in messageData) {
-      await channel.publish(name: name, data: data);
-    }
+    await realtimeMessagesPublishUtil(realtime);
 
     // TODO(tiholic) throws UnimplementedError
     // await realtime.connection.close();
@@ -57,5 +34,31 @@ class RealtimePublishTestState extends TestWidgetState<RealtimePublishTest> {
       'handle': await realtime.handle,
       'log': logMessages,
     });
+  }
+}
+
+Future<void> realtimeMessagesPublishUtil(Realtime realtime) async {
+  final name = 'Hello';
+  final messageData = [
+    null, //null
+    'Ably', //string
+    [1, 2, 3], //numeric list
+    ['hello', 'ably'], //string list
+    {
+      'hello': 'ably',
+      'items': ['1', 2.2, true]
+    }, //map
+    [
+      {'hello': 'ably'},
+      'ably',
+      'realtime'
+    ] //list of map
+  ];
+
+  final channel = await realtime.channels.get('test');
+  await channel.publish(); //publish without name and data
+  await channel.publish(data: messageData[1]); //publish without name
+  for (var data in messageData) {
+    await channel.publish(name: name, data: data);
   }
 }

--- a/test_integration/lib/test/realtime_publish_with_auth_callback_test.dart
+++ b/test_integration/lib/test/realtime_publish_with_auth_callback_test.dart
@@ -1,0 +1,40 @@
+import 'package:ably_flutter_integration_test/test/realtime_publish_test.dart';
+import 'package:ably_flutter_integration_test/test/test_widget_abstract.dart';
+import 'package:ably_flutter_plugin/ably.dart';
+
+import '../test_dispatcher.dart';
+import 'appkey_provision_helper.dart';
+
+class RealtimePublishWithAuthCallbackTest extends TestWidget {
+  RealtimePublishWithAuthCallbackTest(TestDispatcherState dispatcher)
+      : super(dispatcher);
+
+  @override
+  TestWidgetState<TestWidget> createState() =>
+      RealtimePublishWithAuthCallbackTestState();
+}
+
+class RealtimePublishWithAuthCallbackTestState
+    extends TestWidgetState<RealtimePublishWithAuthCallbackTest> {
+  @override
+  Future<void> test() async {
+    var authCallbackInvoked = false;
+    final realtime = Realtime(
+        options: ClientOptions()
+          ..clientId = 'someClientId'
+          ..logLevel = LogLevel.verbose
+          ..authCallback = ((TokenParams params) async {
+            authCallbackInvoked = true;
+            return TokenRequest.fromMap(await getTokenRequest());
+          }));
+    await realtimeMessagesPublishUtil(realtime);
+
+    // TODO(tiholic) throws UnimplementedError
+    // await realtime.connection.close();
+
+    widget.dispatcher.reportTestCompletion(<String, dynamic>{
+      'handle': await realtime.handle,
+      'authCallbackInvoked': authCallbackInvoked,
+    });
+  }
+}

--- a/test_integration/lib/test/test_factory.dart
+++ b/test_integration/lib/test/test_factory.dart
@@ -2,6 +2,7 @@ import 'package:ably_flutter_integration_test/test/appkey_provision_test.dart';
 import 'package:ably_flutter_integration_test/test/platform_and_ably_version_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime_events_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime_publish_test.dart';
+import 'package:ably_flutter_integration_test/test/realtime_publish_with_auth_callback_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime_subscribe.dart';
 import 'package:ably_flutter_integration_test/test/rest_publish_test.dart';
 import 'package:ably_flutter_integration_test/test/rest_publish_with_auth_callback_test.dart';
@@ -17,8 +18,11 @@ final testFactory = <String, TestFactory>{
   TestName.realtimePublish: (d) => RealtimePublishTest(d),
   TestName.realtimeEvents: (d) => RealtimeEventsTest(d),
   TestName.realtimeSubscribe: (d) => RealtimeSubscribeTest(d),
+  TestName.realtimePublishWithAuthCallback: (d) =>
+      RealtimePublishWithAuthCallbackTest(d),
   TestName.restPublish: (d) => RestPublishTest(d),
-  TestName.restPublishWithAuthCallback: (d) => RestPublishWithAuthCallbackTest(d),
+  TestName.restPublishWithAuthCallback: (d) =>
+      RestPublishWithAuthCallbackTest(d),
   TestName.testHelperFlutterErrorTest: (d) => TestHelperFlutterErrorTest(d),
   TestName.testHelperUnhandledExceptionTest: (d) =>
       TestHelperUnhandledExceptionTest(d),

--- a/test_integration/lib/test/test_names.dart
+++ b/test_integration/lib/test/test_names.dart
@@ -11,10 +11,12 @@ class TestName {
       'testHelperUnhandledExceptionTest';
 
   static const String restPublish = 'restPublish';
-  static const String restPublishWithAuthCallback = 'restPublishWithAuthCallback';
+  static const String restPublishWithAuthCallback =
+      'restPublishWithAuthCallback';
 
   static const String realtimePublish = 'realtimePublish';
   static const String realtimeEvents = 'realtimeEvents';
   static const String realtimeSubscribe = 'realtimeSubscribe';
+  static const String realtimePublishWithAuthCallback =
+      'realtimePublishWithAuthCallback';
 }
-

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -225,3 +225,16 @@ Future testRealtimeSubscribe(FlutterDriver driver) async {
   expect(filteredWithNames[3]['name'], 'name2');
   expect(filteredWithNames[3]['data'], equals(['hello', 'ably']));
 }
+
+Future testRealtimePublishWithAuthCallback(FlutterDriver driver) async {
+  final message = TestControlMessage(TestName.realtimePublishWithAuthCallback);
+
+  final response = await getTestResponse(driver, message);
+
+  expect(response.testName, message.testName);
+
+  expect(response.payload['handle'], isA<int>());
+  expect(response.payload['handle'], greaterThan(0));
+
+  expect(response.payload['authCallbackInvoked'], isTrue);
+}

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -23,6 +23,7 @@ final _tests = <TestGroup, Map<String, Function>>{
     'should publish': testRealtimePublish,
     'should subscribe to connection and channel': testRealtimeEvents,
     'should subscribe to messages': testRealtimeSubscribe,
+    'should publish with authCallback': testRealtimePublishWithAuthCallback,
   },
   // FlutterError seems to break the test app and needs to be run last
   TestGroup.HelperTests: {


### PR DESCRIPTION
Support for `authCallback` Realtime operations

### Current status 
**Android**
- [x] Realtime connection
- [x] Realtime publish
- [ ] in-band re-authentication

**iOS**
- [x] Realtime connection
- [x] Realtime publish
- [ ] in-band re-authentication

### How it works
1. Realtime instance will be created with `authCallback` in `ClientOptions`
2. `Realtime#connect` will be triggered from user code
3. ably library code calls a proxy `authCallback` on platform code and that will immediately return `null`, but will make a MethodChannel call (with name `realtimeAuthCallback`) to dart side for token data.
4. dart side receives the `MethodChannel` call and triggers authCallback to return the value to platform code.
platform code will set this response token data in temporary storage.
5. Trigger from `#2` will receive an error with code `80019` which will suppress the error and will check a boolean on dart side if the authentication update was complete and then retry publishing again.
6. Now, the platform code will return with the token data stored temporarily in #5 above for next `authCallback` request from ably library.

#### On token expiry
On token expiry, the connection state listeners will be triggered with connection state set to `disconnected` and with reason as Error with code `80019`. As soon as this event is encountered, `realtimeAuthCallback` method channel api will be triggered from platform side and `Realtime#connect` will be called immediately.


A similar flow occurs in case of publishing to a channel or listening on a channel.