### PR TITLE
Rest Channel Presence#get

### DIFF
--- a/.run/example.run.xml
+++ b/.run/example.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="example" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--observatory-port 8888 --disable-service-auth-codes" />
+    <option name="filePath" value="$PROJECT_DIR$/example/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/integration_test.run.xml
+++ b/.run/integration_test.run.xml
@@ -1,0 +1,7 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="integration_test" type="FlutterRunConfigurationType" factoryName="Flutter">
+    <option name="additionalArgs" value="--observatory-port 8888 --disable-service-auth-codes" />
+    <option name="filePath" value="$PROJECT_DIR$/test_integration/lib/main.dart" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -141,22 +141,22 @@ void getPresence([ably.RestPresenceParams params]) async {
     // getting channel history, by passing or omitting the optional params
     var result = await channel.presence.get(params);
 
-    var messages = result.items; //returns PresenceMessages
+    var presenceMembers = result.items; //returns PresenceMessages
     var hasNextPage = result.hasNext(); //tells whether there are more results
     if(hasNextPage){
       result = await result.next();  //fetches next page results
-      messages = result.items;
+      presenceMembers = result.items;
     }
     if(!hasNextPage){
       result = await result.first();  //fetches first page results
-      messages = result.items;
+      presenceMembers = result.items;
     }
 }
 
-// history with default params
+// getting presence members with default params
 getPresence();
 
-// sorted and filtered history
+// filtered presence members
 getPresence(ably.RestPresenceParams(
   limit: 10,
   clientId: '<clientId>',

--- a/README.md
+++ b/README.md
@@ -134,6 +134,36 @@ getHistory();
 getHistory(ably.RestHistoryParams(direction: 'forwards', limit: 10));
 ```
 
+Get REST Channel Presence:
+
+```dart
+void getPresence([ably.RestPresenceParams params]) async {
+    // getting channel history, by passing or omitting the optional params
+    var result = await channel.presence.get(params);
+
+    var messages = result.items; //returns PresenceMessages
+    var hasNextPage = result.hasNext(); //tells whether there are more results
+    if(hasNextPage){
+      result = await result.next();  //fetches next page results
+      messages = result.items;
+    }
+    if(!hasNextPage){
+      result = await result.first();  //fetches first page results
+      messages = result.items;
+    }
+}
+
+// history with default params
+getPresence();
+
+// sorted and filtered history
+getPresence(ably.RestPresenceParams(
+  limit: 10,
+  clientId: '<clientId>',
+  connectionId: '<connectionID>',
+));
+```
+
 ### Using the Realtime API
 
 Creating the Realtime client instance:

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -27,6 +27,7 @@ import io.ably.lib.types.ClientOptions;
 import io.ably.lib.types.ErrorInfo;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.Param;
+import io.ably.lib.types.PresenceMessage;
 import io.flutter.plugin.common.StandardMessageCodec;
 
 public class AblyMessageCodec extends StandardMessageCodec {
@@ -90,10 +91,14 @@ public class AblyMessageCodec extends StandardMessageCodec {
                         new CodecPair<>(null, self::decodeRestHistoryParams));
                 put(PlatformConstants.CodecTypes.realtimeHistoryParams,
                         new CodecPair<>(null, self::decodeRealtimeHistoryParams));
+                put(PlatformConstants.CodecTypes.restPresenceParams,
+                        new CodecPair<>(null, self::decodeRestPresenceParams));
                 put(PlatformConstants.CodecTypes.errorInfo,
                         new CodecPair<>(self::encodeErrorInfo, null));
                 put(PlatformConstants.CodecTypes.message,
                         new CodecPair<>(self::encodeChannelMessage, self::decodeChannelMessage));
+                put(PlatformConstants.CodecTypes.presenceMessage,
+                        new CodecPair<>(self::encodePresenceMessage, null));
                 put(PlatformConstants.CodecTypes.connectionStateChange,
                         new CodecPair<>(self::encodeConnectionStateChange, null));
                 put(PlatformConstants.CodecTypes.channelStateChange,
@@ -138,6 +143,8 @@ public class AblyMessageCodec extends StandardMessageCodec {
             return PlatformConstants.CodecTypes.connectionStateChange;
         } else if (value instanceof ChannelStateListener.ChannelStateChange) {
             return PlatformConstants.CodecTypes.channelStateChange;
+        } else if (value instanceof PresenceMessage) {
+            return PlatformConstants.CodecTypes.presenceMessage;
         } else if (value instanceof Message) {
             return PlatformConstants.CodecTypes.message;
         }
@@ -353,6 +360,25 @@ public class AblyMessageCodec extends StandardMessageCodec {
         return params;
     }
 
+    private Param[] decodeRestPresenceParams(Map<String, Object> jsonMap) {
+        if (jsonMap == null) return null;
+        Param[] params = new Param[jsonMap.size()];
+        int index = 0;
+        final Object limit = jsonMap.get(PlatformConstants.TxRestPresenceParams.limit);
+        final Object clientId = jsonMap.get(PlatformConstants.TxRestPresenceParams.clientId);
+        final Object connectionId = jsonMap.get(PlatformConstants.TxRestPresenceParams.connectionId);
+        if(limit!=null) {
+            params[index++] = new Param(PlatformConstants.TxRestPresenceParams.limit, (Integer) limit);
+        }
+        if(clientId!=null) {
+            params[index++] = new Param(PlatformConstants.TxRestPresenceParams.clientId, (String) clientId);
+        }
+        if(connectionId!=null) {
+            params[index] = new Param(PlatformConstants.TxRestPresenceParams.connectionId, (String) connectionId);
+        }
+        return params;
+    }
+
     private Message decodeChannelMessage(Map<String, Object> jsonMap) {
         if (jsonMap == null) return null;
         final Message o = new Message();
@@ -563,6 +589,21 @@ public class AblyMessageCodec extends StandardMessageCodec {
         writeValueToJson(jsonMap, PlatformConstants.TxMessage.data, c.data);
         writeValueToJson(jsonMap, PlatformConstants.TxMessage.encoding, c.encoding);
         writeValueToJson(jsonMap, PlatformConstants.TxMessage.extras, c.extras);
+        return jsonMap;
+    }
+
+    private Map<String, Object> encodePresenceMessage(PresenceMessage c) {
+        if (c == null) return null;
+        final HashMap<String, Object> jsonMap = new HashMap<>();
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.id, c.id);
+        writeEnumToJson(jsonMap, PlatformConstants.TxPresenceMessage.action, c.action);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.clientId, c.clientId);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.connectionId, c.connectionId);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.timestamp, c.timestamp);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.data, c.data);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.encoding, c.encoding);
+        // PresenceMessage#extras is not supported in ably-java
+        // Track @ https://github.com/ably/ably-flutter/issues/14
         return jsonMap;
     }
 

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -342,19 +342,19 @@ public class AblyMessageCodec extends StandardMessageCodec {
         final Object limit = jsonMap.get(PlatformConstants.TxRealtimeHistoryParams.limit);
         final Object direction = jsonMap.get(PlatformConstants.TxRealtimeHistoryParams.direction);
         final Object untilAttach = jsonMap.get(PlatformConstants.TxRealtimeHistoryParams.untilAttach);
-        if(start!=null) {
+        if (start != null) {
             params[index++] = new Param(PlatformConstants.TxRealtimeHistoryParams.start, readValueAsLong(start));
         }
-        if(end!=null) {
+        if (end != null) {
             params[index++] = new Param(PlatformConstants.TxRealtimeHistoryParams.end, readValueAsLong(end));
         }
-        if(limit!=null) {
+        if (limit != null) {
             params[index++] = new Param(PlatformConstants.TxRealtimeHistoryParams.limit, (Integer) limit);
         }
-        if(direction!=null) {
+        if (direction != null) {
             params[index++] = new Param(PlatformConstants.TxRealtimeHistoryParams.direction, (String) direction);
         }
-        if(untilAttach!=null) {
+        if (untilAttach != null) {
             params[index] = new Param(PlatformConstants.TxRealtimeHistoryParams.untilAttach, (boolean) untilAttach);
         }
         return params;
@@ -367,13 +367,13 @@ public class AblyMessageCodec extends StandardMessageCodec {
         final Object limit = jsonMap.get(PlatformConstants.TxRestPresenceParams.limit);
         final Object clientId = jsonMap.get(PlatformConstants.TxRestPresenceParams.clientId);
         final Object connectionId = jsonMap.get(PlatformConstants.TxRestPresenceParams.connectionId);
-        if(limit!=null) {
+        if (limit != null) {
             params[index++] = new Param(PlatformConstants.TxRestPresenceParams.limit, (Integer) limit);
         }
-        if(clientId!=null) {
+        if (clientId != null) {
             params[index++] = new Param(PlatformConstants.TxRestPresenceParams.clientId, (String) clientId);
         }
-        if(connectionId!=null) {
+        if (connectionId != null) {
             params[index] = new Param(PlatformConstants.TxRestPresenceParams.connectionId, (String) connectionId);
         }
         return params;
@@ -592,11 +592,28 @@ public class AblyMessageCodec extends StandardMessageCodec {
         return jsonMap;
     }
 
+    private String encodePresenceAction(PresenceMessage.Action action) {
+        switch (action) {
+            case absent:
+                return PlatformConstants.TxEnumConstants.absent;
+            case leave:
+                return PlatformConstants.TxEnumConstants.leave;
+            case enter:
+                return PlatformConstants.TxEnumConstants.enter;
+            case present:
+                return PlatformConstants.TxEnumConstants.present;
+            case update:
+                return PlatformConstants.TxEnumConstants.update;
+            default:
+                return null;
+        }
+    }
+
     private Map<String, Object> encodePresenceMessage(PresenceMessage c) {
         if (c == null) return null;
         final HashMap<String, Object> jsonMap = new HashMap<>();
         writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.id, c.id);
-        writeEnumToJson(jsonMap, PlatformConstants.TxPresenceMessage.action, c.action);
+        writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.action, encodePresenceAction(c.action));
         writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.clientId, c.clientId);
         writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.connectionId, c.connectionId);
         writeValueToJson(jsonMap, PlatformConstants.TxPresenceMessage.timestamp, c.timestamp);

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -235,24 +235,6 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
         });
     }
 
-    private void getNextPage(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-        final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
-        this.<Integer>ablyDo(
-                message,
-                (ablyLibrary, pageHandle) -> ablyLibrary
-                        .getPaginatedResult(pageHandle)
-                        .next(this.paginatedResponseHandler(result, pageHandle)));
-    }
-
-    private void getFirstPage(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-        final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
-        this.<Integer>ablyDo(
-                message,
-                (ablyLibrary, pageHandle) -> ablyLibrary
-                        .getPaginatedResult(pageHandle)
-                        .first(this.paginatedResponseHandler(result, pageHandle)));
-    }
-
     private void getRestPresence(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
         final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
         this.<AblyFlutterMessage<Map<String, Object>>>ablyDo(message, (ablyLibrary, messageData) -> {
@@ -464,6 +446,24 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
             ablyLibrary.getRealtime(realtimeHandle.longValue()).close();
             result.success(null);
         });
+    }
+
+    private void getNextPage(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+        final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
+        this.<Integer>ablyDo(
+                message,
+                (ablyLibrary, pageHandle) -> ablyLibrary
+                        .getPaginatedResult(pageHandle)
+                        .next(this.paginatedResponseHandler(result, pageHandle)));
+    }
+
+    private void getFirstPage(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+        final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
+        this.<Integer>ablyDo(
+                message,
+                (ablyLibrary, pageHandle) -> ablyLibrary
+                        .getPaginatedResult(pageHandle)
+                        .first(this.paginatedResponseHandler(result, pageHandle)));
     }
 
     <Arguments> void ablyDo(final AblyFlutterMessage message, final BiConsumer<AblyLibrary, Arguments> consumer) {

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -194,7 +194,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
             };
 
             final ArrayList<Message> channelMessages = (ArrayList<Message>) map.get("messages");
-            if( channelMessages == null ){
+            if (channelMessages == null) {
                 result.error("Messages cannot be null", null, null);
                 return;
             }
@@ -411,7 +411,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
                 };
 
                 final ArrayList<Message> channelMessages = (ArrayList<Message>) ablyMessage.message.get("messages");
-                if( channelMessages == null ){
+                if (channelMessages == null) {
                     result.error("Messages cannot be null", null, null);
                     return;
                 }

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -19,6 +19,8 @@ final public class PlatformConstants {
         public static final byte paginatedResult = (byte) 135;
         public static final byte restHistoryParams = (byte) 136;
         public static final byte realtimeHistoryParams = (byte) 137;
+        public static final byte restPresenceParams = (byte) 138;
+        public static final byte presenceMessage = (byte) 139;
         public static final byte errorInfo = (byte) 144;
         public static final byte connectionStateChange = (byte) 201;
         public static final byte channelStateChange = (byte) 202;
@@ -32,6 +34,8 @@ final public class PlatformConstants {
         public static final String realtimeAuthCallback = "realtimeAuthCallback";
         public static final String createRestWithOptions = "createRestWithOptions";
         public static final String publish = "publish";
+        public static final String restHistory = "restHistory";
+        public static final String restPresenceGet = "restPresenceGet";
         public static final String createRealtimeWithOptions = "createRealtimeWithOptions";
         public static final String connectRealtime = "connectRealtime";
         public static final String closeRealtime = "closeRealtime";
@@ -39,11 +43,10 @@ final public class PlatformConstants {
         public static final String detachRealtimeChannel = "detachRealtimeChannel";
         public static final String setRealtimeChannelOptions = "setRealtimeChannelOptions";
         public static final String publishRealtimeChannelMessage = "publishRealtimeChannelMessage";
+        public static final String realtimeHistory = "realtimeHistory";
         public static final String onRealtimeConnectionStateChanged = "onRealtimeConnectionStateChanged";
         public static final String onRealtimeChannelStateChanged = "onRealtimeChannelStateChanged";
         public static final String onRealtimeChannelMessage = "onRealtimeChannelMessage";
-        public static final String restHistory = "restHistory";
-        public static final String realtimeHistory = "realtimeHistory";
         public static final String nextPage = "nextPage";
         public static final String firstPage = "firstPage";
     }
@@ -179,6 +182,17 @@ final public class PlatformConstants {
         public static final String extras = "extras";
     }
 
+    static final public class TxPresenceMessage {
+        public static final String id = "id";
+        public static final String action = "action";
+        public static final String clientId = "clientId";
+        public static final String connectionId = "connectionId";
+        public static final String data = "data";
+        public static final String encoding = "encoding";
+        public static final String extras = "extras";
+        public static final String timestamp = "timestamp";
+    }
+
     static final public class TxPaginatedResult {
         public static final String items = "items";
         public static final String type = "type";
@@ -198,6 +212,12 @@ final public class PlatformConstants {
         public static final String direction = "direction";
         public static final String limit = "limit";
         public static final String untilAttach = "untilAttach";
+    }
+
+    static final public class TxRestPresenceParams {
+        public static final String limit = "limit";
+        public static final String clientId = "clientId";
+        public static final String connectionId = "connectionId";
     }
 
 }

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -152,6 +152,10 @@ final public class PlatformConstants {
         public static final String closing = "closing";
         public static final String closed = "closed";
         public static final String failed = "failed";
+        public static final String absent = "absent";
+        public static final String leave = "leave";
+        public static final String enter = "enter";
+        public static final String present = "present";
         public static final String update = "update";
     }
 

--- a/bin/codegencontext.dart
+++ b/bin/codegencontext.dart
@@ -191,6 +191,10 @@ const List<Map<String, dynamic>> _objects = [
       'closing',
       'closed',
       'failed',
+      'absent',
+      'leave',
+      'enter',
+      'present',
       'update',
     ]
   },

--- a/bin/codegencontext.dart
+++ b/bin/codegencontext.dart
@@ -26,6 +26,8 @@ const List<Map<String, dynamic>> _types = [
   {'name': 'paginatedResult', 'value': 135},
   {'name': 'restHistoryParams', 'value': 136},
   {'name': 'realtimeHistoryParams', 'value': 137},
+  {'name': 'restPresenceParams', 'value': 138},
+  {'name': 'presenceMessage', 'value': 139},
   {'name': 'errorInfo', 'value': 144},
 
   // Events
@@ -46,6 +48,8 @@ const List<Map<String, dynamic>> _platformMethods = [
   // Rest
   {'name': 'createRestWithOptions', 'value': 'createRestWithOptions'},
   {'name': 'publish', 'value': 'publish'},
+  {'name': 'restHistory', 'value': 'restHistory'},
+  {'name': 'restPresenceGet', 'value': 'restPresenceGet'},
 
   // Realtime
   {'name': 'createRealtimeWithOptions', 'value': 'createRealtimeWithOptions'},
@@ -58,6 +62,7 @@ const List<Map<String, dynamic>> _platformMethods = [
     'name': 'publishRealtimeChannelMessage',
     'value': 'publishRealtimeChannelMessage'
   },
+  {'name': 'realtimeHistory', 'value': 'realtimeHistory'},
 
   // Realtime events
   {
@@ -69,10 +74,6 @@ const List<Map<String, dynamic>> _platformMethods = [
     'value': 'onRealtimeChannelStateChanged'
   },
   {'name': 'onRealtimeChannelMessage', 'value': 'onRealtimeChannelMessage'},
-
-  // History
-  {'name': 'restHistory', 'value': 'restHistory'},
-  {'name': 'realtimeHistory', 'value': 'realtimeHistory'},
 
   // Paginated results
   {'name': 'nextPage', 'value': 'nextPage'},
@@ -215,6 +216,19 @@ const List<Map<String, dynamic>> _objects = [
     ]
   },
   {
+    'name': 'PresenceMessage',
+    'properties': <String>[
+      'id',
+      'action',
+      'clientId',
+      'connectionId',
+      'data',
+      'encoding',
+      'extras',
+      'timestamp',
+    ]
+  },
+  {
     'name': 'PaginatedResult',
     'properties': <String>['items', 'type', 'hasNext']
   },
@@ -236,7 +250,15 @@ const List<Map<String, dynamic>> _objects = [
       'limit',
       'untilAttach',
     ]
-  }
+  },
+  {
+    'name': 'RestPresenceParams',
+    'properties': <String>[
+      'limit',
+      'clientId',
+      'connectionId',
+    ]
+  },
 ];
 
 // exporting all the constants as a single map

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -544,6 +544,32 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
+  Widget getRealtimeChannelHistory() => FlatButton(
+        onPressed: () async {
+          final next = _realtimeHistory?.hasNext() ?? false;
+          print('Rest history: getting ${next ? 'next' : 'first'} page');
+          try {
+            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
+              final result =
+                  await _realtime.channels.get('test-channel').history(
+                        ably.RealtimeHistoryParams(
+                            direction: 'forwards', limit: 10),
+                      );
+              _realtimeHistory = result;
+            } else if (next) {
+              _realtimeHistory = await _realtimeHistory.next();
+            } else {
+              _realtimeHistory = await _realtimeHistory.first();
+            }
+            setState(() {});
+          } on ably.AblyException catch (e) {
+            print('failed to get history:: $e :: ${e.errorInfo}');
+          }
+        },
+        color: Colors.yellow,
+        child: const Text('Get history'),
+      );
+
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -544,32 +544,6 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
-  Widget getRealtimeChannelHistory() => FlatButton(
-        onPressed: () async {
-          final next = _realtimeHistory?.hasNext() ?? false;
-          print('Rest history: getting ${next ? 'next' : 'first'} page');
-          try {
-            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
-              final result =
-                  await _realtime.channels.get('test-channel').history(
-                        ably.RealtimeHistoryParams(
-                            direction: 'forwards', limit: 10),
-                      );
-              _realtimeHistory = result;
-            } else if (next) {
-              _realtimeHistory = await _realtimeHistory.next();
-            } else {
-              _realtimeHistory = await _realtimeHistory.first();
-            }
-            setState(() {});
-          } on ably.AblyException catch (e) {
-            print('failed to get history:: $e :: ${e.errorInfo}');
-          }
-        },
-        color: Colors.yellow,
-        child: const Text('Get history'),
-      );
-
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,60 +9,18 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
-
   http: ^0.12.0+4
 
 dev_dependencies:
+  ably_flutter:
+    path: ../
+
   flutter_test:
     sdk: flutter
 
-  ably_flutter:
-    path: ../
 
   # Stricter Linting
   pedantic: ^1.0.0
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #  - images/a_dot_burr.jpeg
-  #  - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -28,7 +28,7 @@ app.get('/auth', function (req, res) {
     /* Issue a token with subscribe privileges restricted to one channel
        and configure the token without an identity (anonymous) */
     tokenParams = {
-      capability: {'*': ['publish', 'subscribe']},
+      capability: {'*': ['publish', 'subscribe', 'history', 'presence']},
       ttl: 15000,
     };
   }

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -21,7 +21,7 @@ app.get('/auth', function (req, res) {
     /* Issue a token request with pub & sub permissions on all channels +
        configure the token with an identity */
     tokenParams = {
-      capability: {'*': ['publish', 'subscribe']},
+      capability: {'*': ['publish', 'subscribe', 'history', 'presence']},
       clientId: req.cookies.username,
     };
   } else {

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -6,7 +6,7 @@
 const Ably = require('ably');
 
 const ApiKey = process.argv[2];
-if (ApiKey.indexOf('INSERT') === 0) {
+if (!ApiKey) {
   throw 'Cannot run without an API key. Add your key to example.js';
 }
 var rest = new Ably.Rest({key: ApiKey});

--- a/example/test_harness/tokenRequest.js
+++ b/example/test_harness/tokenRequest.js
@@ -1,19 +1,18 @@
 // Example to run tokenRequest server:
 // This server will return TokenRequest json on making get call to `/auth` endpoint
-// node token "your-app-key"
-// node token "I2E_JQ.79AfrA:sw2y9zarxwl0Lw5a"
+// node tokenRequest "your-app-key"
+// node tokenRequest "I2E_JQ.79AfrA:sw2y9zarxwl0Lw5a"
 
-const Ably = require("ably");
-
+const Ably = require('ably');
 
 const ApiKey = process.argv[2];
-if (ApiKey.indexOf("INSERT") === 0) {
-    throw("Cannot run without an API key. Add your key to example.js");
+if (ApiKey.indexOf('INSERT') === 0) {
+  throw 'Cannot run without an API key. Add your key to example.js';
 }
-var rest = new Ably.Rest({ key: ApiKey });
+var rest = new Ably.Rest({key: ApiKey});
 
 const express = require('express'),
-      app = express();
+  app = express();
 
 app.get('/auth', function (req, res) {
   var tokenParams;
@@ -22,32 +21,45 @@ app.get('/auth', function (req, res) {
     /* Issue a token request with pub & sub permissions on all channels +
        configure the token with an identity */
     tokenParams = {
-      'capability': { '*': ['publish', 'subscribe'] },
-      'clientId': req.cookies.username
+      capability: {'*': ['publish', 'subscribe']},
+      clientId: req.cookies.username,
     };
   } else {
     /* Issue a token with subscribe privileges restricted to one channel
        and configure the token without an identity (anonymous) */
     tokenParams = {
-      'capability': { '*': ['publish', 'subscribe'] },
-      'ttl': 15000
+      capability: {'*': ['publish', 'subscribe']},
+      ttl: 15000,
     };
   }
-  rest.auth.createTokenRequest(tokenParams, function(err, tokenRequest) {
+  rest.auth.createTokenRequest(tokenParams, function (err, tokenRequest) {
     if (err) {
       let message = 'Error requesting token: ' + JSON.stringify(err);
       console.log(message);
       res.status(500).send(message);
     } else {
-      console.log("token request successful\n", JSON.stringify(tokenRequest, null, 2));
+      console.log(
+        'token request successful\n',
+        JSON.stringify(tokenRequest, null, 2)
+      );
       res.setHeader('Content-Type', 'application/json');
       res.send(JSON.stringify(tokenRequest));
     }
   });
 });
 
-app.use('/', (req, res) => res.send('use `/auth` endpoint to acquire token request'));
+app.use('/', (req, res) =>
+  res.send('use `/auth` endpoint to acquire token request')
+);
 
 app.listen(3000, function () {
-  console.log(`Web server listening on port 3000. Visit http://localhost:3000/auth to get requestToken`);
+  // getting localIP Address from network interfaces
+  const localIp = Object.values(require('os').networkInterfaces())
+    .map((interface) =>
+      interface.filter((net) => net.family === 'IPv4' && net.internal === false)
+    )
+    .filter((_) => _.length)[0][0].address;
+  console.log(
+    `Web server listening on port 3000. Visit http://${localIp}:3000/auth to get requestToken`
+  );
 });

--- a/ios/Classes/AblyFlutterPlugin.m
+++ b/ios/Classes/AblyFlutterPlugin.m
@@ -62,7 +62,7 @@ static const FlutterHandler _publishRestMessage = ^void(AblyFlutterPlugin *const
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error publishing rest message; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -85,7 +85,7 @@ static const FlutterHandler _getRestHistory = ^void(AblyFlutterPlugin *const plu
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error getting rest channel history; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -138,7 +138,7 @@ static const FlutterHandler _attachRealtimeChannel = ^void(AblyFlutterPlugin *co
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error attaching to realtime channel; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -163,7 +163,7 @@ static const FlutterHandler _detachRealtimeChannel = ^void(AblyFlutterPlugin *co
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error detaching from realtime channel; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -187,7 +187,7 @@ static const FlutterHandler _publishRealtimeChannelMessage = ^void(AblyFlutterPl
         if(error){
             result(
                    [FlutterError errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                                       message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                                       message:[NSString stringWithFormat:@"Error publishing realtime message; err = %@", [error message]]
                                        details:error]
                    );
         }else{
@@ -218,7 +218,7 @@ static const FlutterHandler _getRealtimeHistory = ^void(AblyFlutterPlugin *const
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to publish message to Ably server; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error getting realtime channel history; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -243,7 +243,7 @@ static const FlutterHandler _getNextPage = ^void(AblyFlutterPlugin *const plugin
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to get next page; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error getting next page; err = %@", [error message]]
                     details:error
                     ]);
         }else{
@@ -263,7 +263,7 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutterPlugin *const plugi
             result([
                     FlutterError
                     errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to get first page; err = %@", [error message]]
+                    message:[NSString stringWithFormat:@"Error getting first page; err = %@", [error message]]
                     details:error
                     ]);
         }else{

--- a/ios/Classes/AblyFlutterPlugin.m
+++ b/ios/Classes/AblyFlutterPlugin.m
@@ -100,46 +100,6 @@ static const FlutterHandler _getRestHistory = ^void(AblyFlutterPlugin *const plu
     }
 };
 
-static const FlutterHandler _getNextPage = ^void(AblyFlutterPlugin *const plugin, FlutterMethodCall *const call, const FlutterResult result) {
-    AblyFlutterMessage *const message = call.arguments;
-    AblyFlutter *const ably = [plugin ably];
-    NSNumber *const handle = message.message;
-    ARTPaginatedResult *paginatedResult = [ably getPaginatedResult:handle];
-    [paginatedResult next:^(ARTPaginatedResult * _Nullable paginatedResult, ARTErrorInfo * _Nullable error) {
-        if(error){
-            result([
-                    FlutterError
-                    errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to get next page; err = %@", [error message]]
-                    details:error
-                    ]);
-        }else{
-            NSNumber *const paginatedResultHandle = [ably setPaginatedResult:paginatedResult handle:handle];
-            result([[AblyFlutterMessage alloc] initWithMessage:paginatedResult handle: paginatedResultHandle]);
-        }
-    }];
-};
-
-static const FlutterHandler _getFirstPage = ^void(AblyFlutterPlugin *const plugin, FlutterMethodCall *const call, const FlutterResult result) {
-    AblyFlutterMessage *const message = call.arguments;
-    AblyFlutter *const ably = [plugin ably];
-    NSNumber *const handle = message.message;
-    ARTPaginatedResult *paginatedResult = [ably getPaginatedResult:handle];
-    [paginatedResult first:^(ARTPaginatedResult * _Nullable paginatedResult, ARTErrorInfo * _Nullable error) {
-        if(error){
-            result([
-                    FlutterError
-                    errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
-                    message:[NSString stringWithFormat:@"Unable to get first page; err = %@", [error message]]
-                    details:error
-                    ]);
-        }else{
-            NSNumber *const paginatedResultHandle = [ably setPaginatedResult:paginatedResult handle:handle];
-            result([[AblyFlutterMessage alloc] initWithMessage:paginatedResult handle: paginatedResultHandle]);
-        }
-    }];
-};
-
 static const FlutterHandler _createRealtimeWithOptions = ^void(AblyFlutterPlugin *const plugin, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const message = call.arguments;
     AblyFlutter *const ably = [plugin ably];
@@ -272,6 +232,47 @@ static const FlutterHandler _getRealtimeHistory = ^void(AblyFlutterPlugin *const
         [channel history:cbk];
     }
 };
+
+static const FlutterHandler _getNextPage = ^void(AblyFlutterPlugin *const plugin, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const message = call.arguments;
+    AblyFlutter *const ably = [plugin ably];
+    NSNumber *const handle = message.message;
+    ARTPaginatedResult *paginatedResult = [ably getPaginatedResult:handle];
+    [paginatedResult next:^(ARTPaginatedResult * _Nullable paginatedResult, ARTErrorInfo * _Nullable error) {
+        if(error){
+            result([
+                    FlutterError
+                    errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
+                    message:[NSString stringWithFormat:@"Unable to get next page; err = %@", [error message]]
+                    details:error
+                    ]);
+        }else{
+            NSNumber *const paginatedResultHandle = [ably setPaginatedResult:paginatedResult handle:handle];
+            result([[AblyFlutterMessage alloc] initWithMessage:paginatedResult handle: paginatedResultHandle]);
+        }
+    }];
+};
+
+static const FlutterHandler _getFirstPage = ^void(AblyFlutterPlugin *const plugin, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const message = call.arguments;
+    AblyFlutter *const ably = [plugin ably];
+    NSNumber *const handle = message.message;
+    ARTPaginatedResult *paginatedResult = [ably getPaginatedResult:handle];
+    [paginatedResult first:^(ARTPaginatedResult * _Nullable paginatedResult, ARTErrorInfo * _Nullable error) {
+        if(error){
+            result([
+                    FlutterError
+                    errorWithCode:[NSString stringWithFormat: @"%ld", (long)error.code]
+                    message:[NSString stringWithFormat:@"Unable to get first page; err = %@", [error message]]
+                    details:error
+                    ]);
+        }else{
+            NSNumber *const paginatedResultHandle = [ably setPaginatedResult:paginatedResult handle:handle];
+            result([[AblyFlutterMessage alloc] initWithMessage:paginatedResult handle: paginatedResultHandle]);
+        }
+    }];
+};
+
 
 
 @implementation AblyFlutterPlugin {

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_END
         [NSString stringWithFormat:@"%d", tokenRequestCodecType]: readTokenRequest,
         [NSString stringWithFormat:@"%d", restHistoryParamsCodecType]: readRestHistoryParams,
         [NSString stringWithFormat:@"%d", realtimeHistoryParamsCodecType]: readRealtimeHistoryParams,
+        [NSString stringWithFormat:@"%d", restPresenceParamsCodecType]: readRestPresenceParams,
     };
     return [_handlers objectForKey:[NSString stringWithFormat:@"%@", type]];
 }
@@ -253,6 +254,17 @@ static AblyCodecDecoder readRealtimeHistoryParams = ^ARTRealtimeHistoryQuery*(NS
         }
     }, dictionary, TxRealtimeHistoryParams_direction);
     READ_VALUE(o, untilAttach, dictionary, TxRealtimeHistoryParams_untilAttach);
+    return o;
+};
+
+static AblyCodecDecoder readRestPresenceParams = ^ARTPresenceQuery*(NSDictionary *const dictionary) {
+    ARTPresenceQuery *const o = [ARTPresenceQuery new];
+    ON_VALUE(^(NSString const *value) {
+        o.limit = [value integerValue];
+    }, dictionary, TxRestPresenceParams_limit);
+    READ_VALUE(o, clientId, dictionary, TxRestPresenceParams_clientId);
+    READ_VALUE(o, connectionId, dictionary, TxRestPresenceParams_connectionId);
+
     return o;
 };
 

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -224,11 +224,28 @@ static AblyCodecEncoder encodeChannelMessage = ^NSMutableDictionary*(ARTMessage 
     return dictionary;
 };
 
++(NSString *) encodePresenceAction: (ARTPresenceAction) action {
+    switch(action) {
+        case ARTPresenceAbsent:
+            return TxEnumConstants_absent;
+        case ARTPresencePresent:
+            return TxEnumConstants_present;
+        case ARTPresenceEnter:
+            return TxEnumConstants_enter;
+        case ARTPresenceLeave:
+            return TxEnumConstants_leave;
+        case ARTPresenceUpdate:
+            return TxEnumConstants_update;
+    }
+}
+
 static AblyCodecEncoder encodePresenceMessage = ^NSMutableDictionary*(ARTPresenceMessage *const message) {
     NSMutableDictionary<NSString *, NSObject *> *dictionary = [[NSMutableDictionary alloc] init];
     
     WRITE_VALUE(dictionary, TxPresenceMessage_id, [message id]);
-    WRITE_ENUM(dictionary, TxPresenceMessage_action, [message action]);
+    WRITE_VALUE(dictionary,
+                TxConnectionStateChange_current,
+                [AblyFlutterWriter encodePresenceAction: [message action]]);
     WRITE_VALUE(dictionary, TxPresenceMessage_clientId, [message clientId]);
     WRITE_VALUE(dictionary, TxPresenceMessage_data, (NSObject *)[message data]);
     WRITE_VALUE(dictionary, TxPresenceMessage_connectionId, [message connectionId]);

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_END
         return channelStateChangeCodecType;
     }else if([value isKindOfClass:[ARTMessage class]]){
         return messageCodecType;
+    }else if([value isKindOfClass:[ARTPresenceMessage class]]){
+        return presenceMessageCodecType;
     }else if([value isKindOfClass:[ARTTokenParams class]]){
         return tokenParamsCodecType;
     }else if([value isKindOfClass:[ARTPaginatedResult class]]){
@@ -40,6 +42,7 @@ NS_ASSUME_NONNULL_END
         [NSString stringWithFormat:@"%d", connectionStateChangeCodecType]: encodeConnectionStateChange,
         [NSString stringWithFormat:@"%d", channelStateChangeCodecType]: encodeChannelStateChange,
         [NSString stringWithFormat:@"%d", messageCodecType]: encodeChannelMessage,
+        [NSString stringWithFormat:@"%d", presenceMessageCodecType]: encodePresenceMessage,
         [NSString stringWithFormat:@"%d", tokenParamsCodecType]: encodeTokenParams,
         [NSString stringWithFormat:@"%d", paginatedResultCodecType]: encodePaginatedResult,
     };
@@ -221,6 +224,23 @@ static AblyCodecEncoder encodeChannelMessage = ^NSMutableDictionary*(ARTMessage 
     return dictionary;
 };
 
+static AblyCodecEncoder encodePresenceMessage = ^NSMutableDictionary*(ARTPresenceMessage *const message) {
+    NSMutableDictionary<NSString *, NSObject *> *dictionary = [[NSMutableDictionary alloc] init];
+    
+    WRITE_VALUE(dictionary, TxPresenceMessage_id, [message id]);
+    WRITE_ENUM(dictionary, TxPresenceMessage_action, [message action]);
+    WRITE_VALUE(dictionary, TxPresenceMessage_clientId, [message clientId]);
+    WRITE_VALUE(dictionary, TxPresenceMessage_data, (NSObject *)[message data]);
+    WRITE_VALUE(dictionary, TxPresenceMessage_connectionId, [message connectionId]);
+    WRITE_VALUE(dictionary, TxPresenceMessage_encoding, [message encoding]);
+    WRITE_VALUE(dictionary, TxPresenceMessage_extras, [message extras]);
+    
+    WRITE_VALUE(dictionary, TxPresenceMessage_timestamp,
+                [message timestamp]?@((long)([[message timestamp] timeIntervalSince1970]*1000)):nil);
+    
+    return dictionary;
+};
+
 static AblyCodecEncoder encodeTokenParams = ^NSMutableDictionary*(ARTTokenParams *const params) {
     NSMutableDictionary<NSString *, NSObject *> *dictionary = [[NSMutableDictionary alloc] init];
     
@@ -237,15 +257,17 @@ static AblyCodecEncoder encodeTokenParams = ^NSMutableDictionary*(ARTTokenParams
 static AblyCodecEncoder encodePaginatedResult = ^NSMutableDictionary*(ARTPaginatedResult *const result) {
     NSMutableDictionary<NSString *, NSObject *> *dictionary = [[NSMutableDictionary alloc] init];
     NSArray* items = [result items];
-    UInt8 type = [AblyFlutterWriter getType:items[0]];
-    if(type != 0){
-        AblyCodecEncoder encoder = [AblyFlutterWriter getEncoder: [NSString stringWithFormat:@"%d", type]];
-        NSMutableArray *result = [NSMutableArray arrayWithCapacity:[items count]];
-        [items enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            [result addObject: encoder(obj)];
-        }];
-        WRITE_VALUE(dictionary, TxPaginatedResult_type, [NSNumber numberWithInt:type]);
-        WRITE_VALUE(dictionary, TxPaginatedResult_items, result);
+    if([items count] > 0){
+        UInt8 type = [AblyFlutterWriter getType:items[0]];
+        if(type != 0){
+            AblyCodecEncoder encoder = [AblyFlutterWriter getEncoder: [NSString stringWithFormat:@"%d", type]];
+            NSMutableArray *result = [NSMutableArray arrayWithCapacity:[items count]];
+            [items enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+                [result addObject: encoder(obj)];
+            }];
+            WRITE_VALUE(dictionary, TxPaginatedResult_type, [NSNumber numberWithInt:type]);
+            WRITE_VALUE(dictionary, TxPaginatedResult_items, result);
+        }
     }
     WRITE_VALUE(dictionary, TxPaginatedResult_hasNext, @([result hasNext]));
     

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -34,6 +34,7 @@ extern NSString *const AblyPlatformMethod_createRestWithOptions;
 extern NSString *const AblyPlatformMethod_publish;
 extern NSString *const AblyPlatformMethod_restHistory;
 extern NSString *const AblyPlatformMethod_restPresenceGet;
+extern NSString *const AblyPlatformMethod_restPresenceHistory;
 extern NSString *const AblyPlatformMethod_createRealtimeWithOptions;
 extern NSString *const AblyPlatformMethod_connectRealtime;
 extern NSString *const AblyPlatformMethod_closeRealtime;
@@ -150,6 +151,10 @@ extern NSString *const TxEnumConstants_suspended;
 extern NSString *const TxEnumConstants_closing;
 extern NSString *const TxEnumConstants_closed;
 extern NSString *const TxEnumConstants_failed;
+extern NSString *const TxEnumConstants_absent;
+extern NSString *const TxEnumConstants_leave;
+extern NSString *const TxEnumConstants_enter;
+extern NSString *const TxEnumConstants_present;
 extern NSString *const TxEnumConstants_update;
 @end
 

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -16,6 +16,8 @@ typedef NS_ENUM(UInt8, _Value) {
     paginatedResultCodecType = 135,
     restHistoryParamsCodecType = 136,
     realtimeHistoryParamsCodecType = 137,
+    restPresenceParamsCodecType = 138,
+    presenceMessageCodecType = 139,
     errorInfoCodecType = 144,
     connectionStateChangeCodecType = 201,
     channelStateChangeCodecType = 202,
@@ -30,6 +32,8 @@ extern NSString *const AblyPlatformMethod_authCallback;
 extern NSString *const AblyPlatformMethod_realtimeAuthCallback;
 extern NSString *const AblyPlatformMethod_createRestWithOptions;
 extern NSString *const AblyPlatformMethod_publish;
+extern NSString *const AblyPlatformMethod_restHistory;
+extern NSString *const AblyPlatformMethod_restPresenceGet;
 extern NSString *const AblyPlatformMethod_createRealtimeWithOptions;
 extern NSString *const AblyPlatformMethod_connectRealtime;
 extern NSString *const AblyPlatformMethod_closeRealtime;
@@ -37,11 +41,10 @@ extern NSString *const AblyPlatformMethod_attachRealtimeChannel;
 extern NSString *const AblyPlatformMethod_detachRealtimeChannel;
 extern NSString *const AblyPlatformMethod_setRealtimeChannelOptions;
 extern NSString *const AblyPlatformMethod_publishRealtimeChannelMessage;
+extern NSString *const AblyPlatformMethod_realtimeHistory;
 extern NSString *const AblyPlatformMethod_onRealtimeConnectionStateChanged;
 extern NSString *const AblyPlatformMethod_onRealtimeChannelStateChanged;
 extern NSString *const AblyPlatformMethod_onRealtimeChannelMessage;
-extern NSString *const AblyPlatformMethod_restHistory;
-extern NSString *const AblyPlatformMethod_realtimeHistory;
 extern NSString *const AblyPlatformMethod_nextPage;
 extern NSString *const AblyPlatformMethod_firstPage;
 @end
@@ -177,6 +180,17 @@ extern NSString *const TxMessage_name;
 extern NSString *const TxMessage_extras;
 @end
 
+@interface TxPresenceMessage : NSObject
+extern NSString *const TxPresenceMessage_id;
+extern NSString *const TxPresenceMessage_action;
+extern NSString *const TxPresenceMessage_clientId;
+extern NSString *const TxPresenceMessage_connectionId;
+extern NSString *const TxPresenceMessage_data;
+extern NSString *const TxPresenceMessage_encoding;
+extern NSString *const TxPresenceMessage_extras;
+extern NSString *const TxPresenceMessage_timestamp;
+@end
+
 @interface TxPaginatedResult : NSObject
 extern NSString *const TxPaginatedResult_items;
 extern NSString *const TxPaginatedResult_type;
@@ -196,4 +210,10 @@ extern NSString *const TxRealtimeHistoryParams_end;
 extern NSString *const TxRealtimeHistoryParams_direction;
 extern NSString *const TxRealtimeHistoryParams_limit;
 extern NSString *const TxRealtimeHistoryParams_untilAttach;
+@end
+
+@interface TxRestPresenceParams : NSObject
+extern NSString *const TxRestPresenceParams_limit;
+extern NSString *const TxRestPresenceParams_clientId;
+extern NSString *const TxRestPresenceParams_connectionId;
 @end

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -16,6 +16,7 @@ NSString *const AblyPlatformMethod_createRestWithOptions= @"createRestWithOption
 NSString *const AblyPlatformMethod_publish= @"publish";
 NSString *const AblyPlatformMethod_restHistory= @"restHistory";
 NSString *const AblyPlatformMethod_restPresenceGet= @"restPresenceGet";
+NSString *const AblyPlatformMethod_restPresenceHistory= @"restPresenceHistory";
 NSString *const AblyPlatformMethod_createRealtimeWithOptions= @"createRealtimeWithOptions";
 NSString *const AblyPlatformMethod_connectRealtime= @"connectRealtime";
 NSString *const AblyPlatformMethod_closeRealtime= @"closeRealtime";
@@ -132,6 +133,10 @@ NSString *const TxEnumConstants_suspended = @"suspended";
 NSString *const TxEnumConstants_closing = @"closing";
 NSString *const TxEnumConstants_closed = @"closed";
 NSString *const TxEnumConstants_failed = @"failed";
+NSString *const TxEnumConstants_absent = @"absent";
+NSString *const TxEnumConstants_leave = @"leave";
+NSString *const TxEnumConstants_enter = @"enter";
+NSString *const TxEnumConstants_present = @"present";
 NSString *const TxEnumConstants_update = @"update";
 @end
 

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -14,6 +14,8 @@ NSString *const AblyPlatformMethod_authCallback= @"authCallback";
 NSString *const AblyPlatformMethod_realtimeAuthCallback= @"realtimeAuthCallback";
 NSString *const AblyPlatformMethod_createRestWithOptions= @"createRestWithOptions";
 NSString *const AblyPlatformMethod_publish= @"publish";
+NSString *const AblyPlatformMethod_restHistory= @"restHistory";
+NSString *const AblyPlatformMethod_restPresenceGet= @"restPresenceGet";
 NSString *const AblyPlatformMethod_createRealtimeWithOptions= @"createRealtimeWithOptions";
 NSString *const AblyPlatformMethod_connectRealtime= @"connectRealtime";
 NSString *const AblyPlatformMethod_closeRealtime= @"closeRealtime";
@@ -21,11 +23,10 @@ NSString *const AblyPlatformMethod_attachRealtimeChannel= @"attachRealtimeChanne
 NSString *const AblyPlatformMethod_detachRealtimeChannel= @"detachRealtimeChannel";
 NSString *const AblyPlatformMethod_setRealtimeChannelOptions= @"setRealtimeChannelOptions";
 NSString *const AblyPlatformMethod_publishRealtimeChannelMessage= @"publishRealtimeChannelMessage";
+NSString *const AblyPlatformMethod_realtimeHistory= @"realtimeHistory";
 NSString *const AblyPlatformMethod_onRealtimeConnectionStateChanged= @"onRealtimeConnectionStateChanged";
 NSString *const AblyPlatformMethod_onRealtimeChannelStateChanged= @"onRealtimeChannelStateChanged";
 NSString *const AblyPlatformMethod_onRealtimeChannelMessage= @"onRealtimeChannelMessage";
-NSString *const AblyPlatformMethod_restHistory= @"restHistory";
-NSString *const AblyPlatformMethod_realtimeHistory= @"realtimeHistory";
 NSString *const AblyPlatformMethod_nextPage= @"nextPage";
 NSString *const AblyPlatformMethod_firstPage= @"firstPage";
 @end
@@ -161,6 +162,17 @@ NSString *const TxMessage_name = @"name";
 NSString *const TxMessage_extras = @"extras";
 @end
 
+@implementation TxPresenceMessage
+NSString *const TxPresenceMessage_id = @"id";
+NSString *const TxPresenceMessage_action = @"action";
+NSString *const TxPresenceMessage_clientId = @"clientId";
+NSString *const TxPresenceMessage_connectionId = @"connectionId";
+NSString *const TxPresenceMessage_data = @"data";
+NSString *const TxPresenceMessage_encoding = @"encoding";
+NSString *const TxPresenceMessage_extras = @"extras";
+NSString *const TxPresenceMessage_timestamp = @"timestamp";
+@end
+
 @implementation TxPaginatedResult
 NSString *const TxPaginatedResult_items = @"items";
 NSString *const TxPaginatedResult_type = @"type";
@@ -180,4 +192,10 @@ NSString *const TxRealtimeHistoryParams_end = @"end";
 NSString *const TxRealtimeHistoryParams_direction = @"direction";
 NSString *const TxRealtimeHistoryParams_limit = @"limit";
 NSString *const TxRealtimeHistoryParams_untilAttach = @"untilAttach";
+@end
+
+@implementation TxRestPresenceParams
+NSString *const TxRestPresenceParams_limit = @"limit";
+NSString *const TxRestPresenceParams_clientId = @"clientId";
+NSString *const TxRestPresenceParams_connectionId = @"connectionId";
 @end

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -553,7 +553,6 @@ class Codec extends StandardMessageCodec {
   }
 
   /// Decodes [eventName] to [ConnectionEvent] enum if not null
-  // ignore: missing_return
   ConnectionEvent _decodeConnectionEvent(String eventName) {
     switch (eventName) {
       case TxEnumConstants.initialized:
@@ -574,11 +573,12 @@ class Codec extends StandardMessageCodec {
         return ConnectionEvent.failed;
       case TxEnumConstants.update:
         return ConnectionEvent.update;
+      default:
+        return null;
     }
   }
 
   /// Decodes [state] to [ConnectionState] enum if not null
-  // ignore: missing_return
   ConnectionState _decodeConnectionState(String state) {
     if (state == null) return null;
     switch (state) {
@@ -598,11 +598,12 @@ class Codec extends StandardMessageCodec {
         return ConnectionState.closed;
       case TxEnumConstants.failed:
         return ConnectionState.failed;
+      default:
+        return null;
     }
   }
 
   /// Decodes [eventName] to [ChannelEvent] enum if not null
-  // ignore: missing_return
   ChannelEvent _decodeChannelEvent(String eventName) {
     switch (eventName) {
       case TxEnumConstants.initialized:
@@ -621,11 +622,12 @@ class Codec extends StandardMessageCodec {
         return ChannelEvent.failed;
       case TxEnumConstants.update:
         return ChannelEvent.update;
+      default:
+        return null;
     }
   }
 
   /// Decodes [state] to [ChannelState] enum if not null
-  // ignore: missing_return
   ChannelState _decodeChannelState(String state) {
     switch (state) {
       case TxEnumConstants.initialized:
@@ -642,6 +644,8 @@ class Codec extends StandardMessageCodec {
         return ChannelState.suspended;
       case TxEnumConstants.failed:
         return ChannelState.failed;
+      default:
+        return null;
     }
   }
 
@@ -698,8 +702,23 @@ class Codec extends StandardMessageCodec {
     return message;
   }
 
-  PresenceAction _decodePresenceAction(int index) =>
-      (index == null) ? null : PresenceAction.values[index];
+  /// Decodes [action] to [PresenceAction] enum if not null
+  PresenceAction _decodePresenceAction(String action) {
+    switch (action) {
+      case TxEnumConstants.present:
+        return PresenceAction.present;
+      case TxEnumConstants.absent:
+        return PresenceAction.absent;
+      case TxEnumConstants.enter:
+        return PresenceAction.enter;
+      case TxEnumConstants.leave:
+        return PresenceAction.leave;
+      case TxEnumConstants.update:
+        return PresenceAction.update;
+      default:
+        return null;
+    }
+  }
 
   PresenceMessage _decodePresenceMessage(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -71,10 +71,14 @@ class Codec extends StandardMessageCodec {
           _CodecPair<RealtimeHistoryParams>(_encodeRealtimeHistoryParams, null),
       CodecTypes.restHistoryParams:
           _CodecPair<RestHistoryParams>(_encodeRestHistoryParams, null),
+      CodecTypes.restPresenceParams:
+      _CodecPair<RestPresenceParams>(_encodeRestPresenceParams, null),
 
       CodecTypes.errorInfo: _CodecPair<ErrorInfo>(null, _decodeErrorInfo),
       CodecTypes.message:
           _CodecPair<Message>(_encodeChannelMessage, _decodeChannelMessage),
+      CodecTypes.presenceMessage:
+      _CodecPair<PresenceMessage>(null, _decodePresenceMessage),
 
       // Events - Connection
       CodecTypes.connectionStateChange:
@@ -110,6 +114,8 @@ class Codec extends StandardMessageCodec {
       return CodecTypes.realtimeHistoryParams;
     } else if (value is RestHistoryParams) {
       return CodecTypes.restHistoryParams;
+    } else if (value is RestPresenceParams) {
+      return CodecTypes.restPresenceParams;
     } else if (value is ErrorInfo) {
       return CodecTypes.errorInfo;
     } else if (value is AblyMessage) {
@@ -266,6 +272,15 @@ class Codec extends StandardMessageCodec {
       jsonMap, TxRestHistoryParams.end, v.end?.millisecondsSinceEpoch);
     _writeToJson(jsonMap, TxRestHistoryParams.direction, v.direction);
     _writeToJson(jsonMap, TxRestHistoryParams.limit, v.limit);
+    return jsonMap;
+  }
+
+  Map<String, dynamic> _encodeRestPresenceParams(final RestPresenceParams v) {
+    if (v == null) return null;
+    final jsonMap = <String, dynamic>{};
+    _writeToJson(jsonMap, TxRestPresenceParams.limit, v.limit);
+    _writeToJson(jsonMap, TxRestPresenceParams.clientId, v.clientId);
+    _writeToJson(jsonMap, TxRestPresenceParams.connectionId, v.connectionId);
     return jsonMap;
   }
 
@@ -677,6 +692,32 @@ class Codec extends StandardMessageCodec {
       ..encoding = _readFromJson<String>(jsonMap, TxMessage.encoding)
       ..extras = _readFromJson<Map>(jsonMap, TxMessage.extras);
     final timestamp = _readFromJson<int>(jsonMap, TxMessage.timestamp);
+    if (timestamp != null) {
+      message.timestamp = DateTime.fromMillisecondsSinceEpoch(timestamp);
+    }
+    return message;
+  }
+
+  PresenceAction _decodePresenceAction(int index) =>
+      (index == null) ? null : PresenceAction.values[index];
+
+  PresenceMessage _decodePresenceMessage(Map<String, dynamic> jsonMap) {
+    if (jsonMap == null) return null;
+    final message = PresenceMessage()
+      ..id = _readFromJson<String>(jsonMap, TxPresenceMessage.id)
+      ..action =
+          _decodePresenceAction(_readFromJson(
+            jsonMap,
+            TxPresenceMessage.action,
+          ))
+      ..clientId = _readFromJson<String>(jsonMap, TxPresenceMessage.clientId)
+      ..data = _readFromJson<dynamic>(jsonMap, TxPresenceMessage.data)
+      ..connectionId =
+          _readFromJson<String>(jsonMap, TxPresenceMessage.connectionId)
+      ..encoding = _readFromJson<String>(jsonMap, TxPresenceMessage.encoding)
+      ..extras =
+          toJsonMap(_readFromJson<Map>(jsonMap, TxPresenceMessage.extras));
+    final timestamp = _readFromJson<int>(jsonMap, TxPresenceMessage.timestamp);
     if (timestamp != null) {
       message.timestamp = DateTime.fromMillisecondsSinceEpoch(timestamp);
     }

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -72,13 +72,13 @@ class Codec extends StandardMessageCodec {
       CodecTypes.restHistoryParams:
           _CodecPair<RestHistoryParams>(_encodeRestHistoryParams, null),
       CodecTypes.restPresenceParams:
-      _CodecPair<RestPresenceParams>(_encodeRestPresenceParams, null),
+          _CodecPair<RestPresenceParams>(_encodeRestPresenceParams, null),
 
       CodecTypes.errorInfo: _CodecPair<ErrorInfo>(null, _decodeErrorInfo),
       CodecTypes.message:
           _CodecPair<Message>(_encodeChannelMessage, _decodeChannelMessage),
       CodecTypes.presenceMessage:
-      _CodecPair<PresenceMessage>(null, _decodePresenceMessage),
+          _CodecPair<PresenceMessage>(null, _decodePresenceMessage),
 
       // Events - Connection
       CodecTypes.connectionStateChange:
@@ -703,25 +703,23 @@ class Codec extends StandardMessageCodec {
 
   PresenceMessage _decodePresenceMessage(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    final message = PresenceMessage()
-      ..id = _readFromJson<String>(jsonMap, TxPresenceMessage.id)
-      ..action =
-          _decodePresenceAction(_readFromJson(
-            jsonMap,
-            TxPresenceMessage.action,
-          ))
-      ..clientId = _readFromJson<String>(jsonMap, TxPresenceMessage.clientId)
-      ..data = _readFromJson<dynamic>(jsonMap, TxPresenceMessage.data)
-      ..connectionId =
-          _readFromJson<String>(jsonMap, TxPresenceMessage.connectionId)
-      ..encoding = _readFromJson<String>(jsonMap, TxPresenceMessage.encoding)
-      ..extras =
-          toJsonMap(_readFromJson<Map>(jsonMap, TxPresenceMessage.extras));
     final timestamp = _readFromJson<int>(jsonMap, TxPresenceMessage.timestamp);
-    if (timestamp != null) {
-      message.timestamp = DateTime.fromMillisecondsSinceEpoch(timestamp);
-    }
-    return message;
+    return PresenceMessage(
+      id: _readFromJson<String>(jsonMap, TxPresenceMessage.id),
+      action: _decodePresenceAction(_readFromJson(
+        jsonMap,
+        TxPresenceMessage.action,
+      )),
+      clientId: _readFromJson<String>(jsonMap, TxPresenceMessage.clientId),
+      data: _readFromJson<dynamic>(jsonMap, TxPresenceMessage.data),
+      connectionId:
+      _readFromJson<String>(jsonMap, TxPresenceMessage.connectionId),
+      encoding: _readFromJson<String>(jsonMap, TxPresenceMessage.encoding),
+      extras: toJsonMap(_readFromJson<Map>(jsonMap, TxPresenceMessage.extras)),
+      timestamp: (timestamp == null)
+        ? null
+        : DateTime.fromMillisecondsSinceEpoch(timestamp),
+    );
   }
 
   PaginatedResult<Object> _decodePaginatedResult(Map<String, dynamic> jsonMap) {

--- a/lib/src/generated/platformconstants.dart
+++ b/lib/src/generated/platformconstants.dart
@@ -16,6 +16,8 @@ class CodecTypes {
   static const int paginatedResult = 135;
   static const int restHistoryParams = 136;
   static const int realtimeHistoryParams = 137;
+  static const int restPresenceParams = 138;
+  static const int presenceMessage = 139;
   static const int errorInfo = 144;
   static const int connectionStateChange = 201;
   static const int channelStateChange = 202;
@@ -29,6 +31,8 @@ class PlatformMethod {
   static const String realtimeAuthCallback = 'realtimeAuthCallback';
   static const String createRestWithOptions = 'createRestWithOptions';
   static const String publish = 'publish';
+  static const String restHistory = 'restHistory';
+  static const String restPresenceGet = 'restPresenceGet';
   static const String createRealtimeWithOptions = 'createRealtimeWithOptions';
   static const String connectRealtime = 'connectRealtime';
   static const String closeRealtime = 'closeRealtime';
@@ -37,13 +41,12 @@ class PlatformMethod {
   static const String setRealtimeChannelOptions = 'setRealtimeChannelOptions';
   static const String publishRealtimeChannelMessage =
       'publishRealtimeChannelMessage';
+  static const String realtimeHistory = 'realtimeHistory';
   static const String onRealtimeConnectionStateChanged =
       'onRealtimeConnectionStateChanged';
   static const String onRealtimeChannelStateChanged =
       'onRealtimeChannelStateChanged';
   static const String onRealtimeChannelMessage = 'onRealtimeChannelMessage';
-  static const String restHistory = 'restHistory';
-  static const String realtimeHistory = 'realtimeHistory';
   static const String nextPage = 'nextPage';
   static const String firstPage = 'firstPage';
 }
@@ -179,6 +182,17 @@ class TxMessage {
   static const String extras = 'extras';
 }
 
+class TxPresenceMessage {
+  static const String id = 'id';
+  static const String action = 'action';
+  static const String clientId = 'clientId';
+  static const String connectionId = 'connectionId';
+  static const String data = 'data';
+  static const String encoding = 'encoding';
+  static const String extras = 'extras';
+  static const String timestamp = 'timestamp';
+}
+
 class TxPaginatedResult {
   static const String items = 'items';
   static const String type = 'type';
@@ -198,4 +212,10 @@ class TxRealtimeHistoryParams {
   static const String direction = 'direction';
   static const String limit = 'limit';
   static const String untilAttach = 'untilAttach';
+}
+
+class TxRestPresenceParams {
+  static const String limit = 'limit';
+  static const String clientId = 'clientId';
+  static const String connectionId = 'connectionId';
 }

--- a/lib/src/generated/platformconstants.dart
+++ b/lib/src/generated/platformconstants.dart
@@ -152,6 +152,10 @@ class TxEnumConstants {
   static const String closing = 'closing';
   static const String closed = 'closed';
   static const String failed = 'failed';
+  static const String absent = 'absent';
+  static const String leave = 'leave';
+  static const String enter = 'enter';
+  static const String present = 'present';
   static const String update = 'update';
 }
 

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -136,13 +136,12 @@ class RealtimeChannel extends PlatformObject
           }
         } else {
           _publishQueue
-            .where((e) => !e.completer.isCompleted)
-            .forEach((e) =>
-            e.completer.completeError(AblyException(
-              pe.code,
-              pe.message,
-              pe.details as ErrorInfo,
-            )));
+              .where((e) => !e.completer.isCompleted)
+              .forEach((e) => e.completer.completeError(AblyException(
+                    pe.code,
+                    pe.message,
+                    pe.details as ErrorInfo,
+                  )));
         }
       }
     }
@@ -210,10 +209,10 @@ class RealtimeChannel extends PlatformObject
   Stream<Message> subscribe({String name, List<String> names}) {
     final subscribedNames = {name, ...?names}.where((n) => n != null).toList();
     return listen(PlatformMethod.onRealtimeChannelMessage, _payload)
-      .map((message) => message as Message)
-      .where((message) =>
-    subscribedNames.isEmpty ||
-      subscribedNames.any((n) => n == message.name));
+        .map((message) => message as Message)
+        .where((message) =>
+            subscribedNames.isEmpty ||
+            subscribedNames.any((n) => n == message.name));
   }
 }
 
@@ -226,7 +225,7 @@ class RealtimePlatformChannels extends RealtimeChannels<RealtimeChannel> {
 
   @override
   RealtimeChannel createChannel(String name, ChannelOptions options) =>
-    RealtimeChannel(realtime, name, options);
+      RealtimeChannel(realtime, name, options);
 }
 
 /// An item for used to enqueue a message to be published after an ongoing

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -23,7 +23,7 @@ class RealtimeChannel extends PlatformObject
   ChannelOptions options;
 
   @override
-  RealtimePresence presence;
+  spec.RealtimePresenceBase presence;
 
   /// instantiates with [Rest], [name] and [ChannelOptions]
   ///

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -23,7 +23,7 @@ class RealtimeChannel extends PlatformObject
   ChannelOptions options;
 
   @override
-  spec.RealtimePresenceBase presence;
+  RealtimePresence presence;
 
   /// instantiates with [Rest], [name] and [ChannelOptions]
   ///

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -21,7 +21,7 @@ class RestChannel extends PlatformObject implements RestChannelInterface {
   @override
   ChannelOptions options;
 
-  spec.RestPresenceInterface _presence;
+  RestPresence _presence;
 
   /// instantiates with [Rest], [name] and [ChannelOptions]
   RestChannel(this.rest, this.name, this.options) {

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -7,6 +7,7 @@ import 'package:pedantic/pedantic.dart';
 import '../../../ably_flutter.dart';
 import '../message.dart';
 import '../platform_object.dart';
+import 'presence.dart';
 import 'rest.dart';
 
 /// Plugin based implementation of Rest channel
@@ -20,11 +21,15 @@ class RestChannel extends PlatformObject implements RestChannelInterface {
   @override
   ChannelOptions options;
 
-  @override
-  spec.RestPresenceInterface presence;
+  spec.RestPresenceInterface _presence;
 
   /// instantiates with [Rest], [name] and [ChannelOptions]
-  RestChannel(this.rest, this.name, this.options);
+  RestChannel(this.rest, this.name, this.options) {
+    _presence = RestPresence(this);
+  }
+
+  @override
+  RestPresence get presence => _presence;
 
   /// createPlatformInstance will return restPlatformObject's handle
   /// as that is what will be required in platforms end to find rest instance

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -21,7 +21,7 @@ class RestChannel extends PlatformObject implements RestChannelInterface {
   ChannelOptions options;
 
   @override
-  RestPresenceInterface presence;
+  spec.RestPresenceInterface presence;
 
   /// instantiates with [Rest], [name] and [ChannelOptions]
   RestChannel(this.rest, this.name, this.options);

--- a/lib/src/impl/rest/presence.dart
+++ b/lib/src/impl/rest/presence.dart
@@ -4,15 +4,17 @@ import '../message.dart';
 import '../paginated_result.dart';
 import '../platform_object.dart';
 import 'channels.dart';
+import 'rest.dart';
 
-class RestPresence extends PlatformObject implements RestPresenceBase {
-  final RestPlatformChannel _restChannel;
+/// Plugin based implementation of [RestPresenceInterface]
+class RestPresence extends PlatformObject implements RestPresenceInterface {
+  final RestChannel _restChannel;
 
+  /// instantiates with a channel
   RestPresence(this._restChannel);
 
   @override
-  Future<int> createPlatformInstance() =>
-      _restChannel.restPlatformObject.handle;
+  Future<int> createPlatformInstance() => (_restChannel.rest as Rest).handle;
 
   @override
   Future<PaginatedResult<PresenceMessage>> get([

--- a/lib/src/impl/rest/presence.dart
+++ b/lib/src/impl/rest/presence.dart
@@ -1,0 +1,37 @@
+import '../../generated/platformconstants.dart';
+import '../../spec/spec.dart';
+import '../message.dart';
+import '../paginated_result.dart';
+import '../platform_object.dart';
+import 'channels.dart';
+
+class RestPresence extends PlatformObject implements RestPresenceBase {
+  final RestPlatformChannel _restChannel;
+
+  RestPresence(this._restChannel);
+
+  @override
+  Future<int> createPlatformInstance() =>
+      _restChannel.restPlatformObject.handle;
+
+  @override
+  Future<PaginatedResult<PresenceMessage>> get([
+    RestPresenceParams params,
+  ]) async {
+    final message = await invoke<AblyMessage>(
+      PlatformMethod.restPresenceGet,
+      {
+        TxTransportKeys.channelName: _restChannel.name,
+        if (params != null) TxTransportKeys.params: params
+      },
+    );
+    return PaginatedResult<PresenceMessage>.fromAblyMessage(message);
+  }
+
+  @override
+  Future<PaginatedResult<PresenceMessage>> history([
+    RestHistoryParams params,
+  ]) {
+    throw UnimplementedError();
+  }
+}

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -46,4 +46,21 @@ class AblyMethodCallHandler {
     _realtimeAuthInProgress = false;
     return callbackResponse;
   }
+
+  bool realtimeAuthInProgress = false;
+  onRealtimeAuthCallback(AblyMessage message) async {
+    if(realtimeAuthInProgress){
+      return null;
+    }
+    realtimeAuthInProgress = true;
+    ably.TokenParams tokenParams = message.message as ably.TokenParams;
+    ably.Realtime realtime = ably.realtimeInstances[message.handle];
+    Object callbackResponse = await realtime.options.authCallback(tokenParams);
+    Future.delayed(Duration.zero, (){
+      realtime.authUpdateComplete();
+    });
+    realtimeAuthInProgress = false;
+    return callbackResponse;
+  }
+
 }

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -46,21 +46,4 @@ class AblyMethodCallHandler {
     _realtimeAuthInProgress = false;
     return callbackResponse;
   }
-
-  bool realtimeAuthInProgress = false;
-  onRealtimeAuthCallback(AblyMessage message) async {
-    if(realtimeAuthInProgress){
-      return null;
-    }
-    realtimeAuthInProgress = true;
-    ably.TokenParams tokenParams = message.message as ably.TokenParams;
-    ably.Realtime realtime = ably.realtimeInstances[message.handle];
-    Object callbackResponse = await realtime.options.authCallback(tokenParams);
-    Future.delayed(Duration.zero, (){
-      realtime.authUpdateComplete();
-    });
-    realtimeAuthInProgress = false;
-    return callbackResponse;
-  }
-
 }

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -902,15 +902,7 @@ class Stats {
 
 /// A collection of Channel objects accessible
 /// through [Rest.channels] or [Realtime.channels]
-///
-/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
 abstract class Channels<ChannelType> {
-  /// instantiates with the ably [Rest] or [Realtime] instance
-  Channels(this.ably);
-
-  /// a [Rest] or [Realtime] instance
-  AblyBase ably;
-
   /// stores channel name vs instance of [ChannelType]
   final _channels = <String, ChannelType>{};
 

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -902,7 +902,15 @@ class Stats {
 
 /// A collection of Channel objects accessible
 /// through [Rest.channels] or [Realtime.channels]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
 abstract class Channels<ChannelType> {
+  /// instantiates with the ably [Rest] or [Realtime] instance
+  Channels(this.ably);
+
+  /// a [Rest] or [Realtime] instance
+  AblyBase ably;
+
   /// stores channel name vs instance of [ChannelType]
   final _channels = <String, ChannelType>{};
 

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -73,10 +73,10 @@ class ErrorInfo {
 
   @override
   String toString() => 'ErrorInfo'
-      ' message=$message'
-      ' code=$code'
-      ' statusCode=$statusCode'
-      ' href=$href';
+    ' message=$message'
+    ' code=$code'
+    ' statusCode=$statusCode'
+    ' href=$href';
 }
 
 /// MessageCount contains aggregate counts for messages and data transferred
@@ -407,10 +407,10 @@ class RestHistoryParams {
 
   @override
   String toString() => 'RestHistoryParams:'
-      ' start=$start'
-      ' end=$end'
-      ' direction=$direction'
-      ' limit=$limit';
+    ' start=$start'
+    ' end=$end'
+    ' direction=$direction'
+    ' limit=$limit';
 }
 
 /// https://docs.ably.io/client-lib-development-guide/features/#RTL10

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -59,38 +59,48 @@ class PresenceMessage {
   /// unique ID for this presence message
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3a
-  String id;
+  final String id;
 
   /// presence action - to update presence status of current client,
   /// or to understand presence state of another client
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3b
-  PresenceAction action;
+  final PresenceAction action;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3c
-  String clientId;
+  final String clientId;
 
   /// connection id of the source of this message
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3d
-  String connectionId;
+  final String connectionId;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3e
-  dynamic data;
+  final Object data;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3f
-  String encoding;
+  final String encoding;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3i
-  Map<String, dynamic> extras;
+  final Map<String, dynamic> extras;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3g
-  DateTime timestamp;
+  final DateTime timestamp;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
   String get memberKey => '$connectionId:$clientId';
 
-  PresenceMessage();
+  /// instantiates presence message with
+  PresenceMessage({
+    this.id,
+    this.action,
+    this.clientId,
+    this.connectionId,
+    this.data,
+    this.encoding,
+    this.extras,
+    this.timestamp,
+  });
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
   ///
@@ -98,21 +108,20 @@ class PresenceMessage {
   ///  RSL6 and RLS6b as mentioned in TP4
   PresenceMessage.fromEncoded(
     Map<String, dynamic> jsonObject, [
-      ChannelOptions channelOptions,
-    ]) {
-    id = jsonObject['id'] as String;
-    action = PresenceAction.values
-      .firstWhere((e) => e.toString() == jsonObject['action'] as String);
-    clientId = jsonObject['clientId'] as String;
-    connectionId = jsonObject['connectionId'] as String;
-    data = jsonObject['data'];
-    encoding = jsonObject['encoding'] as String;
-    extras = Map.castFrom<dynamic, dynamic, String, dynamic>(
-      jsonObject['extras'] as Map);
-    timestamp = jsonObject['timestamp'] != null
-      ? DateTime.fromMillisecondsSinceEpoch(jsonObject['timestamp'] as int)
-      : null;
-  }
+    ChannelOptions channelOptions,
+  ])  : id = jsonObject['id'] as String,
+        action = PresenceAction.values
+            .firstWhere((e) => e.toString() == jsonObject['action'] as String),
+        clientId = jsonObject['clientId'] as String,
+        connectionId = jsonObject['connectionId'] as String,
+        data = jsonObject['data'],
+        encoding = jsonObject['encoding'] as String,
+        extras = Map.castFrom<dynamic, dynamic, String, dynamic>(
+            jsonObject['extras'] as Map),
+        timestamp = jsonObject['timestamp'] != null
+            ? DateTime.fromMillisecondsSinceEpoch(
+                jsonObject['timestamp'] as int)
+            : null;
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
   static List<PresenceMessage> fromEncodedArray(

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -93,6 +93,8 @@ class PresenceMessage {
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
   String get memberKey => '$connectionId$clientId';
 
+  PresenceMessage();
+
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
   ///
   /// TODO(tiholic): decoding and decryption is not implemented as per

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -55,7 +55,7 @@ class Message {
 /// An individual presence message sent or received via realtime
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#TP1
-abstract class PresenceMessage {
+class PresenceMessage {
   /// unique ID for this presence message
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3a
@@ -90,13 +90,35 @@ abstract class PresenceMessage {
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
   String get memberKey => '$connectionId:$clientId';
 
-  /// instantiates a presence message with no defaults
-  PresenceMessage();
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
+  String get memberKey => '$connectionId$clientId';
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
-  PresenceMessage.fromEncoded(Map jsonObject, ChannelOptions channelOptions);
+  ///
+  /// TODO(tiholic): decoding and decryption is not implemented as per
+  ///  RSL6 and RLS6b as mentioned in TP4
+  PresenceMessage.fromEncoded(
+    Map<String, dynamic> jsonObject, [
+      ChannelOptions channelOptions,
+    ]) {
+    id = jsonObject['id'] as String;
+    action = PresenceAction.values
+      .firstWhere((e) => e.toString() == jsonObject['action'] as String);
+    clientId = jsonObject['clientId'] as String;
+    connectionId = jsonObject['connectionId'] as String;
+    data = jsonObject['data'];
+    encoding = jsonObject['encoding'] as String;
+    extras = Map.castFrom<dynamic, dynamic, String, dynamic>(
+      jsonObject['extras'] as Map);
+    timestamp = jsonObject['timestamp'] != null
+      ? DateTime.fromMillisecondsSinceEpoch(jsonObject['timestamp'] as int)
+      : null;
+  }
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
-  PresenceMessage.fromEncodedArray(
-      List jsonArray, ChannelOptions channelOptions);
+  static List<PresenceMessage> fromEncodedArray(
+    List<Map<String, dynamic>> jsonArray, [
+      ChannelOptions channelOptions,
+    ]) =>
+    jsonArray.map((e) => PresenceMessage.fromEncoded(e)).toList();
 }

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -1,3 +1,5 @@
+import 'package:meta/meta.dart';
+
 import 'enums.dart';
 import 'rest/channels.dart';
 
@@ -46,8 +48,8 @@ class Message {
 
   @override
   String toString() => 'Message id=$id timestamp=$timestamp clientId=$clientId'
-      ' connectionId=$connectionId encoding=$encoding name=$name'
-      ' data=$data extras=$extras';
+    ' connectionId=$connectionId encoding=$encoding name=$name'
+    ' data=$data extras=$extras';
 
 // TODO(tiholic) add support for fromEncoded and fromEncodedArray (TM3)
 }
@@ -55,6 +57,7 @@ class Message {
 /// An individual presence message sent or received via realtime
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#TP1
+@immutable
 class PresenceMessage {
   /// unique ID for this presence message
   ///
@@ -91,7 +94,7 @@ class PresenceMessage {
   String get memberKey => '$connectionId:$clientId';
 
   /// instantiates presence message with
-  PresenceMessage({
+  const PresenceMessage({
     this.id,
     this.action,
     this.clientId,
@@ -102,6 +105,21 @@ class PresenceMessage {
     this.timestamp,
   });
 
+  @override
+  bool operator ==(Object other) =>
+      other is PresenceMessage &&
+      other.id == id &&
+      other.action == action &&
+      other.clientId == clientId &&
+      other.connectionId == connectionId &&
+      other.data == data &&
+      other.encoding == encoding &&
+      other.extras == extras &&
+      other.timestamp == timestamp;
+
+  @override
+  int get hashCode => '$id:$clientId:$connectionId:$timestamp'.hashCode;
+
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4
   ///
   /// TODO(tiholic): decoding and decryption is not implemented as per
@@ -110,8 +128,8 @@ class PresenceMessage {
     Map<String, dynamic> jsonObject, [
     ChannelOptions channelOptions,
   ])  : id = jsonObject['id'] as String,
-        action = PresenceAction.values
-            .firstWhere((e) => e.toString() == jsonObject['action'] as String),
+        action = PresenceAction.values.firstWhere((e) =>
+            e.toString().split('.')[1] == jsonObject['action'] as String),
         clientId = jsonObject['clientId'] as String,
         connectionId = jsonObject['connectionId'] as String,
         data = jsonObject['data'],

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -90,9 +90,6 @@ class PresenceMessage {
   /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
   String get memberKey => '$connectionId:$clientId';
 
-  /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
-  String get memberKey => '$connectionId$clientId';
-
   PresenceMessage();
 
   /// https://docs.ably.io/client-lib-development-guide/features/#TP4

--- a/lib/src/spec/rest/channels.dart
+++ b/lib/src/spec/rest/channels.dart
@@ -38,7 +38,7 @@ abstract class RestChannelInterface {
   ///
   /// can only query presence on the channel and presence history
   /// https://docs.ably.io/client-lib-development-guide/features/#RSL3
-  RestPresenceInterface presence;
+  RestPresenceInterface get presence;
 
   /// fetch message history on this channel
   ///

--- a/test/models/presence_message_test.dart
+++ b/test/models/presence_message_test.dart
@@ -1,0 +1,171 @@
+import 'package:ably_flutter_plugin/ably_flutter_plugin.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PresenceMessage', () {
+    const messageId = 'message-id';
+    const action = PresenceAction.present;
+    const clientId = 'client-id';
+    const connectionId = 'connection-id';
+    const data = {
+      'a': 'b',
+      'c': [1, 2, 3]
+    };
+    const encoding = 'msgpack';
+    const extras = {
+      'a': 'b',
+      'c': [1, 2, 3]
+    };
+    final timestamp = DateTime.now();
+    group('Behaves like a model', () {
+      final presenceMessage = PresenceMessage(
+        id: messageId,
+        action: action,
+        clientId: clientId,
+        connectionId: connectionId,
+        data: data,
+        encoding: encoding,
+        extras: extras,
+        timestamp: timestamp,
+      );
+      test('Retrieves id', () {
+        expect(presenceMessage.id, messageId);
+      });
+      test('Retrieves action', () {
+        expect(presenceMessage.action, action);
+      });
+      test('Retrieves clientId', () {
+        expect(presenceMessage.clientId, clientId);
+      });
+      test('Retrieves connectionId', () {
+        expect(presenceMessage.connectionId, connectionId);
+      });
+      test('Retrieves data', () {
+        expect(presenceMessage.data, data);
+      });
+      test('Retrieves encoding', () {
+        expect(presenceMessage.encoding, encoding);
+      });
+      test('Retrieves extras', () {
+        expect(presenceMessage.extras, extras);
+      });
+      test('Retrieves timestamp', () {
+        expect(presenceMessage.timestamp, timestamp);
+      });
+
+      test('#== is true and hashes match when attributes are same', () {
+        final presenceMessage2 = PresenceMessage(
+          id: messageId,
+          action: action,
+          clientId: clientId,
+          connectionId: connectionId,
+          data: data,
+          encoding: encoding,
+          extras: extras,
+          timestamp: timestamp,
+        );
+        expect(presenceMessage == presenceMessage2, true);
+        expect(presenceMessage.hashCode == presenceMessage2.hashCode, true);
+      });
+
+      test("#== is false and hashes don't match when attributes are not same",
+          () {
+        final presenceMessage2 = PresenceMessage(
+          id: '123',
+          action: action,
+          clientId: clientId,
+          connectionId: connectionId,
+          data: data,
+          encoding: encoding,
+          extras: extras,
+          timestamp: timestamp,
+        );
+        expect(presenceMessage == presenceMessage2, false);
+        expect(presenceMessage.hashCode == presenceMessage2.hashCode, false);
+      });
+
+      test("#== is false and hashes don't match for different classes", () {
+        final object = Object();
+        expect(presenceMessage == object, false);
+        expect(presenceMessage.hashCode == object.hashCode, false);
+      });
+    });
+
+    group('memberKey attribute', () {
+      test('is connectionId:clientId', () {
+        const presenceMessage =
+            PresenceMessage(clientId: clientId, connectionId: connectionId);
+        expect(presenceMessage.memberKey, '$connectionId:$clientId');
+      });
+      test('is unique with the same client id across multiple connections', () {
+        const presenceMessage =
+            PresenceMessage(clientId: clientId, connectionId: connectionId);
+        const presenceMessage2 =
+            PresenceMessage(clientId: clientId, connectionId: 'different');
+        expect(presenceMessage.memberKey == presenceMessage2.memberKey, false);
+      });
+      test('is unique with a single connection and different client_ids', () {
+        const presenceMessage =
+            PresenceMessage(clientId: clientId, connectionId: connectionId);
+        const presenceMessage2 =
+            PresenceMessage(clientId: 'different', connectionId: connectionId);
+        expect(presenceMessage.memberKey == presenceMessage2.memberKey, false);
+      });
+    });
+
+    group('fromEncoded', () {
+      test('returns a presence message object', () {
+        final presenceMessage = PresenceMessage.fromEncoded({
+          'id': messageId,
+          'action': 'present',
+          'clientId': clientId,
+          'connectionId': connectionId,
+          'data': data,
+          'encoding': encoding,
+          'extras': extras,
+          'timestamp': timestamp.millisecondsSinceEpoch
+        });
+        expect(presenceMessage.id, messageId);
+        expect(presenceMessage.action, action);
+        expect(presenceMessage.clientId, clientId);
+        expect(presenceMessage.connectionId, connectionId);
+        expect(presenceMessage.data, data);
+        expect(presenceMessage.encoding, encoding);
+        expect(presenceMessage.extras, extras);
+        expect(
+          presenceMessage.timestamp,
+          DateTime.fromMillisecondsSinceEpoch(timestamp.millisecondsSinceEpoch),
+        );
+      });
+    });
+
+    group('fromEncodedArray', () {
+      test('returns a list of presence message objects', () {
+        final presenceMessages = PresenceMessage.fromEncodedArray([
+          {
+            'id': messageId,
+            'action': 'present',
+            'clientId': clientId,
+            'connectionId': connectionId,
+            'data': data,
+            'encoding': encoding,
+            'extras': extras,
+            'timestamp': timestamp.millisecondsSinceEpoch,
+          }
+        ]);
+        final presenceMessage = presenceMessages[0];
+        expect(presenceMessage.id, messageId);
+        expect(presenceMessage.action, action);
+        expect(presenceMessage.clientId, clientId);
+        expect(presenceMessage.connectionId, connectionId);
+        expect(presenceMessage.data, data);
+        expect(presenceMessage.encoding, encoding);
+        expect(presenceMessage.extras, extras);
+        expect(
+          presenceMessage.timestamp,
+          DateTime.fromMillisecondsSinceEpoch(timestamp.millisecondsSinceEpoch),
+        );
+      });
+    });
+  });
+}

--- a/test_integration/pubspec.yaml
+++ b/test_integration/pubspec.yaml
@@ -1,20 +1,6 @@
 name: ably_flutter_integration_test
 description: A new Flutter project.
-
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
-
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
+publish_to: 'none'
 version: 1.0.0+1
 
 environment:
@@ -26,55 +12,13 @@ dependencies:
   flutter:
     sdk: flutter
 
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  #cupertino_icons: ^0.1.3
-
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
   flutter_driver:
     sdk: flutter
+  flutter_test:
+    sdk: flutter
+  http: ^0.12.2
   test: ^1.9.4
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
   uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
getting presence members via `rest#channels#channel#presence#get` list as a `PaginatedResult`

Supported platforms:
- [x] Android
- [x] iOS

Example:
```dart
void getPresence([ably.RestPresenceParams params]) async {
    // getting channel history, by passing or omitting the optional params
    var result = await channel.presence.get(params);

    var presenceMembers = result.items; //returns PresenceMessages
    var hasNextPage = result.hasNext(); //tells whether there are more results
    if(hasNextPage){    
      result = await result.next();  //fetches next page results
      presenceMembers = result.items;
    }
    if(!hasNextPage){
      result = await result.first();  //fetches first page results
      presenceMembers = result.items;
    }
}

// getting presence members with default params
getPresence();

// filtered presence members
getPresence(ably.RestPresenceParams(
  limit: 10,
  clientId: '<clientId>',
  connectionId: '<connectionID>',
));
```


Other changes:
1. re-arrange pagination method call handlers
2. improve log messages on iOS side
3. flutter format on few files