### PR TITLE
Update with newest lints and clean up formatting and comments

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,12 +23,13 @@ linter:
     ## Error Rules
 
     # personal preference this conflicts with prefer_relative_imports
-    #    - always_use_package_imports
+    # - always_use_package_imports
     - avoid_empty_else
     - avoid_print
     - avoid_relative_lib_imports
     - avoid_returning_null_for_future
     - avoid_slow_async_io
+    # - avoid_type_to_string # not yet available
     - avoid_types_as_parameter_names
     - avoid_web_libraries_in_flutter
     # subject to false positives, perhaps worth suppressing in code in such cases
@@ -38,7 +39,7 @@ linter:
     - comment_references
     - control_flow_in_finally
     # This seems to be a lint for debugging widgets, not applicable to this plugin
-    #    - diagnostic_describe_all_properties
+    # - diagnostic_describe_all_properties
     - empty_statements
     - hash_and_equals
     - invariant_booleans
@@ -48,33 +49,35 @@ linter:
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
     - no_logic_in_create_state
-    - prefer_relative_imports      # personal preference
+    - prefer_relative_imports # personal preference
     - prefer_void_to_null
     - test_types_in_equals
     - throw_in_finally
     - unnecessary_statements
     - unrelated_type_equality_checks
+    # - unsafe_html # not applicable to this plugin
+    # - use_key_in_widget_constructors # not applicable to this plugin
     - valid_regexps
 
     ## Style Rules
 
     - always_declare_return_types
-    #    - always_put_control_body_on_new_line # works against dartfmt
+    # - always_put_control_body_on_new_line # works against dartfmt
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
-    #    - always_specify_types        # this works against general Dart style guides
+    # - always_specify_types        # this works against general Dart style guides
     - annotate_overrides
     - avoid_annotating_with_dynamic
-    #    - avoid_as                    # obsolete - this was considered good practice in Dart 1
+    # - avoid_as # obsolete - this was considered good practice in Dart 1
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
     # Annoying rule when using classes as namespaces for constants which is discouraged by the Dart
     # style guide, but I prefer it over aliases in imports for disambiguation.
-    #    - avoid_classes_with_only_static_members
+    # - avoid_classes_with_only_static_members
     - avoid_double_and_int_checks
     - avoid_equals_and_hash_code_on_mutable_classes
-    - avoid_escaping_inner_quotes  # TODO(zoechi) not yet available
+    - avoid_escaping_inner_quotes
     - avoid_field_initializers_in_const_classes
     - avoid_function_literals_in_foreach_calls
     - avoid_implementing_value_types
@@ -82,7 +85,7 @@ linter:
     - avoid_js_rounded_ints
     - avoid_null_checks_in_equality_operators
     - avoid_positional_boolean_parameters
-    - avoid_private_typedef_functions
+    # - avoid_private_typedef_functions # There arent't strong arguments for this
     - avoid_redundant_argument_values
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
@@ -93,14 +96,16 @@ linter:
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
     - avoid_types_on_closure_parameters
+    # - avoid_unnecessary_containers # not applicable to this plugin
     # This is annoying as it shows hints to remove arguments from un-implemented spec
     # Can be enabled once the spec is completely implemented
-    #    - avoid_unused_constructor_parameters
+    # - avoid_unused_constructor_parameters
     - avoid_void_async
     - await_only_futures
     - camel_case_extensions
     - camel_case_types
     - cascade_invocations
+    # - cast_nullable_to_non_nullable # experimental, not yet available
     - constant_identifier_names
     - curly_braces_in_flow_control_structures
     - directives_ordering
@@ -109,6 +114,7 @@ linter:
     - empty_constructor_bodies
     - exhaustive_cases
     - file_names
+    # - flutter_style_todos # Not sure this is desired
     - implementation_imports
     - join_return_with_assignment
     - leading_newlines_in_multiline_strings
@@ -119,8 +125,10 @@ linter:
     - no_default_cases             # experimental
     - no_runtimeType_toString
     - non_constant_identifier_names
+    # - null_check_on_nullable_type_parameter # experimental, not yet available
     - null_closures
     - omit_local_variable_types
+    # - one_member_abstracts # Up for discussion
     - only_throw_errors
     - overridden_fields
     - package_api_docs
@@ -128,7 +136,7 @@ linter:
     - parameter_assignments        # personal preference
     - prefer_adjacent_string_concatenation
     - prefer_asserts_in_initializer_lists
-    #    - prefer_asserts_with_message # personal preference
+    # - prefer_asserts_with_message # personal preference
     - prefer_collection_literals
     - prefer_conditional_assignment
     - prefer_const_constructors
@@ -137,7 +145,7 @@ linter:
     - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
-    #    - prefer_double_quotes # I think Dart style guide prefers single quotes
+    # - prefer_double_quotes # We prefer single quotes
     - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields          # personal preference
@@ -163,29 +171,29 @@ linter:
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables
     - provide_deprecation_message
-    #    - public_member_api_docs      # personal preference
+    # - public_member_api_docs      # personal preference
     - recursive_getters
     - sized_box_for_whitespace
     - slash_for_doc_comments
     - sort_child_properties_last
-    #      - sort_constructors_first           # personal preference
-    #      - sort_unnamed_constructors_first   # personal preference
-    #    - super_goes_last # this is covered by the analyzer already in Dart 2
+    # - sort_constructors_first           # personal preference
+    # - sort_unnamed_constructors_first   # personal preference
+    # - super_goes_last # deprecated
+    # - tighten_type_of_initializing_formals # not yet available
     - type_annotate_public_apis
     - type_init_formals
     - unawaited_futures
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
-    # personal preference
-    # should be aligned with prefer_final_fields, prefer_final_in_for_each, prefer_final_locals
-    #    - unnecessary_final
+    # - unnecessary_final # conflicts with prefer_final_locals
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_new
     - unnecessary_null_aware_assignments
+    # - unnecessary_null_checks # experimental, not yet available
     - unnecessary_null_in_if_null_operators
-    - unnecessary_nullable_for_final_variable_declarations
+    - unnecessary_nullable_for_final_variable_declarations # experimental
     - unnecessary_overrides
     - unnecessary_parenthesis
     - unnecessary_raw_strings
@@ -195,7 +203,7 @@ linter:
     - use_full_hex_values_for_flutter_colors
     - use_function_type_syntax_for_parameters
     - use_is_even_rather_than_modulo
-    - use_late_for_private_fields_and_variables
+    - use_late_for_private_fields_and_variables # experimental
     - use_raw_strings
     - use_rethrow_when_possible
     - use_setters_to_change_properties


### PR DESCRIPTION
I checked https://dart-lang.github.io/linter/lints/ for new linter rules and added them.
Most of the new ones are still commented out because they are not yet available in stable Dart.
I also cleaned up formatting and comments a bit.

If some of the enabled lints are not supported yet in the Dart version you are using, please just comment them out with a comment that it's not yet available.