### PR TITLE
iOS podspec tweaks

### DIFF
--- a/example/ios/Podfile
+++ b/example/ios/Podfile
@@ -1,5 +1,6 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '9.0'
+use_frameworks!
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
     - SAMKeychain (= 1.5.3)
     - SocketRocketAblyFork (= 0.5.2-ably-4)
     - ULID (= 1.1.0)
-  - ably_flutter_plugin (0.0.2):
+  - ably_flutter_plugin (0.0.4):
     - Ably
     - Flutter
   - Flutter (1.0.0)
@@ -98,7 +98,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: b8dd747b116787f0759844dc1a045046ef9a2c7a
-  ably_flutter_plugin: 72069121d750b83f093f89c212380021297fa135
+  ably_flutter_plugin: c8e303077249732c5543591d8d8b0afdbff9a073
   Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
   KSCrashAblyFork: c9f408f9abe1e781753b4bfb6c30e01037287c08
   msgpack: a14de9216d29cfd0a7aff5af5150601a27e899a4
@@ -106,6 +106,6 @@ SPEC CHECKSUMS:
   SocketRocketAblyFork: ed717517ed5cb5217878987c84bc415890582bb3
   ULID: b4714891a02819364faecd574a53e391c4c6de9d
 
-PODFILE CHECKSUM: 49ec7d4076524b7e225c38b98147173651ac4b9d
+PODFILE CHECKSUM: 07b700b6a089503d3913fe771b135d30d991e2ea
 
-COCOAPODS: 1.8.4
+COCOAPODS: 1.9.3

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -9,7 +9,7 @@
 /* Begin PBXBuildFile section */
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
-		5B20C6AD3D6ADBABD1A628C0 /* libPods-Runner.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 5EC6C0963CF731849FD763A5 /* libPods-Runner.a */; };
+		5AFEFE05114FC5E50EF96E4C /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD21D0B67BDA09B54EE1B486 /* Pods_Runner.framework */; };
 		978B8F6F1D3862AE00F588F7 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */; };
 		97C146F31CF9000F007C117D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 97C146F21CF9000F007C117D /* main.m */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
@@ -35,7 +35,6 @@
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
-		5EC6C0963CF731849FD763A5 /* libPods-Runner.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Runner.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7AFFD8ED1D35381100E5BB4D /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		7AFFD8EE1D35381100E5BB4D /* AppDelegate.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -48,6 +47,7 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		CD21D0B67BDA09B54EE1B486 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3336021AE374E30F8FCF54 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -56,7 +56,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5B20C6AD3D6ADBABD1A628C0 /* libPods-Runner.a in Frameworks */,
+				5AFEFE05114FC5E50EF96E4C /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -130,7 +130,7 @@
 		C1E99079044187A2894220D2 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				5EC6C0963CF731849FD763A5 /* libPods-Runner.a */,
+				CD21D0B67BDA09B54EE1B486 /* Pods_Runner.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -150,7 +150,6 @@
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
 				D7EE2BE6CB3568789F209DF6 /* [CP] Embed Pods Frameworks */,
-				F43FCE270D2D5EF79808D36E /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -274,21 +273,6 @@
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
-		F43FCE270D2D5EF79808D36E /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -326,7 +310,6 @@
 /* Begin XCBuildConfiguration section */
 		249021D3217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -401,7 +384,6 @@
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 9740EEB21CF90195004384FC /* Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -457,7 +439,6 @@
 		};
 		97C147041CF9000F007C117D /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/example/ios/Runner/AppDelegate.h
+++ b/example/ios/Runner/AppDelegate.h
@@ -1,5 +1,4 @@
-#import <Flutter/Flutter.h>
-#import <UIKit/UIKit.h>
+@import Flutter;
 
 @interface AppDelegate : FlutterAppDelegate
 

--- a/example/ios/Runner/main.m
+++ b/example/ios/Runner/main.m
@@ -1,5 +1,4 @@
-#import <Flutter/Flutter.h>
-#import <UIKit/UIKit.h>
+@import Flutter;
 #import "AppDelegate.h"
 
 int main(int argc, char* argv[]) {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -8,27 +8,13 @@ packages:
       relative: true
     source: path
     version: "0.0.1"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.13"
-  args:
-    dependency: transitive
-    description:
-      name: args
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.6.0"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -36,6 +22,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
   charcode:
     dependency: transitive
     description:
@@ -43,27 +36,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
+    version: "1.14.13"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -71,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.3"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -95,20 +88,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.3"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.12"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.8"
   meta:
     dependency: transitive
     description:
@@ -122,7 +108,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.7.0"
   pedantic:
     dependency: "direct dev"
     description:
@@ -130,20 +116,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -162,7 +134,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.9.5"
   stream_channel:
     dependency: transitive
     description:
@@ -190,14 +162,14 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.15"
+    version: "0.2.17"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.2.0"
   vector_math:
     dependency: transitive
     description:
@@ -205,13 +177,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.8"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.6.1"
 sdks:
-  dart: ">=2.6.0 <3.0.0"
+  dart: ">=2.9.0-14.0.dev <3.0.0"
   flutter: ">=1.17.0 <2.0.0"

--- a/ios/Classes/AblyFlutterStreamHandler.m
+++ b/ios/Classes/AblyFlutterStreamHandler.m
@@ -1,7 +1,8 @@
+@import Ably.ARTRealtime;
+
 #import "AblyFlutterStreamHandler.h"
 #import "AblyFlutterPlugin.h"
 #import "AblyFlutterMessage.h"
-#import "ARTRealtime.h"
 #import "codec/AblyPlatformConstants.h"
 
 @implementation AblyFlutterStreamHandler{

--- a/ios/Classes/codec/AblyFlutterReader.h
+++ b/ios/Classes/codec/AblyFlutterReader.h
@@ -1,8 +1,7 @@
 @import Foundation;
 @import Flutter;
-#import "ARTTokenDetails.h"
-#import "ARTTokenParams.h"
-
+@import Ably.ARTTokenDetails;
+@import Ably.ARTTokenParams;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -1,10 +1,7 @@
+@import Ably;
 #import "AblyFlutterReader.h"
-#import "Ably.h"
 #import "AblyFlutterMessage.h"
 #import "AblyPlatformConstants.h"
-#import "ARTTokenDetails.h"
-#import "ARTTokenParams.h"
-
 
 static ARTLogLevel _logLevel(NSNumber *const number) {
     switch (number.unsignedIntegerValue) {

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -1,6 +1,5 @@
+@import Ably;
 #import "AblyFlutterWriter.h"
-#import "Ably.h"
-#import "ARTTypes.h"
 #import "AblyFlutterMessage.h"
 #import "AblyFlutterReader.h"
 #import "AblyPlatformConstants.h"

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   s.dependency 'Ably'
   s.platform = :ios
-  s.ios.deployment_target  = '9.0'
+  s.ios.deployment_target  = '8.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.version          = '0.0.2'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
   s.homepage         = 'http://example.com'
-  s.license          = { :file => '../LICENSE' }
+  s.license          = 'Apache 2.0'
   s.author           = { 'Ably' => 'support@ably.io' }
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ably_flutter_plugin'
-  s.version          = '0.0.2'
+  s.version          = '0.0.3'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
   s.homepage         = 'https://www.ably.io/'
   s.license          = 'Apache 2.0'

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ably_flutter_plugin'
-  s.version          = '0.0.4'
+  s.version          = '0.0.5'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
   s.homepage         = 'https://www.ably.io/'
   s.license          = 'Apache 2.0'

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -6,9 +6,6 @@ Pod::Spec.new do |s|
   s.name             = 'ably_flutter_plugin'
   s.version          = '0.0.2'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
-  s.description      = <<-DESC
-Ably Cocoa platform support for our Flutter plugin.
-                       DESC
   s.homepage         = 'http://example.com'
   s.license          = { :file => '../LICENSE' }
   s.author           = { 'Ably' => 'support@ably.io' }

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.name             = 'ably_flutter_plugin'
   s.version          = '0.0.2'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
-  s.homepage         = 'http://example.com'
+  s.homepage         = 'https://www.ably.io/'
   s.license          = 'Apache 2.0'
   s.author           = { 'Ably' => 'support@ably.io' }
   s.source           = { :path => '.' }

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Ably'
-  s.platform = :ios, '8.0'
+  s.platform = :ios
   s.ios.deployment_target  = '9.0'
 
   # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.

--- a/ios/ably_flutter_plugin.podspec
+++ b/ios/ably_flutter_plugin.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'ably_flutter_plugin'
-  s.version          = '0.0.3'
+  s.version          = '0.0.4'
   s.summary          = 'Ably Cocoa platform support for our Flutter plugin.'
   s.homepage         = 'https://www.ably.io/'
   s.license          = 'Apache 2.0'


### PR DESCRIPTION
At https://github.com/ably/ably-flutter/pull/46/commits/72c575ae8602c24afa26291c3c311e80e6f1cb37 this branch sorts out failing `flutter run` for iOS in my test project locally. The test project's `pubspec.yaml` looks like this (with the majority of comments removed for brevity):

```
name: ably_flutter_from_github
description: A new Flutter project.
publish_to: 'none' # Remove this line if you wish to publish to pub.dev
version: 1.0.0+1
environment:
  sdk: ">=2.7.0 <3.0.0"
dependencies:
  flutter:
    sdk: flutter
  ably_flutter_plugin:
    git:
      url: https://github.com/ably/ably-flutter.git
      ref: feature/ios-podspec-20200915
  cupertino_icons: ^0.1.3
dev_dependencies:
  flutter_test:
    sdk: flutter
flutter:
  uses-material-design: true
```