### PR TITLE
Bug fix: Reactivating devices for Push

### DIFF
--- a/ios/Classes/handlers/PushActivationEventHandlers.swift
+++ b/ios/Classes/handlers/PushActivationEventHandlers.swift
@@ -32,7 +32,7 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
     
     public func didActivateAblyPush(_ error: ARTErrorInfo?) {
         defer {
-            flutterResultForDeactivate = nil
+            flutterResultForActivate = nil
         }
         
         guard let result = flutterResultForActivate else {


### PR DESCRIPTION
Users currently cannot **deactivate then reactivate** their device for push, without relaunching the app. If they attempt to do so, an exception will be thrown by:
https://github.com/ably/ably-flutter/blob/d5438808a2e43eb75c9c74ed8d192efddca8e545/ios/Classes/handlers/PushHandlers.swift#L36-L39

**Temporary workaround:** Users would have to restart their app to reactivate devices for push to temporarily workaround this issue.

This issue exists because a wrong variable was used, and this has been fixed in this PR.