### PR TITLE
Preview Release - 1.2.0 preview.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Changelog
 
+## [1.2.0-preview.2](https://github.com/ably/ably-flutter/tree/1.2.0-preview.2)
+
+[Full Changelog](https://github.com/ably/ably-flutter/compare/1.2.0-preview.1...1.2.0-preview.2)
+
+**Implemented enhancements:**
+
+- Presence subscription example [\#53](https://github.com/ably/ably-flutter/issues/53)
+- typed Message\#data [\#35](https://github.com/ably/ably-flutter/issues/35)
+
+**Fixed bugs:**
+
+- compilation error on iOS [\#112](https://github.com/ably/ably-flutter/issues/112)
+
+**Merged pull requests:**
+
+- Fix iOS issue with token details auth [\#115](https://github.com/ably/ably-flutter/pull/115) ([tiholic](https://github.com/tiholic))
+- Add docs workflow [\#97](https://github.com/ably/ably-flutter/pull/97) ([QuintinWillison](https://github.com/QuintinWillison))
+- Realtime Presence [\#81](https://github.com/ably/ably-flutter/pull/81) ([tiholic](https://github.com/tiholic))
+- Feature/rest presence history [\#70](https://github.com/ably/ably-flutter/pull/70) ([tiholic](https://github.com/tiholic))
+- Feature/docstrings [\#69](https://github.com/ably/ably-flutter/pull/69) ([tiholic](https://github.com/tiholic))
+- Rest Channel Presence\#get [\#55](https://github.com/ably/ably-flutter/pull/55) ([tiholic](https://github.com/tiholic))
+
 ## [1.2.0-preview.1](https://github.com/ably/ably-flutter/tree/1.2.0-preview.1)
 
 [Full Changelog](https://github.com/ably/ably-flutter/compare/1.0.0+dev.2...1.2.0-preview.1)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/ably/ably-flutter
 
 environment:
   sdk: ">=2.6.0 <3.0.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=1.17.0"
 
 dependencies:
   collection: ^1.14.13

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ably_flutter
 description: A wrapper around Ably's Cocoa and Java client library SDKs, providing iOS and Android support.
-version: 1.2.0-preview.1
+version: 1.2.0-preview.2
 repository: https://github.com/ably/ably-flutter
 
 environment:


### PR DESCRIPTION
I did a publication dry run before I pushed this branch up which is why there's [an extra commit](https://github.com/ably/ably-flutter/commit/88414c298d3cc3ac2c4ba7240bd207d8c2d5dd4a).

Once this pull request lands then I shall:

1. Create and push the `1.2.0-preview.2` tag
2. Publish to pub.dev
3. Create release with "Pre-release" attribution, per [1.2.0, Preview 1](https://github.com/ably/ably-flutter/releases/tag/1.2.0-preview.1)