### PR TITLE
Get DevicePushDetails (e.g. state) by making network request

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -31,9 +31,11 @@ final public class PlatformConstants {
         public static final byte pushChannelSubscription = (byte) 147;
         public static final byte unNotificationSettings = (byte) 148;
         public static final byte remoteMessage = (byte) 149;
-        public static final byte errorInfo = (byte) 150;
-        public static final byte connectionStateChange = (byte) 151;
-        public static final byte channelStateChange = (byte) 152;
+        public static final byte devicePushDetails = (byte) 150;
+        public static final byte devicePushState = (byte) 151;
+        public static final byte errorInfo = (byte) 152;
+        public static final byte connectionStateChange = (byte) 153;
+        public static final byte channelStateChange = (byte) 154;
     }
 
     static final public class PlatformMethod {
@@ -66,6 +68,7 @@ final public class PlatformConstants {
         public static final String realtimeHistory = "realtimeHistory";
         public static final String pushActivate = "pushActivate";
         public static final String pushDeactivate = "pushDeactivate";
+        public static final String pushGetDevicePushDetails = "pushGetDevicePushDetails";
         public static final String pushSubscribeDevice = "pushSubscribeDevice";
         public static final String pushUnsubscribeDevice = "pushUnsubscribeDevice";
         public static final String pushSubscribeClient = "pushSubscribeClient";
@@ -253,6 +256,7 @@ final public class PlatformConstants {
         public static final String active = "active";
         public static final String failing = "failing";
         public static final String failed = "failed";
+        public static final String unknown = "unknown";
     }
 
     static final public class TxConnectionStateChange {

--- a/bin/codegen_context.dart
+++ b/bin/codegen_context.dart
@@ -28,6 +28,8 @@ Iterable<Map<String, dynamic>> get _types sync* {
     'pushChannelSubscription',
     'unNotificationSettings',
     'remoteMessage',
+    'devicePushDetails',
+    'devicePushState',
 
     'errorInfo',
 
@@ -94,6 +96,7 @@ const List<Map<String, dynamic>> _platformMethods = [
   // Push Notifications
   {'name': 'pushActivate', 'value': 'pushActivate'},
   {'name': 'pushDeactivate', 'value': 'pushDeactivate'},
+  {'name': 'pushGetDevicePushDetails', 'value': 'pushGetDevicePushDetails'},
   {'name': 'pushSubscribeDevice', 'value': 'pushSubscribeDevice'},
   {'name': 'pushUnsubscribeDevice', 'value': 'pushUnsubscribeDevice'},
   {'name': 'pushSubscribeClient', 'value': 'pushSubscribeClient'},
@@ -322,7 +325,7 @@ const List<Map<String, dynamic>> _objects = [
   },
   {
     'name': 'DevicePushStateEnum',
-    'properties': <String>['active', 'failing', 'failed']
+    'properties': <String>['active', 'failing', 'failed', 'unknown']
   },
   {
     'name': 'ConnectionStateChange',

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -43,7 +43,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      launchStyle = "1"
+      launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"

--- a/example/lib/push_notifications/push_notification_service.dart
+++ b/example/lib/push_notifications/push_notification_service.dart
@@ -56,6 +56,14 @@ class PushNotificationService {
   late final ValueStream<ably.UNNotificationSettings>
       notificationSettingsStream = _notificationSettingsSubject.stream;
 
+  // This makes a network request, whereas _localDeviceSubject uses locally
+  // stored data. Use this to get the latest state from Ably servers, to find
+  // out if a message failed to be delivered.
+  final BehaviorSubject<ably.DevicePushDetails> _devicePushDetailsSubject =
+      BehaviorSubject();
+  late final ValueStream<ably.DevicePushDetails> pushStateStream =
+      _devicePushDetailsSubject.stream;
+
   void setRealtimeClient(ably.Realtime realtime) {
     this.realtime = realtime;
     _getChannels();
@@ -123,6 +131,16 @@ class PushNotificationService {
     } else {
       final localDevice = await rest!.device();
       _localDeviceSubject.add(localDevice);
+    }
+  }
+
+  Future<void> getPushState() async {
+    if (realtime != null) {
+      final pushState = await realtime!.push.getDevicePushDetails();
+      _devicePushDetailsSubject.add(pushState);
+    } else {
+      final pushState = await rest!.push.getDevicePushDetails();
+      _devicePushDetailsSubject.add(pushState);
     }
   }
 

--- a/example/lib/ui/push_notifications/push_notifications_device_information.dart
+++ b/example/lib/ui/push_notifications/push_notifications_device_information.dart
@@ -46,6 +46,26 @@ class PushNotificationsDeviceInformation extends StatelessWidget {
                         onPressed: _pushNotificationService.getDevice,
                         child: const Text('Refresh local device information'),
                       ),
+                      Row(
+                        children: [
+                          TextButton(
+                            onPressed: _pushNotificationService.getPushState,
+                            child: const Text('Get push state'),
+                          ),
+                          StreamBuilder(
+                            stream: _pushNotificationService.pushStateStream,
+                            builder: (context, snapshot) {
+                              if (!snapshot.hasData || snapshot.data == null) {
+                                return const Text('No push state yet.');
+                              } else {
+                                final devicePushDetails =
+                                    snapshot.data as ably.DevicePushDetails;
+                                return Text(devicePushDetails.state.toString());
+                              }
+                            },
+                          ),
+                        ],
+                      )
                     ],
                   );
                 }

--- a/ios/Classes/AblyFlutterPlugin.m
+++ b/ios/Classes/AblyFlutterPlugin.m
@@ -630,6 +630,7 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutterPlugin *const plugi
         AblyPlatformMethod_pushUnsubscribeClient: PushHandlers.unsubscribeClient,
         AblyPlatformMethod_pushListSubscriptions: PushHandlers.listSubscriptions,
         AblyPlatformMethod_pushDevice: PushHandlers.device,
+        AblyPlatformMethod_pushGetDevicePushDetails: PushHandlers.getDevicePushDetails,
         AblyPlatformMethod_pushNotificationTapLaunchedAppFromTerminated: PushHandlers.pushNotificationTapLaunchedAppFromTerminated,
     };
     

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -45,6 +45,8 @@ NS_ASSUME_NONNULL_END
         return unNotificationSettingsCodecType;
     } else if ([value isKindOfClass:[RemoteMessage class]]) {
         return remoteMessageCodecType;
+    } else if ([value isKindOfClass:[ARTDevicePushDetails class]]) {
+        return devicePushDetailsCodecType;
     }
     return 0;
 }
@@ -64,6 +66,7 @@ NS_ASSUME_NONNULL_END
         [NSString stringWithFormat:@"%d", pushChannelSubscriptionCodecType]: PushNotificationEncoders.encodePushChannelSubscription,
         [NSString stringWithFormat:@"%d", unNotificationSettingsCodecType]: PushNotificationEncoders.encodeUNNotificationSettings,
         [NSString stringWithFormat:@"%d", remoteMessageCodecType]: PushNotificationEncoders.encodeRemoteMessage,
+        [NSString stringWithFormat:@"%d", devicePushDetailsCodecType]: PushNotificationEncoders.encodeDevicePushDetails,
     };
     return [_handlers objectForKey:[NSString stringWithFormat:@"%@", type]];
 }

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -28,9 +28,11 @@ typedef NS_ENUM(UInt8, _Value) {
     pushChannelSubscriptionCodecType = 147,
     unNotificationSettingsCodecType = 148,
     remoteMessageCodecType = 149,
-    errorInfoCodecType = 150,
-    connectionStateChangeCodecType = 151,
-    channelStateChangeCodecType = 152,
+    devicePushDetailsCodecType = 150,
+    devicePushStateCodecType = 151,
+    errorInfoCodecType = 152,
+    connectionStateChangeCodecType = 153,
+    channelStateChangeCodecType = 154,
 };
 
 
@@ -64,6 +66,7 @@ extern NSString *const AblyPlatformMethod_releaseRealtimeChannel;
 extern NSString *const AblyPlatformMethod_realtimeHistory;
 extern NSString *const AblyPlatformMethod_pushActivate;
 extern NSString *const AblyPlatformMethod_pushDeactivate;
+extern NSString *const AblyPlatformMethod_pushGetDevicePushDetails;
 extern NSString *const AblyPlatformMethod_pushSubscribeDevice;
 extern NSString *const AblyPlatformMethod_pushUnsubscribeDevice;
 extern NSString *const AblyPlatformMethod_pushSubscribeClient;
@@ -234,6 +237,7 @@ extern NSString *const TxDevicePlatformEnum_browser;
 extern NSString *const TxDevicePushStateEnum_active;
 extern NSString *const TxDevicePushStateEnum_failing;
 extern NSString *const TxDevicePushStateEnum_failed;
+extern NSString *const TxDevicePushStateEnum_unknown;
 
 // key constants for ConnectionStateChange
 extern NSString *const TxConnectionStateChange_current;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -36,6 +36,7 @@ NSString *const AblyPlatformMethod_releaseRealtimeChannel= @"releaseRealtimeChan
 NSString *const AblyPlatformMethod_realtimeHistory= @"realtimeHistory";
 NSString *const AblyPlatformMethod_pushActivate= @"pushActivate";
 NSString *const AblyPlatformMethod_pushDeactivate= @"pushDeactivate";
+NSString *const AblyPlatformMethod_pushGetDevicePushDetails= @"pushGetDevicePushDetails";
 NSString *const AblyPlatformMethod_pushSubscribeDevice= @"pushSubscribeDevice";
 NSString *const AblyPlatformMethod_pushUnsubscribeDevice= @"pushUnsubscribeDevice";
 NSString *const AblyPlatformMethod_pushSubscribeClient= @"pushSubscribeClient";
@@ -206,6 +207,7 @@ NSString *const TxDevicePlatformEnum_browser = @"browser";
 NSString *const TxDevicePushStateEnum_active = @"active";
 NSString *const TxDevicePushStateEnum_failing = @"failing";
 NSString *const TxDevicePushStateEnum_failed = @"failed";
+NSString *const TxDevicePushStateEnum_unknown = @"unknown";
 
 // key constants for ConnectionStateChange
 NSString *const TxConnectionStateChange_current = @"current";

--- a/ios/Classes/codec/encoders/PushNotificationEncoders.swift
+++ b/ios/Classes/codec/encoders/PushNotificationEncoders.swift
@@ -20,7 +20,7 @@ public class PushNotificationEncoders: NSObject {
     public static let encodeDevicePushDetails: (ARTDevicePushDetails) -> Dictionary<String, Any> = { devicePushDetails in
         return [
             TxDevicePushDetails_recipient: devicePushDetails.recipient,
-            TxDevicePushDetails_state: devicePushDetails.state as Any,
+            TxDevicePushDetails_state: devicePushDetails.state.toString(),
             TxDevicePushDetails_errorReason: (devicePushDetails.errorReason != nil ? Encoders.encodeErrorInfo(devicePushDetails.errorReason!) : nil) as Any
         ];
     }
@@ -161,6 +161,23 @@ extension UNShowPreviewsSetting {
         case .whenAuthenticated:
             return TxUNShowPreviewsSettingEnum_whenAuthenticated
         @unknown default:
+            fatalError("Unsupported value in \(self).")
+        }
+    }
+}
+
+extension ARTPushState {
+    func toString() -> String {
+        switch (self) {
+        case .active:
+            return TxDevicePushStateEnum_active
+        case .failed:
+            return TxDevicePushStateEnum_failing
+        case .failing:
+            return TxDevicePushStateEnum_failing
+        case .unknown:
+            return TxDevicePushStateEnum_unknown
+        default:
             fatalError("Unsupported value in \(self).")
         }
     }

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -101,6 +101,30 @@ public class PushHandlers: NSObject {
             result(rest.device)
         }
     }
+    
+    @objc
+    public static let getDevicePushDetails: FlutterHandler = { plugin, call, result in
+        let message = call.arguments as! AblyFlutterMessage
+        let ablyClientHandle = message.message as! NSNumber
+        let realtime = plugin.ably.realtime(withHandle: ablyClientHandle)
+        let rest = plugin.ably.getRest(ablyClientHandle)
+
+        if let realtime = realtime {
+            realtime.push.getState { details, error in
+                if (error != nil) {
+                    result(FlutterError(code: String(error!._code), message: "Error getting push state; err = \(error!.localizedDescription)", details: nil))
+                }
+                result(details)
+            }
+        } else if let rest = rest {
+            rest.push.getState { details, error in
+                if (error != nil) {
+                    result(FlutterError(code: String(error!._code), message: "Error getting push state; err = \(error!.localizedDescription)", details: nil))
+                }
+                result(details)
+            }
+        }
+    }
 
     @objc
     public static let listSubscriptions: FlutterHandler = { plugin, call, result in

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -28,9 +28,11 @@ class CodecTypes {
   static const int pushChannelSubscription = 147;
   static const int unNotificationSettings = 148;
   static const int remoteMessage = 149;
-  static const int errorInfo = 150;
-  static const int connectionStateChange = 151;
-  static const int channelStateChange = 152;
+  static const int devicePushDetails = 150;
+  static const int devicePushState = 151;
+  static const int errorInfo = 152;
+  static const int connectionStateChange = 153;
+  static const int channelStateChange = 154;
 }
 
 class PlatformMethod {
@@ -64,6 +66,7 @@ class PlatformMethod {
   static const String realtimeHistory = 'realtimeHistory';
   static const String pushActivate = 'pushActivate';
   static const String pushDeactivate = 'pushDeactivate';
+  static const String pushGetDevicePushDetails = 'pushGetDevicePushDetails';
   static const String pushSubscribeDevice = 'pushSubscribeDevice';
   static const String pushUnsubscribeDevice = 'pushUnsubscribeDevice';
   static const String pushSubscribeClient = 'pushSubscribeClient';
@@ -256,6 +259,7 @@ class TxDevicePushStateEnum {
   static const String active = 'active';
   static const String failing = 'failing';
   static const String failed = 'failed';
+  static const String unknown = 'unknown';
 }
 
 class TxConnectionStateChange {

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -93,6 +93,8 @@ class Codec extends StandardMessageCodec {
       // Push Notifications
       CodecTypes.deviceDetails:
           _CodecPair<DeviceDetails>(null, _decodeDeviceDetails),
+      CodecTypes.devicePushDetails:
+          _CodecPair<DevicePushDetails>(null, _decodeDevicePushDetails),
       CodecTypes.localDevice: _CodecPair<LocalDevice>(null, _decodeLocalDevice),
       CodecTypes.pushChannelSubscription: _CodecPair<PushChannelSubscription>(
           null, _decodePushChannelSubscription),
@@ -729,6 +731,7 @@ class Codec extends StandardMessageCodec {
   }
 
   DevicePushState? _decodeDevicePushState(String? enumValue) {
+    if (enumValue == null) return null;
     switch (enumValue) {
       case TxDevicePushStateEnum.active:
         return DevicePushState.active;
@@ -736,8 +739,12 @@ class Codec extends StandardMessageCodec {
         return DevicePushState.failing;
       case TxDevicePushStateEnum.failed:
         return DevicePushState.failed;
+      case TxDevicePushStateEnum.unknown:
+        return DevicePushState.unknown;
       default:
-        return null;
+        throw AblyException(
+          'Platform communication error. DevicePushState is invalid: $enumValue',
+        );
     }
   }
 

--- a/lib/src/platform/src/push_native.dart
+++ b/lib/src/platform/src/push_native.dart
@@ -74,6 +74,10 @@ class PushNative extends PlatformObject implements Push {
   Future<void> deactivate() => invoke(PlatformMethod.pushDeactivate);
 
   @override
+  Future<DevicePushDetails> getDevicePushDetails() =>
+      invokeRequest<DevicePushDetails>(PlatformMethod.pushGetDevicePushDetails);
+
+  @override
   Future<int?> createPlatformInstance() => (realtime != null)
       ? (realtime as Realtime).handle
       : (rest as Rest).handle;

--- a/lib/src/push_notifications/src/device_push_state.dart
+++ b/lib/src/push_notifications/src/device_push_state.dart
@@ -11,4 +11,7 @@ enum DevicePushState {
 
   /// indicates the device push state failed
   failed,
+
+  /// The DevicePushState is not known
+  unknown,
 }

--- a/lib/src/push_notifications/src/push.dart
+++ b/lib/src/push_notifications/src/push.dart
@@ -84,4 +84,9 @@ abstract class Push {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RSH2b
   Future<void> deactivate();
+
+  /// Makes a network request to Ably to get the device push details stored
+  /// in Ably servers. This method is also useful to get the state and error
+  /// reason to understand why push messages were not sent to the device.
+  Future<DevicePushDetails> getDevicePushDetails();
 }


### PR DESCRIPTION
After discussion in https://github.com/ably/ably-java/issues/697, Marat has implemented https://github.com/ably/ably-cocoa/pull/1186 which allows users to make a network request to get `DevicePushDetails`, which includes `state` and `errorReason`. This makes development easier for the users, since they make this request to see if messages successfully gets sent to devices, or the error reason if messages do not successfully get sent. This PR adds this functionality to Flutter.

# This is WIP: 

I am currently using a branch of Ably cocoa manually, by pointing to the local repository of Ably cocoa containing the changes Marat wanted me to test. I also have to test this with Push Admin. 

The Dart and iOS code is written but in an open PR. More things need to happen:
- Realtime changes required: https://github.com/ably/realtime/issues/3780 to allow devices to get their own device registration **without push admin**.
- Feature spec changes required for this new SDK method: https://github.com/ably/docs/issues/1251
- Ably Java / Android changes required: to make this network request like Ably Cocoa does in https://github.com/ably/ably-cocoa/pull/1186. 
