### PR TITLE
Feature/docstrings

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           channel: "stable"
       - name: "Run Flutter Driver tests"
-        timeout-minutes: 90
+        timeout-minutes: 30
         run: |
           flutter pub get
           cd test_integration && ./run_integration_tests.sh
@@ -52,7 +52,7 @@ jobs:
         with:
           channel: "stable"
       - name: "Run Flutter Driver tests"
-        timeout-minutes: 90
+        timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         # env:
         #   ANDROID_SIGN_PWD: ${{ secrets.ANDROID_SIGN_PWD }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .packages
 .pub/
 build/
+doc/
 
 # Flutter Version Manager
 .fvm

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -171,7 +171,7 @@ linter:
     - prefer_spread_collections
     - prefer_typing_uninitialized_variables
     - provide_deprecation_message
-    # - public_member_api_docs      # personal preference
+    - public_member_api_docs
     - recursive_getters
     - sized_box_for_whitespace
     - slash_for_doc_comments

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -7,7 +7,6 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -7,6 +7,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/bin/templates/platformconstants.dart.dart
+++ b/bin/templates/platformconstants.dart.dart
@@ -2,6 +2,8 @@ String getPrefix(Object str) =>
     ((str as String).length > 26) ? '\n      ' : ' ';
 
 String $(Map<String, dynamic> c) => '''
+// ignore_for_file: public_member_api_docs
+
 class CodecTypes {
 ${c['types'].map((_) => "  static const int ${_['name']} ="
         " ${_['value']};").join('\n')}

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false
+    public_member_api_docs: false

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -573,32 +573,6 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
-  Widget getRealtimeChannelHistory() => FlatButton(
-        onPressed: () async {
-          final next = _realtimeHistory?.hasNext() ?? false;
-          print('Rest history: getting ${next ? 'next' : 'first'} page');
-          try {
-            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
-              final result =
-                  await _realtime.channels.get('test-channel').history(
-                        ably.RealtimeHistoryParams(
-                            direction: 'forwards', limit: 10),
-                      );
-              _realtimeHistory = result;
-            } else if (next) {
-              _realtimeHistory = await _realtimeHistory.next();
-            } else {
-              _realtimeHistory = await _realtimeHistory.first();
-            }
-            setState(() {});
-          } on ably.AblyException catch (e) {
-            print('failed to get history:: $e :: ${e.errorInfo}');
-          }
-        },
-        color: Colors.yellow,
-        child: const Text('Get history'),
-      );
-
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -548,27 +548,30 @@ class _MyAppState extends State<MyApp> {
       );
 
   Widget getRealtimeChannelHistory() => FlatButton(
-        onPressed: () async {
-          final next = _realtimeHistory?.hasNext() ?? false;
-          print('Rest history: getting ${next ? 'next' : 'first'} page');
-          try {
-            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
-              final result =
-                  await _realtime.channels.get('test-channel').history(
-                        ably.RealtimeHistoryParams(
-                            direction: 'forwards', limit: 10),
-                      );
-              _realtimeHistory = result;
-            } else if (next) {
-              _realtimeHistory = await _realtimeHistory.next();
-            } else {
-              _realtimeHistory = await _realtimeHistory.first();
-            }
-            setState(() {});
-          } on ably.AblyException catch (e) {
-            print('failed to get history:: $e :: ${e.errorInfo}');
-          }
-        },
+        onPressed: (_realtime == null)
+            ? null
+            : () async {
+                final next = _realtimeHistory?.hasNext() ?? false;
+                print('Rest history: getting ${next ? 'next' : 'first'} page');
+                try {
+                  if (_realtimeHistory == null ||
+                      _realtimeHistory.items.isEmpty) {
+                    final result =
+                        await _realtime.channels.get('test-channel').history(
+                              ably.RealtimeHistoryParams(
+                                  direction: 'forwards', limit: 10),
+                            );
+                    _realtimeHistory = result;
+                  } else if (next) {
+                    _realtimeHistory = await _realtimeHistory.next();
+                  } else {
+                    _realtimeHistory = await _realtimeHistory.first();
+                  }
+                  setState(() {});
+                } on ably.AblyException catch (e) {
+                  print('failed to get history:: $e :: ${e.errorInfo}');
+                }
+              },
         color: Colors.yellow,
         child: const Text('Get history'),
       );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -544,35 +544,6 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
-  Widget getRealtimeChannelHistory() => FlatButton(
-        onPressed: (_realtime == null)
-            ? null
-            : () async {
-                final next = _realtimeHistory?.hasNext() ?? false;
-                print('Rest history: getting ${next ? 'next' : 'first'} page');
-                try {
-                  if (_realtimeHistory == null ||
-                      _realtimeHistory.items.isEmpty) {
-                    final result =
-                        await _realtime.channels.get('test-channel').history(
-                              ably.RealtimeHistoryParams(
-                                  direction: 'forwards', limit: 10),
-                            );
-                    _realtimeHistory = result;
-                  } else if (next) {
-                    _realtimeHistory = await _realtimeHistory.next();
-                  } else {
-                    _realtimeHistory = await _realtimeHistory.first();
-                  }
-                  setState(() {});
-                } on ably.AblyException catch (e) {
-                  print('failed to get history:: $e :: ${e.errorInfo}');
-                }
-              },
-        color: Colors.yellow,
-        child: const Text('Get history'),
-      );
-
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -547,6 +547,32 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
+  Widget getRealtimeChannelHistory() => FlatButton(
+        onPressed: () async {
+          final next = _realtimeHistory?.hasNext() ?? false;
+          print('Rest history: getting ${next ? 'next' : 'first'} page');
+          try {
+            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
+              final result =
+                  await _realtime.channels.get('test-channel').history(
+                        ably.RealtimeHistoryParams(
+                            direction: 'forwards', limit: 10),
+                      );
+              _realtimeHistory = result;
+            } else if (next) {
+              _realtimeHistory = await _realtimeHistory.next();
+            } else {
+              _realtimeHistory = await _realtimeHistory.first();
+            }
+            setState(() {});
+          } on ably.AblyException catch (e) {
+            print('failed to get history:: $e :: ${e.errorInfo}');
+          }
+        },
+        color: Colors.yellow,
+        child: const Text('Get history'),
+      );
+
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -236,7 +236,7 @@ class _MyAppState extends State<MyApp> {
     _subscriptionsToDispose.add(alphaSubscription);
   }
 
-  void listenRealtimeChannel(ably.RealtimeChannel channel) {
+  void listenRealtimeChannel(ably.RealtimeChannelInterface channel) {
     final _channelStateChangeSubscription = channel.on().listen((stateChange) {
       print('ChannelStateChange: ${stateChange.current}'
           '\nReason: ${stateChange.reason}');

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -573,6 +573,32 @@ class _MyAppState extends State<MyApp> {
         child: const Text('Get history'),
       );
 
+  Widget getRealtimeChannelHistory() => FlatButton(
+        onPressed: () async {
+          final next = _realtimeHistory?.hasNext() ?? false;
+          print('Rest history: getting ${next ? 'next' : 'first'} page');
+          try {
+            if (_realtimeHistory == null || _realtimeHistory.items.isEmpty) {
+              final result =
+                  await _realtime.channels.get('test-channel').history(
+                        ably.RealtimeHistoryParams(
+                            direction: 'forwards', limit: 10),
+                      );
+              _realtimeHistory = result;
+            } else if (next) {
+              _realtimeHistory = await _realtimeHistory.next();
+            } else {
+              _realtimeHistory = await _realtimeHistory.first();
+            }
+            setState(() {});
+          } on ably.AblyException catch (e) {
+            print('failed to get history:: $e :: ${e.errorInfo}');
+          }
+        },
+        color: Colors.yellow,
+        child: const Text('Get history'),
+      );
+
   @override
   Widget build(BuildContext context) => MaterialApp(
         home: Scaffold(

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_print
-
 import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart' as ably;
@@ -515,7 +513,6 @@ class _MyAppState extends State<MyApp> {
                     final result =
                         await _realtime.channels.get('test-channel').history(
                               ably.RealtimeHistoryParams(
-                                direction: 'backwards',
                                 limit: 10,
                                 untilAttach: true,
                               ),

--- a/example/lib/nested_realtime_events.dart
+++ b/example/lib/nested_realtime_events.dart
@@ -1,5 +1,3 @@
-// ignore_for_file: avoid_print
-
 // NOTE: this file is not being used anywhere, yet
 // this could serve as a reference for writing nested listeners
 

--- a/lib/ably_flutter.dart
+++ b/lib/ably_flutter.dart
@@ -1,4 +1,3 @@
-export 'src/defaults.dart';
 export 'src/generated/platformconstants.dart';
 export 'src/impl/paginated_result.dart';
 export 'src/impl/realtime/realtime.dart';

--- a/lib/ably_flutter.dart
+++ b/lib/ably_flutter.dart
@@ -1,6 +1,9 @@
 export 'src/generated/platformconstants.dart';
 export 'src/impl/paginated_result.dart';
+export 'src/impl/realtime/channels.dart';
+export 'src/impl/realtime/connection.dart';
 export 'src/impl/realtime/realtime.dart';
+export 'src/impl/rest/channels.dart';
 export 'src/impl/rest/rest.dart';
 export 'src/info.dart';
 export 'src/spec/spec.dart';

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -39,47 +39,50 @@ class _CodecPair<T> {
   }
 }
 
+/// Custom message codec for encoding objects to send to platform
+/// or decoding objects received from platform.
 class Codec extends StandardMessageCodec {
   /// Map of codec type (a value from [CodecTypes]) vs encoder/decoder pair.
   /// Encoder/decoder can be null.
   /// For example, [ErrorInfo] only needs a decoder but not an encoder.
   Map<int, _CodecPair> codecMap;
 
+  /// initializes codec with codec map linking codec type to codec pair
   Codec() : super() {
     codecMap = {
       // Ably flutter plugin protocol message
       CodecTypes.ablyMessage:
-          _CodecPair<AblyMessage>(encodeAblyMessage, decodeAblyMessage),
+          _CodecPair<AblyMessage>(_encodeAblyMessage, _decodeAblyMessage),
       CodecTypes.ablyEventMessage:
-          _CodecPair<AblyEventMessage>(encodeAblyEventMessage, null),
+          _CodecPair<AblyEventMessage>(_encodeAblyEventMessage, null),
 
       // Other ably objects
       CodecTypes.clientOptions:
-          _CodecPair<ClientOptions>(encodeClientOptions, decodeClientOptions),
+          _CodecPair<ClientOptions>(_encodeClientOptions, _decodeClientOptions),
       CodecTypes.tokenParams:
-          _CodecPair<TokenParams>(encodeTokenParams, decodeTokenParams),
+          _CodecPair<TokenParams>(_encodeTokenParams, _decodeTokenParams),
       CodecTypes.tokenDetails:
-          _CodecPair<TokenDetails>(encodeTokenDetails, decodeTokenDetails),
+          _CodecPair<TokenDetails>(_encodeTokenDetails, _decodeTokenDetails),
       CodecTypes.tokenRequest:
-          _CodecPair<TokenRequest>(encodeTokenRequest, null),
+          _CodecPair<TokenRequest>(_encodeTokenRequest, null),
       CodecTypes.paginatedResult:
-          _CodecPair<PaginatedResult>(null, decodePaginatedResult),
+          _CodecPair<PaginatedResult>(null, _decodePaginatedResult),
       CodecTypes.realtimeHistoryParams:
-          _CodecPair<RealtimeHistoryParams>(encodeRealtimeHistoryParams, null),
+          _CodecPair<RealtimeHistoryParams>(_encodeRealtimeHistoryParams, null),
       CodecTypes.restHistoryParams:
-          _CodecPair<RestHistoryParams>(encodeRestHistoryParams, null),
+          _CodecPair<RestHistoryParams>(_encodeRestHistoryParams, null),
 
-      CodecTypes.errorInfo: _CodecPair<ErrorInfo>(null, decodeErrorInfo),
+      CodecTypes.errorInfo: _CodecPair<ErrorInfo>(null, _decodeErrorInfo),
       CodecTypes.message:
-          _CodecPair<Message>(encodeChannelMessage, decodeChannelMessage),
+          _CodecPair<Message>(_encodeChannelMessage, _decodeChannelMessage),
 
       // Events - Connection
       CodecTypes.connectionStateChange:
-          _CodecPair<ConnectionStateChange>(null, decodeConnectionStateChange),
+          _CodecPair<ConnectionStateChange>(null, _decodeConnectionStateChange),
 
       // Events - Channel
       CodecTypes.channelStateChange:
-          _CodecPair<ChannelStateChange>(null, decodeChannelStateChange),
+          _CodecPair<ChannelStateChange>(null, _decodeChannelStateChange),
     };
   }
 
@@ -148,7 +151,7 @@ class Codec extends StandardMessageCodec {
 
   // =========== ENCODERS ===========
   /// Writes [value] for [key] in [map] if [value] is not null
-  void writeToJson(Map<String, dynamic> map, String key, Object value) {
+  void _writeToJson(Map<String, dynamic> map, String key, Object value) {
     assert(value is! DateTime, '`DateTime` objects cannot be encoded');
     if (value == null) return;
     map[key] = value;
@@ -156,63 +159,63 @@ class Codec extends StandardMessageCodec {
 
   /// Encodes [ClientOptions] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeClientOptions(final ClientOptions v) {
+  Map<String, dynamic> _encodeClientOptions(final ClientOptions v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
     // AuthOptions (super class of ClientOptions)
-    writeToJson(jsonMap, TxClientOptions.authUrl, v.authUrl);
-    writeToJson(jsonMap, TxClientOptions.authMethod, v.authMethod);
-    writeToJson(jsonMap, TxClientOptions.key, v.key);
-    writeToJson(jsonMap, TxClientOptions.tokenDetails,
-        encodeTokenDetails(v.tokenDetails));
-    writeToJson(jsonMap, TxClientOptions.authHeaders, v.authHeaders);
-    writeToJson(jsonMap, TxClientOptions.authParams, v.authParams);
-    writeToJson(jsonMap, TxClientOptions.queryTime, v.queryTime);
-    writeToJson(jsonMap, TxClientOptions.useTokenAuth, v.useTokenAuth);
-    writeToJson(
-        jsonMap, TxClientOptions.hasAuthCallback, v.authCallback != null);
+    _writeToJson(jsonMap, TxClientOptions.authUrl, v.authUrl);
+    _writeToJson(jsonMap, TxClientOptions.authMethod, v.authMethod);
+    _writeToJson(jsonMap, TxClientOptions.key, v.key);
+    _writeToJson(jsonMap, TxClientOptions.tokenDetails,
+      _encodeTokenDetails(v.tokenDetails));
+    _writeToJson(jsonMap, TxClientOptions.authHeaders, v.authHeaders);
+    _writeToJson(jsonMap, TxClientOptions.authParams, v.authParams);
+    _writeToJson(jsonMap, TxClientOptions.queryTime, v.queryTime);
+    _writeToJson(jsonMap, TxClientOptions.useTokenAuth, v.useTokenAuth);
+    _writeToJson(
+      jsonMap, TxClientOptions.hasAuthCallback, v.authCallback != null);
 
     // ClientOptions
-    writeToJson(jsonMap, TxClientOptions.clientId, v.clientId);
-    writeToJson(jsonMap, TxClientOptions.logLevel, v.logLevel);
+    _writeToJson(jsonMap, TxClientOptions.clientId, v.clientId);
+    _writeToJson(jsonMap, TxClientOptions.logLevel, v.logLevel);
     //TODO handle logHandler
-    writeToJson(jsonMap, TxClientOptions.tls, v.tls);
-    writeToJson(jsonMap, TxClientOptions.restHost, v.restHost);
-    writeToJson(jsonMap, TxClientOptions.realtimeHost, v.realtimeHost);
-    writeToJson(jsonMap, TxClientOptions.port, v.port);
-    writeToJson(jsonMap, TxClientOptions.tlsPort, v.tlsPort);
-    writeToJson(jsonMap, TxClientOptions.autoConnect, v.autoConnect);
-    writeToJson(
-        jsonMap, TxClientOptions.useBinaryProtocol, v.useBinaryProtocol);
-    writeToJson(jsonMap, TxClientOptions.queueMessages, v.queueMessages);
-    writeToJson(jsonMap, TxClientOptions.echoMessages, v.echoMessages);
-    writeToJson(jsonMap, TxClientOptions.recover, v.recover);
-    writeToJson(jsonMap, TxClientOptions.environment, v.environment);
-    writeToJson(jsonMap, TxClientOptions.idempotentRestPublishing,
-        v.idempotentRestPublishing);
-    writeToJson(jsonMap, TxClientOptions.httpOpenTimeout, v.httpOpenTimeout);
-    writeToJson(
-        jsonMap, TxClientOptions.httpRequestTimeout, v.httpRequestTimeout);
-    writeToJson(
-        jsonMap, TxClientOptions.httpMaxRetryCount, v.httpMaxRetryCount);
-    writeToJson(jsonMap, TxClientOptions.realtimeRequestTimeout,
-        v.realtimeRequestTimeout);
-    writeToJson(jsonMap, TxClientOptions.fallbackHosts, v.fallbackHosts);
-    writeToJson(jsonMap, TxClientOptions.fallbackHostsUseDefault,
-        v.fallbackHostsUseDefault);
-    writeToJson(
-        jsonMap, TxClientOptions.fallbackRetryTimeout, v.fallbackRetryTimeout);
-    writeToJson(jsonMap, TxClientOptions.defaultTokenParams,
-        encodeTokenParams(v.defaultTokenParams));
-    writeToJson(
-        jsonMap, TxClientOptions.channelRetryTimeout, v.channelRetryTimeout);
-    writeToJson(jsonMap, TxClientOptions.transportParams, v.transportParams);
+    _writeToJson(jsonMap, TxClientOptions.tls, v.tls);
+    _writeToJson(jsonMap, TxClientOptions.restHost, v.restHost);
+    _writeToJson(jsonMap, TxClientOptions.realtimeHost, v.realtimeHost);
+    _writeToJson(jsonMap, TxClientOptions.port, v.port);
+    _writeToJson(jsonMap, TxClientOptions.tlsPort, v.tlsPort);
+    _writeToJson(jsonMap, TxClientOptions.autoConnect, v.autoConnect);
+    _writeToJson(
+      jsonMap, TxClientOptions.useBinaryProtocol, v.useBinaryProtocol);
+    _writeToJson(jsonMap, TxClientOptions.queueMessages, v.queueMessages);
+    _writeToJson(jsonMap, TxClientOptions.echoMessages, v.echoMessages);
+    _writeToJson(jsonMap, TxClientOptions.recover, v.recover);
+    _writeToJson(jsonMap, TxClientOptions.environment, v.environment);
+    _writeToJson(jsonMap, TxClientOptions.idempotentRestPublishing,
+      v.idempotentRestPublishing);
+    _writeToJson(jsonMap, TxClientOptions.httpOpenTimeout, v.httpOpenTimeout);
+    _writeToJson(
+      jsonMap, TxClientOptions.httpRequestTimeout, v.httpRequestTimeout);
+    _writeToJson(
+      jsonMap, TxClientOptions.httpMaxRetryCount, v.httpMaxRetryCount);
+    _writeToJson(jsonMap, TxClientOptions.realtimeRequestTimeout,
+      v.realtimeRequestTimeout);
+    _writeToJson(jsonMap, TxClientOptions.fallbackHosts, v.fallbackHosts);
+    _writeToJson(jsonMap, TxClientOptions.fallbackHostsUseDefault,
+      v.fallbackHostsUseDefault);
+    _writeToJson(
+      jsonMap, TxClientOptions.fallbackRetryTimeout, v.fallbackRetryTimeout);
+    _writeToJson(jsonMap, TxClientOptions.defaultTokenParams,
+      _encodeTokenParams(v.defaultTokenParams));
+    _writeToJson(
+      jsonMap, TxClientOptions.channelRetryTimeout, v.channelRetryTimeout);
+    _writeToJson(jsonMap, TxClientOptions.transportParams, v.transportParams);
     return jsonMap;
   }
 
   /// Encodes [TokenDetails] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeTokenDetails(final TokenDetails v) {
+  Map<String, dynamic> _encodeTokenDetails(final TokenDetails v) {
     if (v == null) return null;
     return {
       TxTokenDetails.token: v.token,
@@ -225,111 +228,115 @@ class Codec extends StandardMessageCodec {
 
   /// Encodes [TokenParams] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeTokenParams(final TokenParams v) {
+  Map<String, dynamic> _encodeTokenParams(final TokenParams v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
-    writeToJson(jsonMap, TxTokenParams.capability, v.capability);
-    writeToJson(jsonMap, TxTokenParams.clientId, v.clientId);
-    writeToJson(jsonMap, TxTokenParams.nonce, v.nonce);
-    writeToJson(jsonMap, TxTokenParams.timestamp, v.timestamp);
-    writeToJson(jsonMap, TxTokenParams.ttl, v.ttl);
+    _writeToJson(jsonMap, TxTokenParams.capability, v.capability);
+    _writeToJson(jsonMap, TxTokenParams.clientId, v.clientId);
+    _writeToJson(jsonMap, TxTokenParams.nonce, v.nonce);
+    _writeToJson(jsonMap, TxTokenParams.timestamp, v.timestamp);
+    _writeToJson(jsonMap, TxTokenParams.ttl, v.ttl);
     return jsonMap;
   }
 
   /// Encodes [TokenRequest] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeTokenRequest(final TokenRequest v) {
+  Map<String, dynamic> _encodeTokenRequest(final TokenRequest v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
-    writeToJson(jsonMap, TxTokenRequest.capability, v.capability);
-    writeToJson(jsonMap, TxTokenRequest.clientId, v.clientId);
-    writeToJson(jsonMap, TxTokenRequest.keyName, v.keyName);
-    writeToJson(jsonMap, TxTokenRequest.mac, v.mac);
-    writeToJson(jsonMap, TxTokenRequest.nonce, v.nonce);
-    writeToJson(
-        jsonMap, TxTokenRequest.timestamp, v.timestamp?.millisecondsSinceEpoch);
-    writeToJson(jsonMap, TxTokenRequest.ttl, v.ttl);
+    _writeToJson(jsonMap, TxTokenRequest.capability, v.capability);
+    _writeToJson(jsonMap, TxTokenRequest.clientId, v.clientId);
+    _writeToJson(jsonMap, TxTokenRequest.keyName, v.keyName);
+    _writeToJson(jsonMap, TxTokenRequest.mac, v.mac);
+    _writeToJson(jsonMap, TxTokenRequest.nonce, v.nonce);
+    _writeToJson(
+      jsonMap, TxTokenRequest.timestamp, v.timestamp?.millisecondsSinceEpoch);
+    _writeToJson(jsonMap, TxTokenRequest.ttl, v.ttl);
     return jsonMap;
   }
 
-  Map<String, dynamic> encodeRestHistoryParams(final RestHistoryParams v) {
+  /// Encodes [RestHistoryParams] to a Map
+  /// returns null of passed value [v] is null
+  Map<String, dynamic> _encodeRestHistoryParams(final RestHistoryParams v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
-    writeToJson(
-        jsonMap, TxRestHistoryParams.start, v.start?.millisecondsSinceEpoch);
-    writeToJson(
-        jsonMap, TxRestHistoryParams.end, v.end?.millisecondsSinceEpoch);
-    writeToJson(jsonMap, TxRestHistoryParams.direction, v.direction);
-    writeToJson(jsonMap, TxRestHistoryParams.limit, v.limit);
+    _writeToJson(
+      jsonMap, TxRestHistoryParams.start, v.start?.millisecondsSinceEpoch);
+    _writeToJson(
+      jsonMap, TxRestHistoryParams.end, v.end?.millisecondsSinceEpoch);
+    _writeToJson(jsonMap, TxRestHistoryParams.direction, v.direction);
+    _writeToJson(jsonMap, TxRestHistoryParams.limit, v.limit);
     return jsonMap;
   }
 
-  Map<String, dynamic> encodeRealtimeHistoryParams(
-      final RealtimeHistoryParams v) {
+  /// Encodes [RealtimeHistoryParams] to a Map
+  /// returns null of passed value [v] is null
+  Map<String, dynamic> _encodeRealtimeHistoryParams(
+    final RealtimeHistoryParams v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
-    writeToJson(jsonMap, TxRealtimeHistoryParams.start,
-        v.start?.millisecondsSinceEpoch);
-    writeToJson(
-        jsonMap, TxRealtimeHistoryParams.end, v.end?.millisecondsSinceEpoch);
-    writeToJson(jsonMap, TxRealtimeHistoryParams.direction, v.direction);
-    writeToJson(jsonMap, TxRealtimeHistoryParams.limit, v.limit);
-    writeToJson(jsonMap, TxRealtimeHistoryParams.untilAttach, v.untilAttach);
+    _writeToJson(jsonMap, TxRealtimeHistoryParams.start,
+      v.start?.millisecondsSinceEpoch);
+    _writeToJson(
+      jsonMap, TxRealtimeHistoryParams.end, v.end?.millisecondsSinceEpoch);
+    _writeToJson(jsonMap, TxRealtimeHistoryParams.direction, v.direction);
+    _writeToJson(jsonMap, TxRealtimeHistoryParams.limit, v.limit);
+    _writeToJson(jsonMap, TxRealtimeHistoryParams.untilAttach, v.untilAttach);
     return jsonMap;
   }
 
   /// Encodes [AblyMessage] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeAblyMessage(final AblyMessage v) {
+  Map<String, dynamic> _encodeAblyMessage(final AblyMessage v) {
     if (v == null) return null;
     final codecType = getCodecType(v.message);
     final message = (v.message == null)
-        ? null
-        : (codecType == null)
-            ? v.message
-            : codecMap[codecType].encode(v.message);
+      ? null
+      : (codecType == null)
+      ? v.message
+      : codecMap[codecType].encode(v.message);
     final jsonMap = <String, dynamic>{};
-    writeToJson(jsonMap, TxAblyMessage.registrationHandle, v.handle);
-    writeToJson(jsonMap, TxAblyMessage.type, codecType);
-    writeToJson(jsonMap, TxAblyMessage.message, message);
+    _writeToJson(jsonMap, TxAblyMessage.registrationHandle, v.handle);
+    _writeToJson(jsonMap, TxAblyMessage.type, codecType);
+    _writeToJson(jsonMap, TxAblyMessage.message, message);
     return jsonMap;
   }
 
   /// Encodes [AblyEventMessage] to a Map
   /// returns null of passed value [v] is null
-  Map<String, dynamic> encodeAblyEventMessage(final AblyEventMessage v) {
+  Map<String, dynamic> _encodeAblyEventMessage(final AblyEventMessage v) {
     if (v == null) return null;
     final codecType = getCodecType(v.message);
     final message = (v.message == null)
-        ? null
-        : (codecType == null)
-            ? v.message
-            : codecMap[codecType].encode(v.message);
+      ? null
+      : (codecType == null)
+      ? v.message
+      : codecMap[codecType].encode(v.message);
     final jsonMap = <String, dynamic>{};
-    writeToJson(jsonMap, TxAblyEventMessage.eventName, v.eventName);
-    writeToJson(jsonMap, TxAblyEventMessage.type, codecType);
-    writeToJson(jsonMap, TxAblyEventMessage.message, message);
+    _writeToJson(jsonMap, TxAblyEventMessage.eventName, v.eventName);
+    _writeToJson(jsonMap, TxAblyEventMessage.type, codecType);
+    _writeToJson(jsonMap, TxAblyEventMessage.message, message);
     return jsonMap;
   }
 
-  Map<String, dynamic> encodeChannelMessage(final Message v) {
+  Map<String, dynamic> _encodeChannelMessage(final Message v) {
     if (v == null) return null;
     final jsonMap = <String, dynamic>{};
     // Note: connectionId and timestamp are automatically set by platform
     // So they are suppressed on dart side
-    writeToJson(jsonMap, TxMessage.name, v.name);
-    writeToJson(jsonMap, TxMessage.clientId, v.clientId);
-    writeToJson(jsonMap, TxMessage.data, v.data);
-    writeToJson(jsonMap, TxMessage.id, v.id);
-    writeToJson(jsonMap, TxMessage.encoding, v.encoding);
-    writeToJson(jsonMap, TxMessage.extras, v.extras);
+    _writeToJson(jsonMap, TxMessage.name, v.name);
+    _writeToJson(jsonMap, TxMessage.clientId, v.clientId);
+    _writeToJson(jsonMap, TxMessage.data, v.data);
+    _writeToJson(jsonMap, TxMessage.id, v.id);
+    _writeToJson(jsonMap, TxMessage.encoding, v.encoding);
+    _writeToJson(jsonMap, TxMessage.extras, v.extras);
     return jsonMap;
   }
 
   // =========== DECODERS ===========
   /// Reads [key] value from [jsonMap]
   /// Casts it to [T] if the value is not null
-  T readFromJson<T>(Map<String, dynamic> jsonMap, String key) {
+  T _readFromJson<T>(Map<String, dynamic> jsonMap, String key) {
     final value = jsonMap[key];
     if (value == null) return null;
     return value as T;
@@ -337,120 +344,202 @@ class Codec extends StandardMessageCodec {
 
   /// Decodes value [jsonMap] to [ClientOptions]
   /// returns null if [jsonMap] is null
-  ClientOptions decodeClientOptions(Map<String, dynamic> jsonMap) {
+  ClientOptions _decodeClientOptions(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
 
     return ClientOptions()
-      // AuthOptions (super class of ClientOptions)
-      ..authUrl = readFromJson<String>(jsonMap, TxClientOptions.authUrl)
-      ..authMethod =
-          readFromJson<HTTPMethods>(jsonMap, TxClientOptions.authMethod)
-      ..key = readFromJson<String>(jsonMap, TxClientOptions.key)
-      ..tokenDetails = decodeTokenDetails(
-          toJsonMap(readFromJson<Map>(jsonMap, TxClientOptions.tokenDetails)))
-      ..authHeaders = readFromJson<Map<String, String>>(
-          jsonMap, TxClientOptions.authHeaders)
-      ..authParams =
-          readFromJson<Map<String, String>>(jsonMap, TxClientOptions.authParams)
-      ..queryTime = readFromJson<bool>(jsonMap, TxClientOptions.queryTime)
-      ..useTokenAuth = readFromJson<bool>(jsonMap, TxClientOptions.useTokenAuth)
+    // AuthOptions (super class of ClientOptions)
+      ..authUrl = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.authUrl,
+      )
+      ..authMethod = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.authMethod,
+      )
+      ..key = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.key,
+      )
+      ..tokenDetails = _decodeTokenDetails(
+        toJsonMap(_readFromJson<Map>(
+          jsonMap,
+          TxClientOptions.tokenDetails,
+        )),
+      )
+      ..authHeaders = _readFromJson<Map<String, String>>(
+        jsonMap,
+        TxClientOptions.authHeaders,
+      )
+      ..authParams = _readFromJson<Map<String, String>>(
+        jsonMap,
+        TxClientOptions.authParams,
+      )
+      ..queryTime = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.queryTime,
+      )
+      ..useTokenAuth = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.useTokenAuth,
+      )
 
-      // ClientOptions
-      ..clientId = readFromJson<String>(jsonMap, TxClientOptions.clientId)
-      ..logLevel = readFromJson<int>(jsonMap, TxClientOptions.logLevel)
-      //TODO handle logHandler
-      ..tls = readFromJson<bool>(jsonMap, TxClientOptions.tls)
-      ..restHost = readFromJson<String>(jsonMap, TxClientOptions.restHost)
-      ..realtimeHost =
-          readFromJson<String>(jsonMap, TxClientOptions.realtimeHost)
-      ..port = readFromJson<int>(jsonMap, TxClientOptions.port)
-      ..tlsPort = readFromJson<int>(jsonMap, TxClientOptions.tlsPort)
-      ..autoConnect = readFromJson<bool>(jsonMap, TxClientOptions.autoConnect)
-      ..useBinaryProtocol =
-          readFromJson<bool>(jsonMap, TxClientOptions.useBinaryProtocol)
-      ..queueMessages =
-          readFromJson<bool>(jsonMap, TxClientOptions.queueMessages)
-      ..echoMessages = readFromJson<bool>(jsonMap, TxClientOptions.echoMessages)
-      ..recover = readFromJson<String>(jsonMap, TxClientOptions.recover)
-      ..environment = readFromJson<String>(jsonMap, TxClientOptions.environment)
-      ..idempotentRestPublishing =
-          readFromJson<bool>(jsonMap, TxClientOptions.idempotentRestPublishing)
-      ..httpOpenTimeout =
-          readFromJson<int>(jsonMap, TxClientOptions.httpOpenTimeout)
-      ..httpRequestTimeout =
-          readFromJson<int>(jsonMap, TxClientOptions.httpRequestTimeout)
-      ..httpMaxRetryCount =
-          readFromJson<int>(jsonMap, TxClientOptions.httpMaxRetryCount)
-      ..realtimeRequestTimeout =
-          readFromJson<int>(jsonMap, TxClientOptions.realtimeRequestTimeout)
-      ..fallbackHosts =
-          readFromJson<List<String>>(jsonMap, TxClientOptions.fallbackHosts)
-      ..fallbackHostsUseDefault =
-          readFromJson<bool>(jsonMap, TxClientOptions.fallbackHostsUseDefault)
-      ..fallbackRetryTimeout =
-          readFromJson<int>(jsonMap, TxClientOptions.fallbackRetryTimeout)
-      ..defaultTokenParams = decodeTokenParams(toJsonMap(
-          readFromJson<Map>(jsonMap, TxClientOptions.defaultTokenParams)))
-      ..channelRetryTimeout =
-          readFromJson<int>(jsonMap, TxClientOptions.channelRetryTimeout)
-      ..transportParams = readFromJson<Map<String, String>>(
-          jsonMap, TxClientOptions.transportParams);
+    // ClientOptions
+      ..clientId = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.clientId,
+      )
+      ..logLevel = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.logLevel,
+      )
+    //TODO handle logHandler
+      ..tls = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.tls,
+      )
+      ..restHost = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.restHost,
+      )
+      ..realtimeHost = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.realtimeHost,
+      )
+      ..port = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.port,
+      )
+      ..tlsPort = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.tlsPort,
+      )
+      ..autoConnect = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.autoConnect,
+      )
+      ..useBinaryProtocol = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.useBinaryProtocol,
+      )
+      ..queueMessages = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.queueMessages,
+      )
+      ..echoMessages = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.echoMessages,
+      )
+      ..recover = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.recover,
+      )
+      ..environment = _readFromJson<String>(
+        jsonMap,
+        TxClientOptions.environment,
+      )
+      ..idempotentRestPublishing = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.idempotentRestPublishing,
+      )
+      ..httpOpenTimeout = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.httpOpenTimeout,
+      )
+      ..httpRequestTimeout = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.httpRequestTimeout,
+      )
+      ..httpMaxRetryCount = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.httpMaxRetryCount,
+      )
+      ..realtimeRequestTimeout = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.realtimeRequestTimeout,
+      )
+      ..fallbackHosts = _readFromJson<List<String>>(
+        jsonMap,
+        TxClientOptions.fallbackHosts,
+      )
+      ..fallbackHostsUseDefault = _readFromJson<bool>(
+        jsonMap,
+        TxClientOptions.fallbackHostsUseDefault,
+      )
+      ..fallbackRetryTimeout = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.fallbackRetryTimeout,
+      )
+      ..defaultTokenParams = _decodeTokenParams(
+        toJsonMap(_readFromJson<Map>(
+          jsonMap,
+          TxClientOptions.defaultTokenParams,
+        )),
+      )
+      ..channelRetryTimeout = _readFromJson<int>(
+        jsonMap,
+        TxClientOptions.channelRetryTimeout,
+      )
+      ..transportParams = _readFromJson<Map<String, String>>(
+        jsonMap,
+        TxClientOptions.transportParams,
+      );
   }
 
   /// Decodes value [jsonMap] to [TokenDetails]
   /// returns null if [jsonMap] is null
-  TokenDetails decodeTokenDetails(Map<String, dynamic> jsonMap) {
+  TokenDetails _decodeTokenDetails(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    return TokenDetails(readFromJson<String>(jsonMap, TxTokenDetails.token))
-      ..expires = readFromJson<int>(jsonMap, TxTokenDetails.expires)
-      ..issued = readFromJson<int>(jsonMap, TxTokenDetails.issued)
-      ..capability = readFromJson<String>(jsonMap, TxTokenDetails.capability)
-      ..clientId = readFromJson<String>(jsonMap, TxTokenDetails.clientId);
+    return TokenDetails(_readFromJson<String>(jsonMap, TxTokenDetails.token))
+      ..expires = _readFromJson<int>(jsonMap, TxTokenDetails.expires)
+      ..issued = _readFromJson<int>(jsonMap, TxTokenDetails.issued)
+      ..capability = _readFromJson<String>(jsonMap, TxTokenDetails.capability)
+      ..clientId = _readFromJson<String>(jsonMap, TxTokenDetails.clientId);
   }
 
   /// Decodes value [jsonMap] to [TokenParams]
   /// returns null if [jsonMap] is null
-  TokenParams decodeTokenParams(Map<String, dynamic> jsonMap) {
+  TokenParams _decodeTokenParams(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
     return TokenParams()
-      ..capability = readFromJson<String>(jsonMap, TxTokenParams.capability)
-      ..clientId = readFromJson<String>(jsonMap, TxTokenParams.clientId)
-      ..nonce = readFromJson<String>(jsonMap, TxTokenParams.nonce)
+      ..capability = _readFromJson<String>(jsonMap, TxTokenParams.capability)
+      ..clientId = _readFromJson<String>(jsonMap, TxTokenParams.clientId)
+      ..nonce = _readFromJson<String>(jsonMap, TxTokenParams.nonce)
       ..timestamp = DateTime.fromMillisecondsSinceEpoch(
-          readFromJson<int>(jsonMap, TxTokenParams.timestamp))
-      ..ttl = readFromJson<int>(jsonMap, TxTokenParams.ttl);
+        _readFromJson<int>(jsonMap, TxTokenParams.timestamp))
+      ..ttl = _readFromJson<int>(jsonMap, TxTokenParams.ttl);
   }
 
   /// Decodes value [jsonMap] to [AblyMessage]
   /// returns null if [jsonMap] is null
-  AblyMessage decodeAblyMessage(Map<String, dynamic> jsonMap) {
+  AblyMessage _decodeAblyMessage(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    final type = readFromJson<int>(jsonMap, TxAblyMessage.type);
+    final type = _readFromJson<int>(jsonMap, TxAblyMessage.type);
     dynamic message = jsonMap[TxAblyMessage.message];
     if (type != null) {
-      message = codecMap[type]
-          .decode(toJsonMap(readFromJson<Map>(jsonMap, TxAblyMessage.message)));
+      message = codecMap[type].decode(
+        toJsonMap(_readFromJson<Map>(jsonMap, TxAblyMessage.message)));
     }
     return AblyMessage(message,
-        handle: jsonMap[TxAblyMessage.registrationHandle] as int, type: type);
+      handle: jsonMap[TxAblyMessage.registrationHandle] as int, type: type);
   }
 
   /// Decodes value [jsonMap] to [ErrorInfo]
   /// returns null if [jsonMap] is null
-  ErrorInfo decodeErrorInfo(Map<String, dynamic> jsonMap) {
+  ErrorInfo _decodeErrorInfo(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
     return ErrorInfo(
-        code: jsonMap[TxErrorInfo.code] as int,
-        message: jsonMap[TxErrorInfo.message] as String,
-        statusCode: jsonMap[TxErrorInfo.statusCode] as int,
-        href: jsonMap[TxErrorInfo.href] as String,
-        requestId: jsonMap[TxErrorInfo.requestId] as String,
-        cause: jsonMap[TxErrorInfo.cause] as ErrorInfo);
+      code: jsonMap[TxErrorInfo.code] as int,
+      message: jsonMap[TxErrorInfo.message] as String,
+      statusCode: jsonMap[TxErrorInfo.statusCode] as int,
+      href: jsonMap[TxErrorInfo.href] as String,
+      requestId: jsonMap[TxErrorInfo.requestId] as String,
+      cause: jsonMap[TxErrorInfo.cause] as ErrorInfo);
   }
 
   /// Decodes [eventName] to [ConnectionEvent] enum if not null
   // ignore: missing_return
-  ConnectionEvent decodeConnectionEvent(String eventName) {
+  ConnectionEvent _decodeConnectionEvent(String eventName) {
     switch (eventName) {
       case TxEnumConstants.initialized:
         return ConnectionEvent.initialized;
@@ -475,7 +564,7 @@ class Codec extends StandardMessageCodec {
 
   /// Decodes [state] to [ConnectionState] enum if not null
   // ignore: missing_return
-  ConnectionState decodeConnectionState(String state) {
+  ConnectionState _decodeConnectionState(String state) {
     if (state == null) return null;
     switch (state) {
       case TxEnumConstants.initialized:
@@ -499,7 +588,7 @@ class Codec extends StandardMessageCodec {
 
   /// Decodes [eventName] to [ChannelEvent] enum if not null
   // ignore: missing_return
-  ChannelEvent decodeChannelEvent(String eventName) {
+  ChannelEvent _decodeChannelEvent(String eventName) {
     switch (eventName) {
       case TxEnumConstants.initialized:
         return ChannelEvent.initialized;
@@ -522,7 +611,7 @@ class Codec extends StandardMessageCodec {
 
   /// Decodes [state] to [ChannelState] enum if not null
   // ignore: missing_return
-  ChannelState decodeChannelState(String state) {
+  ChannelState _decodeChannelState(String state) {
     switch (state) {
       case TxEnumConstants.initialized:
         return ChannelState.initialized;
@@ -543,64 +632,65 @@ class Codec extends StandardMessageCodec {
 
   /// Decodes value [jsonMap] to [ConnectionStateChange]
   /// returns null if [jsonMap] is null
-  ConnectionStateChange decodeConnectionStateChange(
-      Map<String, dynamic> jsonMap) {
+  ConnectionStateChange _decodeConnectionStateChange(
+    Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    final current = decodeConnectionState(
-        readFromJson<String>(jsonMap, TxConnectionStateChange.current));
-    final previous = decodeConnectionState(
-        readFromJson<String>(jsonMap, TxConnectionStateChange.previous));
-    final event = decodeConnectionEvent(
-        readFromJson<String>(jsonMap, TxConnectionStateChange.event));
-    final retryIn = readFromJson<int>(jsonMap, TxConnectionStateChange.retryIn);
-    final reason = decodeErrorInfo(
-        toJsonMap(readFromJson<Map>(jsonMap, TxConnectionStateChange.reason)));
+    final current = _decodeConnectionState(
+      _readFromJson<String>(jsonMap, TxConnectionStateChange.current));
+    final previous = _decodeConnectionState(
+      _readFromJson<String>(jsonMap, TxConnectionStateChange.previous));
+    final event = _decodeConnectionEvent(
+      _readFromJson<String>(jsonMap, TxConnectionStateChange.event));
+    final retryIn =
+    _readFromJson<int>(jsonMap, TxConnectionStateChange.retryIn);
+    final reason = _decodeErrorInfo(
+      toJsonMap(_readFromJson<Map>(jsonMap, TxConnectionStateChange.reason)));
     return ConnectionStateChange(current, previous, event,
-        retryIn: retryIn, reason: reason);
+      retryIn: retryIn, reason: reason);
   }
 
   /// Decodes value [jsonMap] to [ChannelStateChange]
   /// returns null if [jsonMap] is null
-  ChannelStateChange decodeChannelStateChange(Map<String, dynamic> jsonMap) {
+  ChannelStateChange _decodeChannelStateChange(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    final current = decodeChannelState(
-        readFromJson<String>(jsonMap, TxChannelStateChange.current));
-    final previous = decodeChannelState(
-        readFromJson<String>(jsonMap, TxChannelStateChange.previous));
-    final event = decodeChannelEvent(
-        readFromJson<String>(jsonMap, TxChannelStateChange.event));
-    final resumed = readFromJson<bool>(jsonMap, TxChannelStateChange.resumed);
-    final reason = decodeErrorInfo(
-        toJsonMap(readFromJson<Map>(jsonMap, TxChannelStateChange.reason)));
+    final current = _decodeChannelState(
+      _readFromJson<String>(jsonMap, TxChannelStateChange.current));
+    final previous = _decodeChannelState(
+      _readFromJson<String>(jsonMap, TxChannelStateChange.previous));
+    final event = _decodeChannelEvent(
+      _readFromJson<String>(jsonMap, TxChannelStateChange.event));
+    final resumed = _readFromJson<bool>(jsonMap, TxChannelStateChange.resumed);
+    final reason = _decodeErrorInfo(
+      toJsonMap(_readFromJson<Map>(jsonMap, TxChannelStateChange.reason)));
     return ChannelStateChange(current, previous, event,
-        resumed: resumed, reason: reason);
+      resumed: resumed, reason: reason);
   }
 
-  Message decodeChannelMessage(Map<String, dynamic> jsonMap) {
+  Message _decodeChannelMessage(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
     final message = Message(
-        name: readFromJson<String>(jsonMap, TxMessage.name),
-        clientId: readFromJson<String>(jsonMap, TxMessage.clientId),
-        data: readFromJson<dynamic>(jsonMap, TxMessage.data))
-      ..id = readFromJson<String>(jsonMap, TxMessage.id)
-      ..connectionId = readFromJson<String>(jsonMap, TxMessage.connectionId)
-      ..encoding = readFromJson<String>(jsonMap, TxMessage.encoding)
-      ..extras = readFromJson<Map>(jsonMap, TxMessage.extras);
-    final timestamp = readFromJson<int>(jsonMap, TxMessage.timestamp);
+      name: _readFromJson<String>(jsonMap, TxMessage.name),
+      clientId: _readFromJson<String>(jsonMap, TxMessage.clientId),
+      data: _readFromJson<dynamic>(jsonMap, TxMessage.data))
+      ..id = _readFromJson<String>(jsonMap, TxMessage.id)
+      ..connectionId = _readFromJson<String>(jsonMap, TxMessage.connectionId)
+      ..encoding = _readFromJson<String>(jsonMap, TxMessage.encoding)
+      ..extras = _readFromJson<Map>(jsonMap, TxMessage.extras);
+    final timestamp = _readFromJson<int>(jsonMap, TxMessage.timestamp);
     if (timestamp != null) {
       message.timestamp = DateTime.fromMillisecondsSinceEpoch(timestamp);
     }
     return message;
   }
 
-  PaginatedResult<Object> decodePaginatedResult(Map<String, dynamic> jsonMap) {
+  PaginatedResult<Object> _decodePaginatedResult(Map<String, dynamic> jsonMap) {
     if (jsonMap == null) return null;
-    final type = readFromJson<int>(jsonMap, TxPaginatedResult.type);
-    final items = readFromJson<List>(jsonMap, TxPaginatedResult.items)
-            ?.map((e) => codecMap[type].decode(toJsonMap(e as Map)))
-            ?.toList() ??
-        [];
+    final type = _readFromJson<int>(jsonMap, TxPaginatedResult.type);
+    final items = _readFromJson<List>(jsonMap, TxPaginatedResult.items)
+      ?.map((e) => codecMap[type].decode(toJsonMap(e as Map)))
+      ?.toList() ??
+      [];
     return PaginatedResult(items,
-        hasNext: readFromJson(jsonMap, TxPaginatedResult.hasNext) as bool);
+      hasNext: _readFromJson(jsonMap, TxPaginatedResult.hasNext) as bool);
   }
 }

--- a/lib/src/defaults.dart
+++ b/lib/src/defaults.dart
@@ -1,4 +1,0 @@
-/// Java: io.ably.lib.transport.Defaults
-abstract class TransportDefaults {
-  static const int httpAsyncThreadpoolSize = 64;
-}

--- a/lib/src/generated/platformconstants.dart
+++ b/lib/src/generated/platformconstants.dart
@@ -3,6 +3,8 @@
 // source file can be found at bin/templates'
 //
 
+// ignore_for_file: public_member_api_docs
+
 class CodecTypes {
   static const int ablyMessage = 128;
   static const int ablyEventMessage = 129;

--- a/lib/src/impl/message.dart
+++ b/lib/src/impl/message.dart
@@ -1,4 +1,4 @@
-import '../../ably_flutter_plugin.dart';
+import '../../ably_flutter.dart';
 
 /// An encapsulating object used to pass data to/from platform for method calls
 class AblyMessage {

--- a/lib/src/impl/message.dart
+++ b/lib/src/impl/message.dart
@@ -1,8 +1,21 @@
+import '../../ably_flutter_plugin.dart';
+
+/// An encapsulating object used to pass data to/from platform for method calls
 class AblyMessage {
+  /// handle of rest/realtime instance
   final int handle;
+
+  /// type of message (same as the generated [CodecTypes])
   final int type;
+
+  /// message to be passed to platform / received from platform
   final Object message;
 
+  /// creates instance with a non-null [message]
+  ///
+  /// [handle] and [type] are optional
+  ///
+  /// Raises [AssertionError] if [message] is null
   AblyMessage(
     this.message, {
     this.handle,
@@ -10,10 +23,19 @@ class AblyMessage {
   }) : assert(message != null);
 }
 
+/// An encapsulating object used to pass data to platform for registering events
 class AblyEventMessage {
+  /// name of the event to register a listener for
   final String eventName;
+
+  /// data to be passed for starting a listener
   final Object message;
 
+  /// creates an instance with non-nul [eventName]
+  ///
+  /// [message] is optional
+  ///
+  /// Raises [AssertionError] if [eventName] is null
   AblyEventMessage(this.eventName, [this.message])
       : assert(eventName != null, 'eventName cannot be null');
 }

--- a/lib/src/impl/paginated_result.dart
+++ b/lib/src/impl/paginated_result.dart
@@ -3,9 +3,13 @@ import '../spec/spec.dart' as spec;
 import 'message.dart';
 import 'platform_object.dart';
 
+/// PaginatedResult [TG1](https://docs.ably.io/client-lib-development-guide/features/#TG1)
+///
+/// A type that represents page results from a paginated query.
+/// The response is accompanied by metadata that indicates the
+/// relative queries available.
 class PaginatedResult<T> extends PlatformObject
     implements spec.PaginatedResultInterface<T> {
-
   /// stores page handle created by platform APIs
   ///
   /// handle is updated after creating an instance as they are received
@@ -28,11 +32,16 @@ class PaginatedResult<T> extends PlatformObject
   /// Creates a PaginatedResult instance from items and a boolean indicating
   /// whether there is a next page
   PaginatedResult(this._items, {bool hasNext})
-      : _hasNext = hasNext,
-        super(fetchHandle: false);
+    : _hasNext = hasNext,
+      super(fetchHandle: false);
 
+  /// Instantiates by extracting result from [AblyMessage] returned from
+  /// platform method.
+  ///
+  /// Sets appropriate [_pageHandle] for identifying platform side of this
+  /// result object so that [next] and [first] can be executed
   PaginatedResult.fromAblyMessage(AblyMessage message)
-      : super(fetchHandle: false) {
+    : super(fetchHandle: false) {
     final rawResult = message.message as PaginatedResult<Object>;
     _items = rawResult.items.map<T>((e) => e as T).toList();
     _hasNext = rawResult.hasNext();
@@ -42,25 +51,21 @@ class PaginatedResult<T> extends PlatformObject
   @override
   Future<int> createPlatformInstance() async => _pageHandle;
 
-  /// returns a new PaginatedResult containing items of next page
   @override
   Future<PaginatedResult<T>> next() async {
     final message = await invoke<AblyMessage>(PlatformMethod.nextPage);
     return PaginatedResult<T>.fromAblyMessage(message);
   }
 
-  /// returns a new PaginatedResult containing items of first page
   @override
   Future<PaginatedResult<T>> first() async {
     final message = await invoke<AblyMessage>(PlatformMethod.firstPage);
     return PaginatedResult<T>.fromAblyMessage(message);
   }
 
-  /// returns whether there is a next page
   @override
   bool hasNext() => _hasNext;
 
-  /// returns whether this is the last page
   @override
   bool isLast() => !_hasNext;
 }

--- a/lib/src/impl/platform_object.dart
+++ b/lib/src/impl/platform_object.dart
@@ -15,6 +15,10 @@ abstract class PlatformObject {
   Future<int> _handle;
   int _handleValue; // Only for logging. Otherwise use _handle instead.
 
+  /// immediately instantiates an object on platform side by calling
+  /// [createPlatformInstance] if [fetchHandle] is true,
+  /// otherwise, platform instance will be created only when
+  /// [createPlatformInstance] is explicitly called.
   PlatformObject({bool fetchHandle = true}) : assert(fetchHandle != null) {
     if (fetchHandle) {
       _handle = _acquireHandle();
@@ -24,8 +28,13 @@ abstract class PlatformObject {
   @override
   String toString() => 'Ably Platform Object $_handleValue';
 
+  /// creates an instance of this object on platform side
   Future<int> createPlatformInstance();
 
+  /// returns [_handle] which will be same as handle on platform side
+  ///
+  /// if [_handle] is empty, it creates platform instance, acquires handle,
+  /// updates [_handle] and returns it.
   Future<int> get handle async => _handle ??= _acquireHandle();
 
   Future<int> _acquireHandle() =>
@@ -37,8 +46,10 @@ abstract class PlatformObject {
         );
       }).then((value) => _handleValue = value);
 
+  /// [MethodChannel] to make method calls to platform side
   MethodChannel get methodChannel => platform.methodChannel;
 
+  /// [EventChannel] to register events on platform side
   StreamsChannel get eventChannel => platform.streamsChannel;
 
   /// invoke platform method channel without AblyMessage encapsulation

--- a/lib/src/impl/realtime/channels.dart
+++ b/lib/src/impl/realtime/channels.dart
@@ -11,8 +11,8 @@ import '../message.dart';
 import '../platform_object.dart';
 import 'realtime.dart';
 
-class RealtimePlatformChannel extends PlatformObject
-    implements spec.RealtimeChannel {
+class RealtimeChannel extends PlatformObject
+    implements spec.RealtimeChannelInterface {
   @override
   spec.AblyBase ably;
 
@@ -25,7 +25,7 @@ class RealtimePlatformChannel extends PlatformObject
   @override
   spec.RealtimePresence presence;
 
-  RealtimePlatformChannel(this.ably, this.name, this.options) : super() {
+  RealtimeChannel(this.ably, this.name, this.options) : super() {
     state = spec.ChannelState.initialized;
     on().listen((event) => state = event.current);
   }
@@ -208,13 +208,12 @@ class RealtimePlatformChannel extends PlatformObject
   }
 }
 
-class RealtimePlatformChannels
-    extends spec.RealtimeChannels<RealtimePlatformChannel> {
+class RealtimePlatformChannels extends spec.RealtimeChannels<RealtimeChannel> {
   RealtimePlatformChannels(Realtime ably) : super(ably);
 
   @override
-  RealtimePlatformChannel createChannel(String name, ChannelOptions options) =>
-      RealtimePlatformChannel(ably, name, options);
+  RealtimeChannel createChannel(String name, ChannelOptions options) =>
+    RealtimeChannel(ably, name, options);
 }
 
 /// An item for used to enqueue a message to be published after an ongoing

--- a/lib/src/impl/realtime/connection.dart
+++ b/lib/src/impl/realtime/connection.dart
@@ -6,21 +6,27 @@ import '../../spec/spec.dart'
 import '../platform_object.dart';
 import 'realtime.dart';
 
+/// connects to Ably service
 class Connection extends PlatformObject implements ConnectionInterface {
-  Realtime realtimePlatformObject;
+  /// Realtime client instance
+  Realtime realtime;
 
-  Connection(this.realtimePlatformObject) : super() {
+  /// instantiates a connection with [realtime] client instance
+  ///
+  /// sets default [state] to [ConnectionState.initialized] and starts listening
+  /// for updates to the connection [state].
+  Connection(this.realtime) : super() {
     state = ConnectionState.initialized;
     on().listen((event) {
       if (event.reason?.code == ErrorCodes.authCallbackFailure) {
-        realtimePlatformObject.awaitAuthUpdateAndReconnect();
+        realtime.awaitAuthUpdateAndReconnect();
       }
       state = event.current;
     });
   }
 
   @override
-  Future<int> createPlatformInstance() async => realtimePlatformObject.handle;
+  Future<int> createPlatformInstance() async => realtime.handle;
 
   @override
   ErrorInfo errorReason;
@@ -49,10 +55,10 @@ class Connection extends PlatformObject implements ConnectionInterface {
               connectionStateChange.event == connectionEvent);
 
   @override
-  Future<void> close() => realtimePlatformObject.close();
+  Future<void> close() => realtime.close();
 
   @override
-  Future<void> connect() => realtimePlatformObject.connect();
+  Future<void> connect() => realtime.connect();
 
   @override
   Future<int> ping() {

--- a/lib/src/impl/realtime/connection.dart
+++ b/lib/src/impl/realtime/connection.dart
@@ -1,14 +1,15 @@
 import 'dart:async';
 
 import '../../../ably_flutter.dart';
-import '../../spec/spec.dart' show Connection, ConnectionState, ErrorInfo;
+import '../../spec/spec.dart'
+    show ConnectionInterface, ConnectionState, ErrorInfo;
 import '../platform_object.dart';
 import 'realtime.dart';
 
-class ConnectionPlatformObject extends PlatformObject implements Connection {
+class Connection extends PlatformObject implements ConnectionInterface {
   Realtime realtimePlatformObject;
 
-  ConnectionPlatformObject(this.realtimePlatformObject) : super() {
+  Connection(this.realtimePlatformObject) : super() {
     state = ConnectionState.initialized;
     on().listen((event) {
       if (event.reason?.code == ErrorCodes.authCallbackFailure) {

--- a/lib/src/impl/realtime/realtime.dart
+++ b/lib/src/impl/realtime/realtime.dart
@@ -25,7 +25,7 @@ class Realtime extends PlatformObject
   })  : assert(options != null || key != null),
         options = options ?? ClientOptions.fromKey(key),
         super() {
-    _connection = ConnectionPlatformObject(this);
+    _connection = Connection(this);
     _channels = RealtimePlatformChannels(this);
   }
 
@@ -42,10 +42,10 @@ class Realtime extends PlatformObject
   // The _connection instance keeps a reference to this platform object.
   // Ideally connection would be final, but that would need 'late final'
   // which is coming. https://stackoverflow.com/questions/59449666/initialize-a-final-variable-with-this-in-dart#comment105082936_59450231
-  Connection _connection;
+  ConnectionInterface _connection;
 
   @override
-  Connection get connection => _connection;
+  ConnectionInterface get connection => _connection;
 
   @override
   Auth auth;

--- a/lib/src/impl/rest/channels.dart
+++ b/lib/src/impl/rest/channels.dart
@@ -10,7 +10,7 @@ import '../message.dart';
 import '../platform_object.dart';
 import 'rest.dart';
 
-class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
+class RestChannel extends PlatformObject implements spec.RestChannelInterface {
   /// [Rest] instance
   @override
   spec.AblyBase ably;
@@ -24,7 +24,7 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
   @override
   spec.Presence presence;
 
-  RestPlatformChannel(this.ably, this.name, this.options);
+  RestChannel(this.ably, this.name, this.options);
 
   Rest get restPlatformObject => ably as Rest;
 
@@ -143,12 +143,12 @@ class RestPlatformChannel extends PlatformObject implements spec.RestChannel {
   }
 }
 
-class RestPlatformChannels extends spec.RestChannels<RestPlatformChannel> {
+class RestPlatformChannels extends spec.RestChannels<RestChannel> {
   RestPlatformChannels(Rest ably) : super(ably);
 
   @override
-  RestPlatformChannel createChannel(String name, ChannelOptions options) =>
-      RestPlatformChannel(ably, name, options);
+  RestChannel createChannel(String name, ChannelOptions options) =>
+      RestChannel(ably, name, options);
 }
 
 /// An item for used to enqueue a message to be published after an ongoing

--- a/lib/src/impl/rest/rest.dart
+++ b/lib/src/impl/rest/rest.dart
@@ -10,11 +10,18 @@ import 'channels.dart';
 Map<int, Rest> _restInstances = {};
 Map<int, Rest> _restInstancesUnmodifiableView;
 
+/// Returns readonly copy of instances of all [Rest] clients created.
 Map<int, Rest> get restInstances =>
     _restInstancesUnmodifiableView ??= UnmodifiableMapView(_restInstances);
 
+/// Ably's Rest client
 class Rest extends PlatformObject
     implements spec.RestInterface<RestPlatformChannels> {
+  /// instantiates with [ClientOptions] and a String [key]
+  ///
+  /// creates client options from key if [key] is provided
+  ///
+  /// raises [AssertionError] if both [options] and [key] are null
   Rest({
     ClientOptions options,
     final String key,
@@ -34,6 +41,12 @@ class Rest extends PlatformObject
     return handle;
   }
 
+  /// @internal
+  /// required due to the complications involved in the way ably-java expects
+  /// authCallback to be performed synchronously, while method channel call from
+  /// platform side to dart side is asynchronous
+  ///
+  /// discussion: https://github.com/ably/ably-flutter/issues/31
   void authUpdateComplete() {
     for (final channel in channels.all) {
       channel.authUpdateComplete();

--- a/lib/src/impl/streams_channel.dart
+++ b/lib/src/impl/streams_channel.dart
@@ -23,8 +23,11 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
+/// Manages multiple event listeners which would otherwise require verbose code
+/// on platform side
 class StreamsChannel {
-  StreamsChannel(this.name, [this.codec = const StandardMethodCodec()]);
+  /// initializes with event channel [name] and method [codec]
+  StreamsChannel(this.name, this.codec);
 
   /// The logical channel on which communication happens, not null.
   final String name;
@@ -34,6 +37,8 @@ class StreamsChannel {
 
   int _lastId = 0;
 
+  /// registers a listener on platform side and manages the listener
+  /// with incremental identifiers
   Stream<dynamic> receiveBroadcastStream([Object arguments]) {
     final methodChannel = MethodChannel(name, codec);
 

--- a/lib/src/info.dart
+++ b/lib/src/info.dart
@@ -1,5 +1,4 @@
 import 'generated/platformconstants.dart' show PlatformMethod;
-
 import 'platform.dart' show invoke;
 
 /// Get android/iOS platform version

--- a/lib/src/method_call_handler.dart
+++ b/lib/src/method_call_handler.dart
@@ -4,7 +4,10 @@ import '../ably_flutter.dart' as ably;
 import 'generated/platformconstants.dart';
 import 'impl/message.dart';
 
+/// Handles method calls invoked from platform side to dart side
 class AblyMethodCallHandler {
+  /// creates instance with method channel and forwards calls respective
+  /// instance methods: [onAuthCallback], [onRealtimeAuthCallback], etc
   AblyMethodCallHandler(MethodChannel channel) {
     channel.setMethodCallHandler((call) async {
       switch (call.method) {
@@ -19,6 +22,7 @@ class AblyMethodCallHandler {
     });
   }
 
+  /// handles auth callback for rest instances
   Future<Object> onAuthCallback(AblyMessage message) async {
     final tokenParams = message.message as ably.TokenParams;
     final rest = ably.restInstances[message.handle];
@@ -29,6 +33,7 @@ class AblyMethodCallHandler {
 
   bool _realtimeAuthInProgress = false;
 
+  /// handles auth callback for realtime instances
   Future<Object> onRealtimeAuthCallback(AblyMessage message) async {
     if (_realtimeAuthInProgress) {
       return null;

--- a/lib/src/platform.dart
+++ b/lib/src/platform.dart
@@ -38,6 +38,11 @@ Future _initialize() async {
   return _initializer;
 }
 
+/// invokes a platform [method] with [arguments]
+///
+/// calls an [_initialize] method before invoking any method so as to handle
+/// any cleanup tasks that are especially required while performing hot-restart
+/// (as hot-restart is known to not clear any objects on platform side)
 Future<T> invoke<T>(String method, [Object arguments]) async {
   await _initialize();
   return methodChannel.invokeMethod<T>(method, arguments);

--- a/lib/src/spec/auth.dart
+++ b/lib/src/spec/auth.dart
@@ -1,21 +1,41 @@
 import 'common.dart';
 import 'rest/options.dart';
 
-class AuthBase {
-  String clientId;
-}
+/// [Auth] object provides a way to create [TokenRequest] objects
+/// with [createTokenRequest] method or create Ably Tokens with
+/// [requestToken] method.
+///
+/// https://www.ably.io/documentation/core-features/authentication#auth-object
+abstract class Auth {
+  /// The clientId for this library instance
+  ///
+  /// see:
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA12
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA7b
+  String get clientId;
 
-abstract class Auth extends AuthBase {
+  /// Instructs the library to create a token immediately and ensures
+  /// Token Auth is used for all future requests
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA10
   Future<TokenDetails> authorize({
     TokenParams tokenParams,
     AuthOptions authOptions,
   });
 
+  /// Returns a signed TokenRequest object that can be used to obtain
+  /// a token from Ably.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA9
   Future<TokenRequest> createTokenRequest({
     TokenParams tokenParams,
     AuthOptions authOptions,
   });
 
+  /// Implicitly creates a TokenRequest if required and requests a token
+  /// from Ably if required. Returns a [TokenDetails] object.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA8
   Future<TokenDetails> requestToken({
     TokenParams tokenParams,
     AuthOptions authOptions,

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -299,12 +299,11 @@ class RestHistoryParams {
         end = end ?? DateTime.now();
 
   @override
-  String toString() =>
-      'RestHistoryParams:'
-        ' start=$start'
-        ' end=$end'
-        ' direction=$direction'
-        ' limit=$limit';
+  String toString() => 'RestHistoryParams:'
+      ' start=$start'
+      ' end=$end'
+      ' direction=$direction'
+      ' limit=$limit';
 }
 
 /// https://docs.ably.io/client-lib-development-guide/features/#RTL10
@@ -478,21 +477,31 @@ abstract class EventEmitter<E, G> {
 /// The response is accompanied by metadata that indicates the
 /// relative queries available.
 abstract class PaginatedResultInterface<T> {
-  /// items contain page of results (TG3)
+  /// items contain page of results
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TG3
   List<T> get items;
 
-  /// returns a new PaginatedResult loaded with the next page of results. (TG4)
+  /// returns a new PaginatedResult loaded with the next page of results.
   ///
-  /// If there are no further pages, then null is returned
+  /// If there are no further pages, then null is returned.
+  /// https://docs.ably.io/client-lib-development-guide/features/#TG4
   Future<PaginatedResultInterface<T>> next();
 
-  /// returns a new PaginatedResult for the first page of results (TG5)
+  /// returns a new PaginatedResult for the first page of results
+  ///
+  /// If there are no further pages, then null is returned.
+  /// https://docs.ably.io/client-lib-development-guide/features/#TG5
   Future<PaginatedResultInterface<T>> first();
 
-  /// returns true if there are further pages (TG6)
+  /// returns true if there are further pages
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TG6
   bool hasNext();
 
-  /// returns true if this page is the last page (TG7)
+  /// returns true if this page is the last page
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TG7
   bool isLast();
 }
 

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -1,9 +1,10 @@
+import 'dart:async';
+
 import 'package:flutter/services.dart';
 
 import '../impl/realtime/connection.dart';
 import 'auth.dart';
 import 'enums.dart';
-import 'rest/ably_base.dart';
 import 'spec.dart';
 
 /// params to configure encryption for a channel
@@ -468,7 +469,7 @@ class RestPresenceParams {
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#RTP11c
 class RealtimePresenceParams {
-  /// When true, [Presence.get] will wait until SYNC is complete
+  /// When true, [RealtimePresence.get] will wait until SYNC is complete
   /// before returning a list of members
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#RTP11c1
@@ -752,7 +753,12 @@ abstract class EventListener<E> {
 /// Interface implemented by Ably classes that can emit events,
 /// offering the capability to create listeners for those events.
 /// [E] is type of event to listen for
-/// [G] is the instance which will be passed back in streams
+/// [G] is the instance which will be passed back in streams.
+///
+///
+/// There is no `off` API as in other Ably client libraries as on returns a
+/// [Stream] which can be subscribed for, and that subscription can be cancelled
+/// using [StreamSubscription.cancel] API
 abstract class EventEmitter<E, G> {
   // Remove all listener registrations, irrespective of type.
   // Future<void> off();

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -760,9 +760,6 @@ abstract class EventListener<E> {
 /// [Stream] which can be subscribed for, and that subscription can be cancelled
 /// using [StreamSubscription.cancel] API
 abstract class EventEmitter<E, G> {
-  // Remove all listener registrations, irrespective of type.
-  // Future<void> off();
-
   /// Create a listener, with which registrations may be made.
   Stream<G> on([E event]);
 }
@@ -904,15 +901,7 @@ class Stats {
 
 /// A collection of Channel objects accessible
 /// through [Rest.channels] or [Realtime.channels]
-///
-/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
 abstract class Channels<ChannelType> {
-  /// instantiates with the ably [Rest] or [Realtime] instance
-  Channels(this.ably);
-
-  /// a [Rest] or [Realtime] instance
-  AblyBase ably;
-
   /// stores channel name vs instance of [ChannelType]
   final _channels = <String, ChannelType>{};
 

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -1,81 +1,175 @@
-import 'package:ably_flutter/src/spec/spec.dart';
+import 'package:flutter/services.dart';
 
+import '../impl/realtime/connection.dart';
 import 'auth.dart';
 import 'enums.dart';
 import 'rest/ably_base.dart';
 import 'spec.dart';
 
-//==============================================================================
-//==========================    ABSTRACT CLASSES    ============================
-//==============================================================================
+/// params to configure encryption for a channel
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TZ1
 abstract class CipherParams {
+  /// Specifies the algorithm to use for encryption
+  ///
+  /// Default is AES. Currently only AES is supported.
+  /// https://docs.ably.io/client-lib-development-guide/features/#TZ2a
   String algorithm;
+
+  /// private key used to encrypt and decrypt payloads
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TZ2d
   dynamic key;
+
+  /// the length in bits of the key
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TZ2b
   int keyLength;
+
+  /// Specify cipher mode
+  ///
+  /// Default is CBC. Currently only CBC is supported
+  /// https://docs.ably.io/client-lib-development-guide/features/#TZ2c
   String mode;
 }
 
-///An [AblyException] encapsulates [ErrorInfo] which carries details
-///about information related to Ably-specific error [code],
+/// An [AblyException] encapsulates [ErrorInfo] which carries details
+/// about information related to Ably-specific error [code],
 /// generic [statusCode], error [message],
 /// link to error related documentation as [href],
 /// [requestId] and [cause] of this exception
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TI1
 class ErrorInfo {
+  /// ably specific error code
   final int code;
+
+  /// link to error related documentation as
   final String href;
+
+  /// error message
   final String message;
+
+  /// cause for the error
   final ErrorInfo cause;
+
+  /// generic status code
   final int statusCode;
+
+  /// request id which triggered this exception
   final String requestId;
 
-  ErrorInfo(
-      {this.code,
-      this.href,
-      this.message,
-      this.cause,
-      this.statusCode,
-      this.requestId});
+  /// instantiates a [ErrorInfo] with provided values
+  ErrorInfo({
+    this.code,
+    this.href,
+    this.message,
+    this.cause,
+    this.statusCode,
+    this.requestId,
+  });
 
   @override
-  String toString() => 'ErrorInfo message=$message code=$code '
-      'statusCode=$statusCode href=$href';
+  String toString() => 'ErrorInfo'
+      ' message=$message'
+      ' code=$code'
+      ' statusCode=$statusCode'
+      ' href=$href';
 }
 
+/// MessageCount contains aggregate counts for messages and data transferred
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS5
 abstract class StatsMessageCount {
+  /// Count of all messages.
   int count;
+
+  /// Total data transferred for all messages in bytes.
   int data;
 }
 
+/// MessageTypes contains a breakdown of summary stats data
+/// for different (message vs presence) message types
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS6
 abstract class StatsMessageTypes {
+  /// All messages count (includes both presence & messages).
   StatsMessageCount all;
+
+  /// Count of channel messages.
   StatsMessageCount messages;
+
+  /// Count of presence messages.
   StatsMessageCount presence;
 }
 
+/// RequestCount contains aggregate counts for requests made
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS8
 abstract class StatsRequestCount {
+  /// Requests failed.
   int failed;
+
+  /// Requests refused typically as a result of permissions
+  /// or a limit being exceeded.
   int refused;
+
+  /// Requests succeeded.
   int succeeded;
 }
 
+/// ResourceCount contains aggregate data for usage of a resource
+/// in a specific scope
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS9
 abstract class StatsResourceCount {
+  /// Average resources of this type used for this period.
   int mean;
+
+  /// Minimum total resources of this type used for this period.
   int min;
+
+  /// Total resources of this type opened.
   int opened;
+
+  /// Peak resources of this type used for this period.
   int peak;
+
+  /// Resource requests refused within this period.
   int refused;
 }
 
+/// ConnectionTypes contains a breakdown of summary stats data
+/// for different (TLS vs non-TLS) connection types
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS4
 abstract class StatsConnectionTypes {
+  /// All connection count (includes both TLS & non-TLS connections).
   StatsResourceCount all;
+
+  /// Non-TLS connection count (unencrypted).
   StatsResourceCount plain;
+
+  /// TLS connection count.
   StatsResourceCount tls;
 }
 
+/// MessageTraffic contains a breakdown of summary stats data
+/// for traffic over various transport types
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS7
 abstract class StatsMessageTraffic {
+  /// All messages count (includes realtime, rest and webhook messages).
   StatsMessageTypes all;
+
+  /// Count of messages transferred over a realtime transport
+  /// such as WebSockets.
   StatsMessageTypes realtime;
+
+  /// Count of messages transferred using REST.
   StatsMessageTypes rest;
+
+  /// Count of messages delivered using WebHooks.
   StatsMessageTypes webhook;
 }
 
@@ -86,7 +180,7 @@ abstract class StatsMessageTraffic {
 /// [Auth.authorize], [Auth.requestToken] and [Auth.createTokenRequest]
 /// accept an instance of TokenParams as a parameter
 ///
-/// spec: https://docs.ably.io/client-lib-development-guide/features/#TK1
+/// https://docs.ably.io/client-lib-development-guide/features/#TK1
 class TokenParams {
   /// Capability of the token.
   ///
@@ -94,14 +188,14 @@ class TokenParams {
   /// returned token will be the intersection of this [capability]
   /// with the capability of the issuing key.
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TK2b
+  /// https://docs.ably.io/client-lib-development-guide/features/#TK2b
   String capability;
 
   /// A clientId to associate with this token.
   ///
   /// The generated token may be used to authenticate as this clientId.
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TK2c
+  /// https://docs.ably.io/client-lib-development-guide/features/#TK2c
   String clientId;
 
   /// An opaque nonce string of at least 16 characters to ensure uniqueness.
@@ -109,7 +203,7 @@ class TokenParams {
   /// Timestamps, in conjunction with the nonce,
   /// are used to prevent requests from being replayed
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TK2d
+  /// https://docs.ably.io/client-lib-development-guide/features/#TK2d
   String nonce;
 
   /// The timestamp (in millis since the epoch) of this request.
@@ -117,7 +211,7 @@ class TokenParams {
   ///	Timestamps, in conjunction with the nonce, are used to prevent
   ///	token requests from being replayed.
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TK2d
+  /// https://docs.ably.io/client-lib-development-guide/features/#TK2d
   DateTime timestamp;
 
   /// Requested time to live for the token.
@@ -128,9 +222,10 @@ class TokenParams {
   ///
   /// 0 means Ably will set it to the default value
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TK2a
+  /// https://docs.ably.io/client-lib-development-guide/features/#TK2a
   int ttl;
 
+  /// instantiates a [TokenParams] with provided values
   TokenParams({
     this.capability,
     this.clientId,
@@ -142,24 +237,24 @@ class TokenParams {
 
 /// Response to a `requestToken` request
 ///
-/// spec: https://docs.ably.io/client-lib-development-guide/features/#TD1
+/// https://docs.ably.io/client-lib-development-guide/features/#TD1
 class TokenDetails {
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TD2
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD2
   String token;
 
   /// Token expiry time in milliseconds
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TD3
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD3
   int expires;
 
   /// the time the token was issued in milliseconds
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TD4
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD4
   int issued;
 
   /// stringified capabilities JSON
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TD5
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD5
   String capability;
 
   /// Client ID assigned to the token.
@@ -170,9 +265,10 @@ class TokenDetails {
   /// any clientId. Any other string value for clientId implies that the
   /// clientId is both enforced and assumed for all operations for this token
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TD6
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD6
   String clientId;
 
+  /// instantiates a [TokenDetails] with provided values
   TokenDetails(
     this.token, {
     this.expires,
@@ -181,7 +277,9 @@ class TokenDetails {
     this.clientId,
   });
 
-  /// TD7
+  /// Creates an instance from the map
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TD7
   TokenDetails.fromMap(Map<String, dynamic> map) {
     token = map['token'] as String;
     expires = map['expires'] as int;
@@ -219,10 +317,12 @@ class TokenRequest {
 
   /// stringified capabilities JSON
   ///
-  /// spec: https://docs.ably.io/client-lib-development-guide/features/#TE3
+  /// https://docs.ably.io/client-lib-development-guide/features/#TE3
   String capability;
 
-  /// TE2
+  ///  Client ID assigned to the tokenRequest.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TE2
   String clientId;
 
   /// timestamp long – The timestamp (in milliseconds since the epoch)
@@ -238,6 +338,7 @@ class TokenRequest {
   /// spec: https://docs.ably.io/client-lib-development-guide/features/#TE4
   int ttl;
 
+  /// instantiates a [TokenRequest] with provided values
   TokenRequest({
     this.keyName,
     this.nonce,
@@ -289,6 +390,10 @@ class RestHistoryParams {
   /// RLS2b3
   final int limit;
 
+  /// instantiates with [direction] set to "backwards", [limit] to 100
+  /// [start] to epoch and end to current time
+  ///
+  /// Raises [AssertionError] if [direction] is not "backwards" or "forwards"
   RestHistoryParams({
     DateTime start,
     DateTime end,
@@ -314,6 +419,10 @@ class RealtimeHistoryParams extends RestHistoryParams {
   /// was attached or emitted an UPDATE indicating loss of continuity.
   bool untilAttach;
 
+  /// instantiates with [direction] set to "backwards", [limit] to 100
+  /// [start] to epoch and end to current time
+  ///
+  /// Raises [AssertionError] if [direction] is not "backwards" or "forwards"
   RealtimeHistoryParams({
     DateTime start,
     DateTime end,
@@ -328,36 +437,77 @@ class RealtimeHistoryParams extends RestHistoryParams {
         );
 }
 
+/// Params used as a filter for querying presence on a channel
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSP3a
 class RestPresenceParams {
+  /// number of records to fetch per page
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSP3a1
   int limit;
+
+  /// filters members by the provided clientId
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSP3a2
   String clientId;
+
+  /// filters members by the provided connectionId
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSP3a3
   String connectionId;
 
+  /// initializes with default [limit] set to 100
   RestPresenceParams({
-    this.limit,
+    this.limit = 100,
     this.clientId,
     this.connectionId,
   });
 }
 
+/// Params used as a filter for querying presence on a channel
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTP11c
 class RealtimePresenceParams {
+  /// When true, [Presence.get] will wait until SYNC is complete
+  /// before returning a list of members
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP11c1
   bool waitForSync;
+
+  /// filters members by the provided clientId
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP11c2
   String clientId;
+
+  /// filters members by the provided connectionId
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP11c3
   String connectionId;
 
+  /// initializes with [waitForSync] set to true by default
   RealtimePresenceParams({
-    this.waitForSync,
+    this.waitForSync = true,
     this.clientId,
     this.connectionId,
   });
 }
 
-/// An exception generated by the client library SDK called by this plugin.
+/// An exception generated by the native client library called by this plugin
 class AblyException implements Exception {
+  /// platform error code
+  ///
+  /// Mostly used for storing [PlatformException.code]
   final String code;
+
+  /// platform error message
+  ///
+  /// Mostly used for storing [PlatformException.message]
   final String message;
+
+  /// error message from ably native sdk
   final ErrorInfo errorInfo;
 
+  /// initializes with no defaults
   AblyException([
     this.code,
     this.message,
@@ -373,13 +523,39 @@ class AblyException implements Exception {
   }
 }
 
+/// Whenever the channel state changes, a ChannelStateChange object
+/// is emitted on the Channel object
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TH1
 class ChannelStateChange {
+  /// the event that generated the channel state change
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TH5
   final ChannelEvent event;
+
+  /// current state of the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TH2
   final ChannelState current;
+
+  /// previous state of the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TH2
   final ChannelState previous;
+
+  /// reason for failure, in case of a failed state
+  ///
+  /// If the channel state change includes error information,
+  /// then the reason attribute will contain an ErrorInfo
+  /// object describing the reason for the error
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TH3
   ErrorInfo reason;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TH4
   final bool resumed;
 
+  /// initializes with [resumed] set to false
   ChannelStateChange(
     this.current,
     this.previous,
@@ -389,13 +565,41 @@ class ChannelStateChange {
   });
 }
 
+/// Whenever the connection state changes,
+/// a ConnectionStateChange object is emitted on the [Connection] object
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TA1
 class ConnectionStateChange {
+  /// https://docs.ably.io/client-lib-development-guide/features/#TA2
   final ConnectionEvent event;
+
+  /// current state of the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TA2
   final ConnectionState current;
+
+  /// previous state of the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TA2
   final ConnectionState previous;
+
+  /// reason for failure, in case of a failed state
+  ///
+  /// If the channel state change includes error information,
+  /// then the reason attribute will contain an ErrorInfo
+  /// object describing the reason for the error
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TA3
   ErrorInfo reason;
+
+  /// when the client is not connected, a connection attempt will be made
+  /// automatically by the library after the number of milliseconds
+  /// specified by [retryIn]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TA2
   int retryIn;
 
+  /// initializes without any defaults
   ConnectionStateChange(
     this.current,
     this.previous,
@@ -405,47 +609,133 @@ class ConnectionStateChange {
   });
 }
 
+/// Details of the push registration for a given device
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#PCP1
 abstract class DevicePushDetails {
-  dynamic recipient;
-  DevicePushState state; //optional
-  ErrorInfo errorReason; //optional
+  /// A map of string key/value pairs containing details of the push transport
+  /// and address.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCP3
+  Map<String, String> recipient;
+
+  /// The state of the push registration.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCP4
+  DevicePushState state;
+
+  /// Any error information associated with the registration.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCP2
+  ErrorInfo errorReason;
 }
 
+/// Details of a registered device.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#PCD1
 abstract class DeviceDetails {
+  /// The id of the device registration.
+  ///
+  /// Generated locally if not available
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD2
   String id;
-  String clientId; //optional
+
+  /// populated for device registrations associated with a clientId (optional)
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD3
+  String clientId;
+
+  /// The device platform.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD6
   DevicePlatform platform;
+
+  /// the device form factor.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD4
   FormFactor formFactor;
-  dynamic metadata; //optional
-  String deviceSecret; //optional
-  DevicePushDetails push; //optional
+
+  /// a map of string key/value pairs containing any other registered
+  /// metadata associated with the device registration
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD5
+  Map<String, String> metadata;
+
+  /// Device token. Generated locally, if not available.
+  String deviceSecret;
+
+  /// Details of the push registration for this device.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCD7
+  DevicePushDetails push;
 }
 
+/// Details of a push subscription to a channel.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#PCS1
 abstract class PushChannelSubscription {
+  /// the channel name associated with this subscription
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCS4
   String channel;
-  String deviceId; //optional
-  String clientId; //optional
+
+  /// populated for subscriptions made for a specific device registration
+  /// (optional)
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCS2
+  String deviceId;
+
+  /// populated for subscriptions made for a specific clientId (optional)
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#PCS3
+  String clientId;
 }
 
+/// Params to filter push device registrations.
+///
+/// see: [PushDeviceRegistrations.list], [PushDeviceRegistrations.removeWhere]
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH1b2
 abstract class DeviceRegistrationParams {
-  String clientId; //optional
-  String deviceId; //optional
-  int limit; //optional
-  DevicePushState state; //optional
+  /// filter by client id
+  String clientId;
+
+  /// filter by device id
+  String deviceId;
+
+  /// limit results for each page
+  int limit;
+
+  /// filter by device state
+  DevicePushState state;
 }
 
+/// Params to filter push channel subscriptions.
+///
+/// See [PushChannelSubscriptions.list], [PushChannelSubscriptions.removeWhere]
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH1c1
 abstract class PushChannelSubscriptionParams {
-  String channel; //optional
-  String clientId; //optional
-  String deviceId; //optional
-  int limit; //optional
+  /// filter by channel
+  String channel;
+
+  /// filter by clientId
+  String clientId;
+
+  /// filter by deviceId
+  String deviceId;
+
+  /// limit results for each page
+  int limit;
 }
 
+/// params to filter channels on a [PushChannelSubscriptions]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH1c2
 abstract class PushChannelsParams {
-  int limit; //optional
+  /// limit results for each page
+  int limit;
 }
 
-// Internal Classes
 /// Interface implemented by event listeners, returned by event emitters.
 abstract class EventListener<E> {
   /// Register for all events (no parameter), or a specific event.
@@ -488,7 +778,7 @@ abstract class PaginatedResultInterface<T> {
   /// https://docs.ably.io/client-lib-development-guide/features/#TG4
   Future<PaginatedResultInterface<T>> next();
 
-  /// returns a new PaginatedResult for the first page of results
+  /// returns a new PaginatedResult with the first page of results
   ///
   /// If there are no further pages, then null is returned.
   /// https://docs.ably.io/client-lib-development-guide/features/#TG5
@@ -505,36 +795,130 @@ abstract class PaginatedResultInterface<T> {
   bool isLast();
 }
 
-abstract class HttpPaginatedResponse extends PaginatedResultInterface<String> {
+/// The response from an HTTP request containing an empty or
+/// JSON-encodable object response
+///
+/// [T] can be a [Map] or [List]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#HP1
+abstract class HttpPaginatedResponse<T> extends PaginatedResultInterface<T> {
+  /// HTTP status code for the response
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP4
   int statusCode;
+
+  /// indicates whether the request is successful
+  ///
+  /// true when 200 <= [statusCode] < 300
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP5
   bool success;
+
+  /// Value from X-Ably-Errorcode HTTP header, if available in response
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP6
   int errorCode;
+
+  /// Value from X-Ably-Errormessage HTTP header, if available in response
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP7
   String errorMessage;
-  Map<String, String> headers;
+
+  /// Array of key value pairs of each response header
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP8
+  List<Map<String, String>> headers;
+
+  /// returns a new HttpPaginatedResponse loaded with the next page of results.
+  ///
+  /// If there are no further pages, then null is returned.
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP2
+  @override
+  Future<HttpPaginatedResponse<T>> next();
+
+  /// returns a new HttpPaginatedResponse with the first page of results
+  ///
+  /// If there are no further pages, then null is returned.
+  /// https://docs.ably.io/client-lib-development-guide/features/#HP2
+  @override
+  Future<HttpPaginatedResponse<T>> first();
 }
 
+/// A class representing an individual statistic for a specified [intervalId]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TS1
 class Stats {
+  /// Aggregates inbound and outbound messages.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12e
   StatsMessageTypes all;
+
+  /// Breakdown of API requests received via the REST API.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12e
   StatsRequestCount apiRequests;
+
+  /// Breakdown of channels stats.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12e
   StatsResourceCount channels;
+
+  /// Breakdown of connection stats data for different (TLS vs non-TLS)
+  /// connection types.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12i
   StatsConnectionTypes connections;
+
+  /// All inbound messages i.e.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12f
   StatsMessageTraffic inbound;
+
+  /// The interval that this statistic applies to,
+  /// see GRANULARITY and INTERVAL_FORMAT_STRING.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12a
   String intervalId;
+
+  /// All outbound messages i.e.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12g
   StatsMessageTraffic outbound;
+
+  /// Messages persisted for later retrieval via the history API.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12h
   StatsMessageTypes persisted;
+
+  /// Breakdown of Token requests received via the REST API.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TS12l
   StatsRequestCount tokenRequests;
 }
 
+/// A collection of Channel objects accessible
+/// through [Rest.channels] or [Realtime.channels]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
 abstract class Channels<ChannelType> {
+  /// instantiates with the ably [Rest] or [Realtime] instance
   Channels(this.ably);
 
+  /// a [Rest] or [Realtime] instance
   AblyBase ably;
+
+  /// stores channel name vs instance of [ChannelType]
   final _channels = <String, ChannelType>{};
 
+  /// creates a channel with provided name and options
   ChannelType createChannel(String name, ChannelOptions options);
 
+  /// returns all channels
   Iterable<ChannelType> get all => _channels.values;
 
+  /// creates a channel with [name].
+  ///
+  /// Doesn't create a channel instance on platform side yet.
   ChannelType get(String name) {
     //TODO add ChannelOptions as optional argument here,
     // and pass it on to createChannel
@@ -544,11 +928,11 @@ abstract class Channels<ChannelType> {
     return _channels[name];
   }
 
+  /// returns true if a channel exists [name]
   bool exists(String name) => _channels[name] != null;
 
-  Iterable<ChannelType> iterate() => _channels.values;
-
-  void release(String str) {
+  /// releases channel with [name]
+  void release(String name) {
     throw UnimplementedError();
   }
 }

--- a/lib/src/spec/common.dart
+++ b/lib/src/spec/common.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 
+import '../../ably_flutter.dart';
 import '../impl/realtime/connection.dart';
 import 'auth.dart';
 import 'enums.dart';

--- a/lib/src/spec/connection.dart
+++ b/lib/src/spec/connection.dart
@@ -1,10 +1,10 @@
 import 'common.dart';
 import 'enums.dart';
 
-/// connects to Ably service using a [websocket](https://www.ably.io/topic/websockets) connection
+/// connects to Ably service using a [web-socket](https://www.ably.io/topic/websockets) connection
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#RTN1
-abstract class Connection
+abstract class ConnectionInterface
     implements EventEmitter<ConnectionEvent, ConnectionStateChange> {
   /// current state of this connection
   ///

--- a/lib/src/spec/connection.dart
+++ b/lib/src/spec/connection.dart
@@ -1,19 +1,33 @@
 import 'common.dart';
 import 'enums.dart';
 
+/// connects to Ably service using a [websocket](https://www.ably.io/topic/websockets) connection
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTN1
 abstract class Connection
     implements EventEmitter<ConnectionEvent, ConnectionStateChange> {
-  ///current state of this connection
+  /// current state of this connection
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#connection-states-operations
   ConnectionState state;
 
-  ///Error information associated with connection failure
+  /// Error information associated with connection failure
+  ///
+  /// See:
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN14
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN15
   ErrorInfo errorReason;
 
-  ///A public identifier for this connection, used to identify
+  /// A public identifier for this connection, used to identify
   /// this member in presence events and message ids.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN8
   String id;
 
-  /// The assigned connection key.
+  /// A unique private connection key provided by Ably that is used to reconnect
+  /// and retain connection state following an unexpected disconnection
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN9
   String key;
 
   /// RTN16b) Connection#recoveryKey is an attribute composed of the
@@ -21,11 +35,24 @@ abstract class Connection
   String recoveryKey;
 
   /// The serial number of the last message to be received on this connection.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN10
   int serial;
 
-  Future<void> close();
-
+  /// Explicitly connects to Ably service if not already connected
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN11
   Future<void> connect();
 
+  /// closes the connection
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN12
+  Future<void> close();
+
+  /// ping's ably server
+  ///
+  /// Will send a ProtocolMessage with action HEARTBEAT the Ably service when
+  /// connected and expects a HEARTBEAT message in response
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTN13
   Future<int> ping();
 }

--- a/lib/src/spec/constants.dart
+++ b/lib/src/spec/constants.dart
@@ -1,4 +1,4 @@
-import '../../ably_flutter_plugin.dart';
+import '../../ably_flutter.dart';
 
 /// Log levels - control verbosity of log messages
 ///

--- a/lib/src/spec/constants.dart
+++ b/lib/src/spec/constants.dart
@@ -1,12 +1,34 @@
+import '../../ably_flutter_plugin.dart';
+
+/// Log levels - control verbosity of log messages
+///
+/// Can be used for [ClientOptions.logLevel]
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TO3b
+///
+/// TODO(tiholic) convert [LogLevel] to enum and update encoder to pass
+///  right numeric values to platform methods
 class LogLevel {
+  /// No logging
   static const int none = 99;
+
+  /// Verbose logs
   static const int verbose = 2;
+
+  /// debug logs
   static const int debug = 3;
+
+  /// info logs
   static const int info = 4;
+
+  /// warning logs
   static const int warn = 5;
+
+  /// error logs
   static const int error = 6;
 }
 
+/// Static error codes used inside the SDK
 class ErrorCodes {
   /// error code sent from platform in case if response from
   /// authCallback is not of valid type.
@@ -16,6 +38,9 @@ class ErrorCodes {
   static const int authCallbackFailure = 80019;
 }
 
+/// Static timeouts used inside the SDK
 class Timeouts {
+  /// max time allowed for retrying an operation for auth failure
+  /// in case of usage of authCallback
   static const retryOperationOnAuthFailure = Duration(seconds: 30);
 }

--- a/lib/src/spec/enums.dart
+++ b/lib/src/spec/enums.dart
@@ -1,101 +1,246 @@
-enum ChannelState {
-  initialized,
-  attaching,
-  attached,
-  detaching,
-  detached,
-  suspended,
-  failed,
-}
+import '../../ably_flutter_plugin.dart';
 
+/// Set of flags that represent the capabilities of a channel for current client
+///
+/// See:
+/// https://docs.ably.io/client-lib-development-guide/features/#TB2d
+/// https://docs.ably.io/client-lib-development-guide/features/#RTL4m
 enum ChannelMode {
-  // TB2d
+  /// specifies that channel can check for presence
   presence,
+
+  /// specifies that channel can publish
   publish,
+
+  /// specifies that channel can subscribe to messages
   subscribe,
+
+  /// specifies that channel can subscribe to presence events
   presenceSubscribe,
 }
 
-enum ChannelEvent {
-  initialized,
-  attaching,
-  attached,
-  detaching,
-  detached,
-  suspended,
-  failed,
-  update,
-}
-
+/// Connection state
+///
+/// See Ably Realtime API documentation for more details.
+/// https://docs.ably.io/client-lib-development-guide/features/#connection-states-operations
 enum ConnectionState {
+  /// specifies that a connection is initialized
   initialized,
+
+  /// specifies that a connection to ably is being established
   connecting,
+
+  /// specifies that a connection to ably is established
   connected,
+
+  /// specifies that a connection to ably is disconnected
   disconnected,
+
+  /// specifies that a connection to ably is suspended
   suspended,
+
+  /// specifies that a connection to ably is closing
   closing,
+
+  /// specifies that a connection to ably is closed
   closed,
+
+  /// specifies that a connection to ably is failed
   failed,
 }
 
+/// Connection event is same as [ConnectionState] except that it also handles
+/// update operations on a connection
+///
+/// See Ably Realtime API documentation for more details.
 enum ConnectionEvent {
+  /// specifies that a connection is initialized
   initialized,
+
+  /// specifies that a connection to ably is being established
   connecting,
+
+  /// specifies that a connection to ably is established
   connected,
+
+  /// specifies that a connection to ably is disconnected
   disconnected,
+
+  /// specifies that a connection to ably is suspended
   suspended,
+
+  /// specifies that a connection to ably is closing
   closing,
+
+  /// specifies that a connection to ably is closed
   closed,
+
+  /// specifies that a connection to ably is failed
   failed,
+
+  /// specifies that a connection is updated
   update,
 }
 
+/// Channel states
+///
+/// See Ably Realtime API documentation for more details.
+/// https://docs.ably.io/client-lib-development-guide/features/#channel-states-operations
+enum ChannelState {
+  /// represents that a channel is initialized and no action was taken
+  /// i.e., even auto connect was not triggered - if enabled
+  initialized,
+
+  /// channel is attaching
+  attaching,
+
+  /// channel is attached
+  attached,
+
+  /// channel is detaching
+  detaching,
+
+  /// channel is detached
+  detached,
+
+  /// channel is suspended
+  suspended,
+
+  /// channel failed to connect
+  failed,
+}
+
+/// Channel events
+///
+/// See Ably Realtime API documentation for more details.
+enum ChannelEvent {
+  /// represents that a channel is initialized and no action was taken
+  /// i.e., even auto connect was not triggered - if enabled
+  initialized,
+
+  /// channel is attaching
+  attaching,
+
+  /// channel is attached
+  attached,
+
+  /// channel is detaching
+  detaching,
+
+  /// channel is detached
+  detached,
+
+  /// channel is suspended
+  suspended,
+
+  /// channel failed to connect
+  failed,
+
+  /// specifies that a channel state is updated
+  update,
+}
+
+/// Status on a presence message
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TP2
 enum PresenceAction {
+  /// indicates that a client is absent for incoming [PresenceMessage]
   absent,
+
+  /// indicates that a client is present for incoming [PresenceMessage]
   present,
+
+  /// indicates that a client wants to enter a channel presence via
+  /// outgoing [PresenceMessage]
   enter,
+
+  /// indicates that a client wants to leave a channel presence via
+  /// outgoing [PresenceMessage]
   leave,
+
+  /// indicates that presence status of a client in presence member map
+  /// needs to be updated
   update,
 }
 
+/// https://docs.ably.io/client-lib-development-guide/features/#TS12c
 enum StatsIntervalGranularity {
+  /// indicates units in minutes
   minute,
-  hour,
-  day,
-  month,
-}
 
-enum HTTPMethods {
-  post,
-  get,
+  /// indicates units in hours
+  hour,
+
+  /// indicates units in days
+  day,
+
+  /// indicates units in months
+  month,
 }
 
 /// Java: io.ably.lib.http.HttpAuth.Type
 enum HttpAuthType {
+  /// indicates basic authentication
   basic,
+
+  /// digest authentication
   digest,
+
+  /// Token auth
   xAblyToken,
 }
 
+/// To indicate Push State of a device in [DeviceDetails] via [DevicePushState]
+/// while registering
 enum DevicePushState {
+  /// indicates active push state of the device
   active,
+
+  /// indicates that push state is failing
   failing,
+
+  /// indicates the device push state failed
   failed,
 }
 
+/// To indicate the operating system -or- platform of the client using SDK
+/// in [DeviceDetails] while registering
 enum DevicePlatform {
+  /// indicates an android device
   android,
+
+  /// indicates an iOS device
   ios,
+
+  /// indicates a browser
   browser,
 }
 
+/// To indicate the type of device in [DeviceDetails] while registering
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#PCD4
 enum FormFactor {
+  /// indicates the device is a mobile phone
   phone,
+
+  /// indicates the device is a tablet
   tablet,
+
+  /// indicates the device is a desktop
   desktop,
+
+  /// indicates the device is a television
   tv,
+
+  /// indicates the device is a smart watch
   watch,
+
+  /// indicates the device is an automobile
   car,
+
+  /// indicates the device is an embedded system / iOT device
   embedded,
+
+  /// indicates the device belong to categories other than mentioned above
   other,
 }

--- a/lib/src/spec/enums.dart
+++ b/lib/src/spec/enums.dart
@@ -1,4 +1,4 @@
-import '../../ably_flutter_plugin.dart';
+import '../../ably_flutter.dart';
 
 /// Set of flags that represent the capabilities of a channel for current client
 ///

--- a/lib/src/spec/message.dart
+++ b/lib/src/spec/message.dart
@@ -1,69 +1,102 @@
 import 'enums.dart';
 import 'rest/channels.dart';
 
+/// An individual message to be sent/received by Ably
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TM1
 class Message {
   /// A unique ID for this message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2a
   String id;
 
   /// The timestamp for this message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2f
   DateTime timestamp;
 
   /// The id of the publisher of this message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2b
   String clientId;
 
   /// The connection id of the publisher of this message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2c
   String connectionId;
 
   /// Any transformation applied to the data for this message
   String encoding;
 
-  /// The message payload
+  /// Message payload
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2d
   Object data;
 
-  /// The event name, if available
+  /// Name of the message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TM2g
   String name;
 
   /// Extras, if available
   Map extras;
 
-  Message({this.name, this.data, this.clientId}); // TM2
+  /// Creates a message instance with [name], [data] and [clientId]
+  Message({this.name, this.data, this.clientId});
 
   @override
   String toString() => 'Message id=$id timestamp=$timestamp clientId=$clientId'
-        ' connectionId=$connectionId encoding=$encoding name=$name'
-        ' data=$data extras=$extras';
+      ' connectionId=$connectionId encoding=$encoding name=$name'
+      ' data=$data extras=$extras';
+
+// TODO(tiholic) add support for fromEncoded and fromEncodedArray (TM3)
 }
 
-abstract class MessageStatic {
-  //TODO why is this class required?
-  MessageStatic.fromEncoded(Map jsonObject, ChannelOptions channelOptions);
-
-  MessageStatic.fromEncodedArray(List jsonArray, ChannelOptions channelOptions);
-}
-
+/// An individual presence message sent or received via realtime
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TP1
 abstract class PresenceMessage {
-  PresenceMessage.fromEncoded(Map jsonObject, ChannelOptions channelOptions);
-
-  PresenceMessage.fromEncodedArray(
-      List jsonArray, ChannelOptions channelOptions);
-
-  PresenceAction action;
-  String clientId;
-  String connectionId;
-  dynamic data;
-  String encoding;
-  Map<String, dynamic> extras;
+  /// unique ID for this presence message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3a
   String id;
+
+  /// presence action - to update presence status of current client,
+  /// or to understand presence state of another client
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3b
+  PresenceAction action;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3c
+  String clientId;
+
+  /// connection id of the source of this message
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3d
+  String connectionId;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3e
+  dynamic data;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3f
+  String encoding;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3i
+  Map<String, dynamic> extras;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3g
   DateTime timestamp;
 
-  String memberKey();
-}
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP3h
+  String get memberKey => '$connectionId:$clientId';
 
-abstract class PresenceMessageStatic {
-  //TODO why is this class required?
-  PresenceMessageStatic.fromEncoded(
-      Map jsonObject, ChannelOptions channelOptions);
+  /// instantiates a presence message with no defaults
+  PresenceMessage();
 
-  PresenceMessageStatic.fromEncodedArray(
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP4
+  PresenceMessage.fromEncoded(Map jsonObject, ChannelOptions channelOptions);
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TP4
+  PresenceMessage.fromEncodedArray(
       List jsonArray, ChannelOptions channelOptions);
 }

--- a/lib/src/spec/push/channels.dart
+++ b/lib/src/spec/push/channels.dart
@@ -1,18 +1,36 @@
 import '../common.dart';
 
+/// Channel to recieve push notificaitons on
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH7
 abstract class PushChannel {
-  // RSH7a
+  /// Subscribes device to push notifications on channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH7a
   Future<void> subscribeDevice();
 
-  // RSH7b
+  /// Subscribes client to push notifications on the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH7b
   Future<void> subscribeClient();
 
-  // RSH7c
+  /// un-subscribes device from push notifications
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH7c
   Future<void> unsubscribeDevice();
 
-  // RSH7d
+  /// un-subscribes client from push notifications
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH7d
   Future<void> unsubscribeClient();
 
-  // RSH7e
-  Future<PaginatedResultInterface<PushChannelSubscription>> listSubscriptions();
+  /// Lists subscriptions
+  ///
+  /// as [PushChannelSubscription] objects encapsulated in a paginated result.
+  /// Optional filters can be passed as a [params] map
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH7e
+  Future<PaginatedResultInterface<PushChannelSubscription>> listSubscriptions([
+    Map<String, dynamic> params,
+  ]);
 }

--- a/lib/src/spec/push/channels.dart
+++ b/lib/src/spec/push/channels.dart
@@ -1,6 +1,6 @@
 import '../common.dart';
 
-/// Channel to recieve push notificaitons on
+/// Channel to receive push notifications on
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#RSH7
 abstract class PushChannel {

--- a/lib/src/spec/push/push.dart
+++ b/lib/src/spec/push/push.dart
@@ -4,14 +4,14 @@ abstract class PushChannelSubscriptions {
   Future<PushChannelSubscription> save(PushChannelSubscription subscription);
 
   Future<PaginatedResultInterface<PushChannelSubscription>> list(
-    PushChannelsParams params,
+    PushChannelSubscriptionParams params,
   );
 
   Future<PaginatedResultInterface<String>> listChannels(
     PushChannelsParams params,
   );
 
-  Future<void> remove(PushChannelsParams params);
+  Future<void> remove(PushChannelSubscription subscription);
 
   Future<void> removeWhere(PushChannelSubscriptionParams params);
 }

--- a/lib/src/spec/push/push.dart
+++ b/lib/src/spec/push/push.dart
@@ -1,48 +1,112 @@
 import '../common.dart';
 
+/// Manage push notification channel subscriptions for devices or clients
 abstract class PushChannelSubscriptions {
-  Future<PushChannelSubscription> save(PushChannelSubscription subscription);
-
+  /// List channel subscriptions filtered by optional params.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c1
   Future<PaginatedResultInterface<PushChannelSubscription>> list(
     PushChannelSubscriptionParams params,
   );
 
+  /// List channels with at least one subscribed device.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c2
   Future<PaginatedResultInterface<String>> listChannels(
     PushChannelsParams params,
   );
 
+  /// Save push channel subscription for a device or client ID.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c3
+  Future<PushChannelSubscription> save(PushChannelSubscription subscription);
+
+  /// Remove a push channel subscription.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c4
   Future<void> remove(PushChannelSubscription subscription);
 
+  /// Remove all matching push channel subscriptions.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c5
   Future<void> removeWhere(PushChannelSubscriptionParams params);
 }
 
+/// Manage device registrations for push notifications
 abstract class PushDeviceRegistrations {
-  Future<DeviceDetails> save(DeviceDetails deviceDetails);
-
+  /// Get registered device by device ID.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b1
   Future<DeviceDetails> get({
     DeviceDetails deviceDetails,
     String deviceId,
   });
 
+  /// List registered devices filtered by optional params.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b2
   Future<PaginatedResultInterface<DeviceDetails>> list(
-    DeviceRegistrationParams params,
-  );
+    DeviceRegistrationParams params,);
 
+  /// Save and register device.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b3
+  Future<DeviceDetails> save(DeviceDetails deviceDetails);
+
+  /// Remove device.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b4
   Future<void> remove({
     DeviceDetails deviceDetails,
     String deviceId,
   });
 
+  /// Remove device matching where params.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b5
   Future<void> removeWhere(DeviceRegistrationParams params);
 }
 
+/// Class providing push notification administrative functionality
+/// for registering devices and attaching to channels etc.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH1
 abstract class PushAdmin {
+  /// Manage device registrations.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1b
   PushDeviceRegistrations deviceRegistrations;
+
+  /// Manage channel subscriptions for devices or clients.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1c
   PushChannelSubscriptions channelSubscriptions;
 
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1a
   Future<void> publish(Map<String, dynamic> recipient, Map payload);
 }
 
-class Push {
+/// Class providing push notification functionality
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSH1
+abstract class Push {
+  /// Admin features for push notifications like managing devices
+  /// and channel subscriptions.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH1
   PushAdmin admin;
+
+  /// Activate this device for push notifications by registering
+  /// with the push transport such as GCM/APNS.
+  ///
+  /// returns DeviceDetails
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH2a
+  Future<DeviceDetails> activate();
+
+  /// Deactivate this device for push notifications by removing
+  /// the registration with the push transport such as GCM/APNS.
+  ///
+  /// returns deviceId
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH2b
+  Future<String> deactivate();
 }

--- a/lib/src/spec/realtime/channels.dart
+++ b/lib/src/spec/realtime/channels.dart
@@ -1,41 +1,83 @@
+import 'dart:async';
+
+import '../../../ably_flutter_plugin.dart';
 import '../common.dart';
 import '../enums.dart';
 import '../message.dart';
 import '../push/channels.dart';
-import '../rest/ably_base.dart';
 import '../rest/channels.dart';
 import 'presence.dart';
+import 'realtime.dart';
 
+/// A named channel through with realtime client can interact with ably service.
+///
+/// The same channel can be interacted with relevant APIs via rest channel.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTL1
 abstract class RealtimeChannelInterface
     extends EventEmitter<ChannelEvent, ChannelStateChange> {
+  /// creates a Realtime channel instance
   RealtimeChannelInterface(
-    this.ably,
+    this.realtime,
     this.name,
     this.options,
   );
 
-  AblyBase ably;
+  /// realtime client instance
+  RealtimeInterface realtime;
 
-  final String name; //Not in IDL
-  final ChannelOptions options; //Not in IDL
+  /// name of the channel
+  final String name;
 
+  /// channel options
+  final ChannelOptions options;
+
+  /// will hold reason for failure of attaching to channel in such cases
   ErrorInfo errorReason;
+
+  /// current state of channel
   ChannelState state;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL9
   RealtimePresence presence;
 
-//  ChannelProperties properties;
+  // TODO(tihoic) RTL15 - experimental, ChannelProperties properties;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSH4
+  /// (see IDL for more details)
   PushChannel push;
+
+  /// modes of this channel as returned by Ably server
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL4m
   List<ChannelMode> modes;
+
+  /// Subset of the params passed via [ClientOptions]
+  /// that the server has recognised and validated
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL4k
   Map<String, String> params;
 
+  /// Attaches the realtime client to this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL4
   Future<void> attach();
 
+  /// Detaches the realtime client from this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL5
   Future<void> detach();
 
+  /// returns channel history based on filters passed as [params]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL10
   Future<PaginatedResultInterface<Message>> history([
     RealtimeHistoryParams params,
   ]);
 
+  /// publishes messages onto the channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL6
   Future<void> publish({
     Message message,
     List<Message> messages,
@@ -43,15 +85,33 @@ abstract class RealtimeChannelInterface
     Object data,
   });
 
+  /// subscribes for messages on this channel
+  ///
+  /// there is no unsubscribe api in flutter like in other Ably client SDK's
+  /// as subscribe returns a stream which can be cancelled
+  /// by calling [StreamSubscription.cancel]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL7
   Stream<Message> subscribe({
     String name,
     List<String> names,
   });
 
-  void setOptions(ChannelOptions options);
+  /// takes a ChannelOptions object and sets or updates the
+  /// stored channel options
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTL16
+  Future<void> setOptions(ChannelOptions options);
 }
 
+/// A collection of realtime channel objects
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTS1
 abstract class RealtimeChannels<T extends RealtimeChannelInterface>
-  extends Channels<T> {
-  RealtimeChannels(AblyBase ably) : super(ably);
+    extends Channels<T> {
+  /// instance of ably realtime client
+  RealtimeInterface realtime;
+
+  /// instantiates with the ably [RealtimeInterface] instance
+  RealtimeChannels(this.realtime);
 }

--- a/lib/src/spec/realtime/channels.dart
+++ b/lib/src/spec/realtime/channels.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import '../../../ably_flutter_plugin.dart';
+import '../../../ably_flutter.dart';
 import '../common.dart';
 import '../enums.dart';
 import '../message.dart';

--- a/lib/src/spec/realtime/channels.dart
+++ b/lib/src/spec/realtime/channels.dart
@@ -6,9 +6,9 @@ import '../rest/ably_base.dart';
 import '../rest/channels.dart';
 import 'presence.dart';
 
-abstract class RealtimeChannel
+abstract class RealtimeChannelInterface
     extends EventEmitter<ChannelEvent, ChannelStateChange> {
-  RealtimeChannel(
+  RealtimeChannelInterface(
     this.ably,
     this.name,
     this.options,
@@ -51,6 +51,7 @@ abstract class RealtimeChannel
   void setOptions(ChannelOptions options);
 }
 
-abstract class RealtimeChannels<T extends RealtimeChannel> extends Channels<T> {
+abstract class RealtimeChannels<T extends RealtimeChannelInterface>
+  extends Channels<T> {
   RealtimeChannels(AblyBase ably) : super(ably);
 }

--- a/lib/src/spec/realtime/presence.dart
+++ b/lib/src/spec/realtime/presence.dart
@@ -1,39 +1,78 @@
+import 'dart:async';
+
 import '../common.dart';
 import '../enums.dart';
 import '../message.dart';
+import 'channels.dart';
 
+/// Presence object on a [RealtimeChannelInterface] helps to query
+/// Presence members and presence history
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTP1
 abstract class RealtimePresence {
+  /// Returns true when the initial member SYNC following
+  /// channel attach is completed.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP13
   bool syncComplete;
 
+  /// Get the presence members for this Channel.
+  ///
+  /// filters the results if [params] are passed
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP11
   Future<List<PresenceMessage>> get([RealtimePresenceParams params]);
 
+  /// Return the presence messages history for the channel as a PaginatedResult
+  ///
+  /// filters the results if [params] are passed
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP12
   Future<PaginatedResultInterface<PresenceMessage>> history([
     RealtimeHistoryParams params,
   ]);
 
-  Future<void> subscribe({
+  /// subscribes to presence messages on a realtime channel
+  ///
+  /// there is no unsubscribe api in flutter like in other Ably client SDK's
+  /// as subscribe returns a stream which can be cancelled
+  /// by calling [StreamSubscription.cancel]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP6
+  Future<Stream<PresenceMessage>> subscribe({
     PresenceAction action,
     List<PresenceAction> actions,
     EventListener<PresenceMessage> listener,
-    //TODO(tiholic) check if this is the expected type for listener
   });
 
-  void unsubscribe({
-    PresenceAction action,
-    List<PresenceAction> actions,
-    EventListener<PresenceMessage> listener,
-    //TODO(tiholic) check if this is the expected type for listener
-  });
-
+  /// Enters the current client into this channel, optionally with the data
+  /// and/or extras provided
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP8
   Future<void> enter([Object data]);
 
+  /// Enter the specified client_id into this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP15
+  Future<void> enterClient(String clientId, [Object data]);
+
+  /// Update the presence data for this client.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP9
   Future<void> update([Object data]);
 
+  /// Update the presence data for a specified client_id into this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP15
+  Future<void> updateClient(String clientId, [Object data]);
+
+  /// Leave this client from this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP10
   Future<void> leave([Object data]);
 
-  Future<void> enterClient({String clientId, Object data});
-
-  Future<void> updateClient({String clientId, Object data});
-
-  Future<void> leaveClient({String clientId, Object data});
+  /// Leave a given client_id from this channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTP15
+  Future<void> leaveClient(String clientId, [Object data]);
 }

--- a/lib/src/spec/realtime/realtime.dart
+++ b/lib/src/spec/realtime/realtime.dart
@@ -3,7 +3,11 @@ import '../rest/ably_base.dart';
 import '../rest/options.dart';
 import 'channels.dart';
 
+/// an abstract class for Ably's Realtime client
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RTC1
 abstract class RealtimeInterface<C extends RealtimeChannels> extends AblyBase {
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC1
   RealtimeInterface({
     ClientOptions options,
     final String key,
@@ -12,13 +16,19 @@ abstract class RealtimeInterface<C extends RealtimeChannels> extends AblyBase {
           key: key,
         );
 
-  String clientId;
-
+  /// closes the [connection]
   void close();
 
+  /// connects to [connection]
   void connect();
 
+  /// Provides access to the underlying Connection object
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC2
   ConnectionInterface get connection;
 
+  /// collection of [RealtimeChannelInterface] objects
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC3
   C get channels;
 }

--- a/lib/src/spec/realtime/realtime.dart
+++ b/lib/src/spec/realtime/realtime.dart
@@ -18,7 +18,7 @@ abstract class RealtimeInterface<C extends RealtimeChannels> extends AblyBase {
 
   void connect();
 
-  Connection get connection;
+  ConnectionInterface get connection;
 
   C get channels;
 }

--- a/lib/src/spec/rest/ably_base.dart
+++ b/lib/src/spec/rest/ably_base.dart
@@ -1,35 +1,44 @@
 import 'package:flutter/foundation.dart';
 
+import '../../../ably_flutter_plugin.dart';
 import '../auth.dart';
 import '../common.dart';
-import '../message.dart';
 import '../push/push.dart';
 import 'options.dart';
 
-abstract class Crypto {
-  String generateRandomKey();
-}
-
-///io.ably.lib.rest.AblyBase
+/// A base class for [Rest] and [Realtime]
 abstract class AblyBase {
+  /// takes [ClientOptions] or a [key] string to authenticate with ably
   AblyBase({
     ClientOptions options,
     final String key,
-  }) : assert(options != null || key != null) {
-    this.options = (options == null) ? ClientOptions.fromKey(key) : options;
-  }
+  })  : assert(options != null || key != null),
+        options = (options == null) ? ClientOptions.fromKey(key) : options;
 
-  ClientOptions options;
-  static Crypto crypto;
-  static MessageStatic message;
-  static PresenceMessageStatic presenceMessage;
+  /// [ClientOptions] indicating authentication and other settings for this
+  /// instance to interact with ably service
+  final ClientOptions options;
+
+  /// a custom auth object to perform authentication related operations
+  /// based on the [options]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSC5
   Auth auth;
+
+  /// a push object interacting with Push API
+  /// viz., subscribing for push notifications, etc
   Push push;
 
+  /// gets stats based on params as a [PaginatedResult]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSC6
   Future<PaginatedResultInterface<Stats>> stats([
     Map<String, dynamic> params,
   ]);
 
+  /// creates and sends a raw request to ably service
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSC19
   Future<HttpPaginatedResponse> request({
     @required String method,
     @required String path,
@@ -38,5 +47,8 @@ abstract class AblyBase {
     Map<String, String> headers,
   });
 
+  /// returns server time
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSC16
   Future<DateTime> time();
 }

--- a/lib/src/spec/rest/ably_base.dart
+++ b/lib/src/spec/rest/ably_base.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/foundation.dart';
 
-import '../../../ably_flutter_plugin.dart';
+import '../../../ably_flutter.dart';
 import '../auth.dart';
 import '../common.dart';
 import '../push/push.dart';

--- a/lib/src/spec/rest/channels.dart
+++ b/lib/src/spec/rest/channels.dart
@@ -1,4 +1,4 @@
-import '../../../ably_flutter_plugin.dart';
+import '../../../ably_flutter.dart';
 import '../common.dart';
 import '../message.dart';
 import 'presence.dart';

--- a/lib/src/spec/rest/channels.dart
+++ b/lib/src/spec/rest/channels.dart
@@ -1,37 +1,75 @@
+import '../../../ably_flutter_plugin.dart';
 import '../common.dart';
 import '../message.dart';
-import 'ably_base.dart';
 import 'presence.dart';
 
+/// options provided when instantiating a channel
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TB1
 abstract class ChannelOptions {
+  /// https://docs.ably.io/client-lib-development-guide/features/#TB2b
   dynamic cipher;
+// TODO add params and modes for realtime channel options
 }
 
+/// A named channel through with rest client can interact with ably service.
+///
+/// The same channel can be interacted with relevant APIs via realtime channel.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSL1
 abstract class RestChannelInterface {
+  /// creates a Rest channel instance
   RestChannelInterface(
-    this.ably,
+    this.rest,
     this.name,
     this.options,
-  ) {
-    presence = Presence();
-  }
+  );
 
-  AblyBase ably;
+  /// reference to Rest client
+  RestInterface rest;
+
+  /// name of the channel
   String name;
-  ChannelOptions options;
-  Presence presence;
 
+  /// options of the channel
+  ChannelOptions options;
+
+  /// presence interface for this channel
+  ///
+  /// can only query presence on the channel and presence history
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSL3
+  RestPresenceInterface presence;
+
+  /// fetch message history on this channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSL2
   Future<PaginatedResultInterface<Message>> history([RestHistoryParams params]);
 
+  /// publish messages on this channel
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSL1
   Future<void> publish({
     Message message,
     List<Message> messages,
     String name,
     Object data,
   });
+
+  /// takes a ChannelOptions object and sets or updates the
+  /// stored channel options, then indicates success
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSL7
+  Future<void> setOptions(ChannelOptions options);
 }
 
+/// A collection of rest channel objects
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
 abstract class RestChannels<T extends RestChannelInterface>
-  extends Channels<T> {
-  RestChannels(AblyBase ably) : super(ably);
+    extends Channels<T> {
+  /// instance of a rest client
+  RestInterface rest;
+
+  /// instantiates with the ably [RestInterface] instance
+  RestChannels(this.rest);
 }

--- a/lib/src/spec/rest/channels.dart
+++ b/lib/src/spec/rest/channels.dart
@@ -7,8 +7,8 @@ abstract class ChannelOptions {
   dynamic cipher;
 }
 
-abstract class RestChannel {
-  RestChannel(
+abstract class RestChannelInterface {
+  RestChannelInterface(
     this.ably,
     this.name,
     this.options,
@@ -31,6 +31,7 @@ abstract class RestChannel {
   });
 }
 
-abstract class RestChannels<T extends RestChannel> extends Channels<T> {
+abstract class RestChannels<T extends RestChannelInterface>
+  extends Channels<T> {
   RestChannels(AblyBase ably) : super(ably);
 }

--- a/lib/src/spec/rest/options.dart
+++ b/lib/src/spec/rest/options.dart
@@ -1,6 +1,5 @@
 import '../../../ably_flutter.dart';
 import '../common.dart';
-import '../enums.dart';
 
 /// Function-type alias implemented by a function that provides either tokens,
 /// or signed token requests, in response to a request with given token params.
@@ -9,7 +8,15 @@ import '../enums.dart';
 /// returns either a [String] token or [TokenDetails] or [TokenRequest]
 typedef AuthCallback = Future<dynamic> Function(TokenParams params);
 
+/// A class providing configurable authentication options used when
+/// authenticating or issuing tokens explicitly.
+///
+/// These options are used when invoking Auth#authorize, Auth#requestToken,
+/// Auth#createTokenRequest and Auth#authorize.
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#AO1
 abstract class AuthOptions {
+  /// initializes an instance without any defaults
   AuthOptions();
 
   /// Convenience constructor, to create an AuthOptions based
@@ -23,100 +30,275 @@ abstract class AuthOptions {
     }
   }
 
-  ///A function which is called when a new token is required.
-  ///The role of the callback is to either generate
-  /// a signed TokenRequest which may then be submitted automatically
-  ///by the library to the Ably REST API requestToken;
-  /// or to provide a valid token in as a TokenDetails object.
+  /// A function which is called when a new token is required.
+  ///
+  /// The role of the callback is to either generate a signed [TokenRequest]
+  /// which may then be submitted automatically by the library to
+  /// the Ably REST API requestToken; or to provide a valid token
+  /// as a [TokenDetails] object.
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2b
   AuthCallback authCallback;
 
-  ///A URL that the library may use to obtain a
-  /// token String (in plain text format),
-  /// or a signed TokenRequest or TokenDetails (in JSON format).
-  String authUrl; //optional
-  HTTPMethods authMethod; //optional
-  String key; //optional
+  /// A URL that the library may use to obtain
+  /// a token String (in plain text format),
+  /// or a signed [TokenRequest] or [TokenDetails] (in JSON format).
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2c
+  String authUrl;
 
-  TokenDetails tokenDetails; //optional
+  /// HTTP Method used when a request is made using authURL
+  ///
+  /// defaults to 'GET', supports 'GET' and 'POST'
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2d
+  String authMethod;
 
-  Map<String, String> authHeaders; //optional
-  Map<String, String> authParams; //optional
+  /// Full Ably key string, as obtained from dashboard,
+  /// used when signing token requests locally
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2a
+  String key;
 
-  bool queryTime; //optional
-  bool useTokenAuth; //optional
+  /// An authentication token issued for this application
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2i
+  TokenDetails tokenDetails;
+
+  /// Headers to be included in any request made to the [authUrl]
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2e
+  Map<String, String> authHeaders;
+
+  /// Additional params to be included in any request made to the [authUrl]
+  ///
+  /// As query params in the case of GET
+  /// and as form-encoded in the body in the case of POST
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2f
+  Map<String, String> authParams;
+
+  /// If true, the library will when issuing a token request query
+  /// the Ably system for the current time instead of relying on a
+  /// locally-available time of day.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#AO2g
+  bool queryTime;
+
+  /// Token Auth is used if useTokenAuth is set to true
+  ///
+  /// or if useTokenAuth is unspecified and any one of
+  /// [authUrl], [authCallback], token, or [TokenDetails] is provided
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSA4
+  bool useTokenAuth;
+
+// TODO(tiholic) missing token attribute here
+//  see: https://docs.ably.io/client-lib-development-guide/features/#AO2h
 }
 
+/// Custom handler to handle SDK log messages
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TO3c
 typedef LogHandler = void Function({
   String msg,
   AblyException exception,
 });
 
+/// Ably library options used when instancing a REST or Realtime client library
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#TO1
 class ClientOptions extends AuthOptions {
+  /// initializes [ClientOptions] with log level set to info
   ClientOptions() {
     logLevel = LogLevel.info;
   }
 
+  /// initializes [ClientOptions] with a key and log level set to info
+  ///
+  /// See [AuthOptions.fromKey] for more details
   ClientOptions.fromKey(String key) : super.fromKey(key) {
     logLevel = LogLevel.info;
   }
 
-  ///Optional clientId that can be used to specify the identity for this client.
+  /// Optional clientId that can be used to specify the identity for this client
+  ///
   /// In most cases it is preferable to instead specific a clientId in the token
   /// issued to this client.
-  String clientId; //optional
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3a
+  String clientId;
 
-  ///Logger configuration
-  LogHandler logHandler; //optional
-  int logLevel; //optional
+  /// Custom log handler
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3c
+  LogHandler logHandler;
 
-  String restHost; //optional
-  String realtimeHost; //optional
-  int port; //optional
+  /// Controls the level of verbosity of log messages from the library
+  ///
+  /// Use constants from [LogLevel] to pass arguments
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3b
+  int logLevel;
 
-  ///Use a non-secure connection connection. By default,
-  /// a TLS connection is used to connect to Ably
-  bool tls; //optional
-  int tlsPort; //optional
+  /// for development environments only
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k2
+  String restHost;
 
-  ///When true will automatically connect to Ably when library is instanced.
-  /// This is true by default
-  bool autoConnect; //optional
+  /// for development environments only
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k3
+  String realtimeHost;
 
-  /// When true, the more efficient MsgPack binary encoding is used.
-  /// When false, JSON text encoding is used.
-  bool useBinaryProtocol; //optional
+  /// for development environments only
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k4
+  int port;
 
-  ///When true, messages will be queued whilst the connection is disconnected.
+  /// Use a non-secure connection connection.
+  ///
+  /// By default, a TLS connection is used to connect to Ably
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3d
+  bool tls;
+
+  /// for development environments only
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k5
+  int tlsPort;
+
+  /// When true will automatically connect to Ably when library is instanced.
+  ///
+  /// This is true by default. If false, will wait for an explicit
+  /// [Connection]#connect to be called before connecting
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC1b
+  bool autoConnect;
+
+  /// Decides whether to use MsgPack binary encoding or JSON encoding.
+  ///
+  /// Defaults to true. If false, JSON encoding is used for REST and Realtime
+  /// operations, instead of the default binary msgpack encoding.
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3f
+  bool useBinaryProtocol;
+
+  /// When true, messages will be queued whilst the connection is disconnected.
+  ///
   /// True by default.
-  bool queueMessages; //optional
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3g
+  bool queueMessages;
 
-  ///When true, messages published on channels by this client will be
-  /// echoed back to this client. This is true by default
-  bool echoMessages; //optional;
+  /// When true, messages published on channels by this client will be
+  /// echoed back to this client.
+  ///
+  /// This is true by default.
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3h
+  bool echoMessages;
 
-  ///Can be used to explicitly recover a connection.
-  ///See https://www.ably.io/documentation/realtime/connection#connection-state-recovery
+  /// Can be used to explicitly recover a connection.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3i
+  /// Also see https://www.ably.io/documentation/realtime/connection#connection-state-recovery
   String recover;
 
-  ///Use this only if you have been provided a dedicated environment by Ably
-  String environment; //optional
+  /// for development environments only
+  ///
+  /// Use this only if you have been provided a dedicated environment by Ably
+  String environment;
 
-  // Fallbacks
-  List<String> fallbackHosts; //optional
-  bool fallbackHostsUseDefault; //optional
+  /// for development environments only
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k6
+  List<String> fallbackHosts;
 
-  TokenParams defaultTokenParams; //optional
+  /// for development environments only;
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3k7
+  @Deprecated('no alternative to this')
+  bool fallbackHostsUseDefault;
 
-  int disconnectedRetryTimeout; //optional
-  int suspendedRetryTimeout; //optional
-  bool idempotentRestPublishing; //optional
-  Map<String, String> transportParams; //optional
+  /// When a TokenParams object is provided, it will override
+  /// the client library defaults described in TokenParams
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3j11
+  TokenParams defaultTokenParams;
 
+  /// When the connection enters the [ConnectionState.disconnected] state,
+  /// after this delay in milliseconds, if the state is still
+  /// [ConnectionState.disconnected], the client library will
+  /// attempt to reconnect automatically
+  ///
+  /// default 15,000 (15 seconds)
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l1
+  int disconnectedRetryTimeout;
+
+  /// When the connection enters the [ConnectionState.suspended] state,
+  /// after this delay in milliseconds, if the state is still
+  /// [ConnectionState.suspended], the client library will
+  /// attempt to reconnect automatically
+  ///
+  /// default 30,000 (30 seconds)
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l2
+  int suspendedRetryTimeout;
+
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3n
+  bool idempotentRestPublishing;
+
+  /// Additional parameters to be sent in the querystring when initiating
+  /// a realtime connection
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC1f
+  Map<String, String> transportParams;
+
+  /// Timeout for opening the connection, available in the client library
+  /// if supported by the transport
+  ///
+  /// default 4,000 (4s)
+  /// https://docs.ably.io/client-lib-development-guide/features/#RTC1f
   int httpOpenTimeout;
+
+  /// Timeout for any single HTTP request and response
+  ///
+  /// default 10,000 (10s)
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l4
   int httpRequestTimeout;
 
+  /// Max number of fallback hosts to use as a fallback when an HTTP request
+  /// to the primary host is unreachable or indicates that it is unserviceable
+  ///
+  /// default 3
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l5
   int httpMaxRetryCount;
+
+  /// When a realtime client library is establishing a connection with Ably,
+  /// or sending a HEARTBEAT, CONNECT, ATTACH, DETACH or CLOSE ProtocolMessage
+  /// to Ably, this is the amount of time that the client library will wait
+  /// before considering that request as failed and triggering a suitable
+  /// failure condition
+  ///
+  /// default 10s
+  /// https://docs.ably.io/client-lib-development-guide/features/#DF1b
   int realtimeRequestTimeout;
+
+  /// After a failed request to the default endpoint,
+  /// followed by a successful request to a fallback endpoint,
+  /// the period in milliseconds before HTTP requests are retried
+  /// against the default endpoint
+  ///
+  /// default 600000 (10 minutes)
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l10
   int fallbackRetryTimeout;
+
+  /// When a channel becomes [ChannelState.suspended] following a server
+  /// initiated [ChannelState.detached], after this delay in milliseconds,
+  /// if the channel is still [ChannelState.suspended] and the connection
+  /// is [ConnectionState.connected], the client library will attempt
+  /// to re-attach the channel automatically
+  ///
+  /// default 15,000 (15s)
+  /// https://docs.ably.io/client-lib-development-guide/features/#TO3l7
   int channelRetryTimeout;
+
+// TODO(tiholic) unimplemented:
+//
+//  (TO3m) logExceptionReportingUrl
+//  (TO3l6) httpMaxRetryDuration
+//  (TO3l8) maxMessageSize
+//  (TO3l9) maxFrameSize
+//  (TO3o) plugins
+//  (TO3p) addRequestIds
+//  (DF1a) connectionStateTtl
 }

--- a/lib/src/spec/rest/options.dart
+++ b/lib/src/spec/rest/options.dart
@@ -164,7 +164,7 @@ class ClientOptions extends AuthOptions {
   /// When true will automatically connect to Ably when library is instanced.
   ///
   /// This is true by default. If false, will wait for an explicit
-  /// [Connection]#connect to be called before connecting
+  /// [ConnectionInterface]#connect to be called before connecting
   /// https://docs.ably.io/client-lib-development-guide/features/#RTC1b
   bool autoConnect;
 

--- a/lib/src/spec/rest/presence.dart
+++ b/lib/src/spec/rest/presence.dart
@@ -1,16 +1,23 @@
 import '../common.dart';
 import '../message.dart';
+import 'channels.dart';
 
-class Presence {
+/// Presence object on a [RestChannelInterface] helps to query Presence members
+/// and presence history
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSP1
+abstract class RestPresenceInterface {
+  /// Obtain the set of members currently present for a channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSP3
   Future<PaginatedResultInterface<PresenceMessage>> get([
     RestPresenceParams params,
-  ]) {
-    throw UnimplementedError();
-  }
+  ]);
 
+  /// Return the presence messages history for the channel.
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSP4
   Future<PaginatedResultInterface<PresenceMessage>> history([
     RestHistoryParams params,
-  ]) {
-    throw UnimplementedError();
-  }
+  ]);
 }

--- a/lib/src/spec/rest/rest.dart
+++ b/lib/src/spec/rest/rest.dart
@@ -8,7 +8,7 @@ import 'options.dart';
 ///
 /// https://docs.ably.io/client-lib-development-guide/features/#RSC1
 abstract class RestInterface<C extends RestChannels> extends AblyBase {
-  /// collection of [RestChannel] objects
+  /// collection of [RestChannelInterface] objects
   ///
   /// https://docs.ably.io/client-lib-development-guide/features/#RSN1
   C channels;

--- a/lib/src/spec/rest/rest.dart
+++ b/lib/src/spec/rest/rest.dart
@@ -4,9 +4,16 @@ import 'ably_base.dart';
 import 'channels.dart';
 import 'options.dart';
 
+/// an abstract class for Ably's Rest client
+///
+/// https://docs.ably.io/client-lib-development-guide/features/#RSC1
 abstract class RestInterface<C extends RestChannels> extends AblyBase {
+  /// collection of [RestChannel] objects
+  ///
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSN1
   C channels;
 
+  /// https://docs.ably.io/client-lib-development-guide/features/#RSC1
   RestInterface({
     ClientOptions options,
     final String key,
@@ -14,25 +21,4 @@ abstract class RestInterface<C extends RestChannels> extends AblyBase {
           options: options,
           key: key,
         );
-
-/*Future<PaginatedResult<Stats>> stats([Map<String, dynamic> params]){
-    //TO-DO implement
-    return null;
-  }
-  Future<HttpPaginatedResponse> request({
-    @required String method,
-    @required String path,
-    Map<String, dynamic> params,
-    dynamic body,
-    Map<String, String> headers
-  }){
-    //TO-DO implement
-    return null;
-  }
-
-  Future<int> time(){
-    //TO-DO implement
-    return null;
-  }*/
-
 }

--- a/test_integration/analysis_options.yaml
+++ b/test_integration/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false
+    public_member_api_docs: false

--- a/test_integration/pubspec.lock
+++ b/test_integration/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "12.0.0"
   ably_flutter:
     dependency: "direct main"
     description:
@@ -21,7 +21,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.15"
+    version: "0.40.6"
   archive:
     dependency: transitive
     description:
@@ -70,7 +70,7 @@ packages:
       name: cli_util
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.4"
+    version: "0.2.0"
   clock:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.14.0"
+    version: "0.14.2"
   crypto:
     dependency: transitive
     description:
@@ -106,13 +106,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.5"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.2"
   fake_async:
     dependency: transitive
     description:
@@ -154,13 +147,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
   http:
     dependency: transitive
     description:
@@ -188,7 +174,7 @@ packages:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.4"
+    version: "0.3.5"
   js:
     dependency: transitive
     description:
@@ -230,14 +216,14 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "0.9.7"
   node_interop:
     dependency: transitive
     description:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.1"
   node_io:
     dependency: transitive
     description:
@@ -251,7 +237,7 @@ packages:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.12"
+    version: "1.4.13"
   package_config:
     dependency: transitive
     description:
@@ -307,28 +293,28 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+2"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.3"
+    version: "0.2.4+1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -431,7 +417,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "5.5.0"
   vm_service_client:
     dependency: transitive
     description:
@@ -466,7 +452,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.5"
   yaml:
     dependency: transitive
     description:

--- a/test_integration/test_driver/test_implementation/basic_platform_tests.dart
+++ b/test_integration/test_driver/test_implementation/basic_platform_tests.dart
@@ -1,4 +1,3 @@
-//ignore_for_file: avoid_print
 import 'package:ably_flutter_integration_test/driver_data_handler.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
1. Adding docstrings to all public members

2. Rename few abstract methods as `xxxInterface` and name the implementations as `xxx`
> ex: `abstract RestChannels` -> `abstract RestChannelsInterface` and `RestChannelPlatformObject` -> `RestChannel`

This is done as a prerequisite to improvising the members of library that are supposed to be available via library import ( `import 'package:ably_flutter_plugin/ably_flutter_plugin.dart';`)

> _No logical/API changes were made as a part of this PR - and no changes to integration tests_