### PR TITLE
Copy unawaited implementation into Ably Flutter to fix build failures for Flutter 2.2.3

### DIFF
--- a/lib/src/common/src/backwards_compatibility.dart
+++ b/lib/src/common/src/backwards_compatibility.dart
@@ -1,0 +1,14 @@
+/// This function was added to add backwards compatibility.
+///
+/// `unawaited` was previously imported in code from package:pedantic.
+/// However, this package was deprecated, and `unawaited` was added to Flutter
+/// directly. Unfortunately, it was only added in Flutter 2.5 (Dart 2.14).
+///
+/// Users who use the package with Flutter versions older than 2.5 will
+/// face missing method errors. Forcing users to upgrade to 2.5 may force them
+/// to undergo [breaking changes](https://flutter.dev/docs/release/breaking-changes#released-in-flutter-25).
+///
+/// Reminder: Once we increase our minimum dart version support to 2.14 and
+/// minimum Flutter version support 2.5.0, we can remove this method and replace
+/// it with `unawaited`
+void unawaitedWorkaroundForDartPre214(Future<void> future) {}

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -3,6 +3,7 @@ import 'dart:collection';
 
 import '../../../authentication/authentication.dart';
 import '../../../common/common.dart';
+import '../../../common/src/backwards_compatibility.dart';
 import '../../../error/error.dart';
 import '../../../generated/platform_constants.dart';
 import '../../../push_notifications/push_notifications.dart';
@@ -78,7 +79,7 @@ class Realtime extends PlatformObject
   Future<void> connect() async {
     final queueItem = Completer<void>();
     _connectQueue.add(queueItem);
-    unawaited(_connect());
+    unawaitedWorkaroundForDartPre214(_connect());
     return queueItem.future;
   }
 

--- a/lib/src/platform/src/realtime/realtime_channel.dart
+++ b/lib/src/platform/src/realtime/realtime_channel.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:flutter/services.dart';
 import 'package:meta/meta.dart';
 
+import '../../../common/src/backwards_compatibility.dart';
 import '../../../error/error.dart';
 import '../../../generated/platform_constants.dart';
 import '../../../message/message.dart';
@@ -75,7 +76,7 @@ class RealtimeChannel extends PlatformObject
     ];
     final queueItem = _PublishQueueItem(Completer<void>(), messages);
     _publishQueue.add(queueItem);
-    unawaited(_publishInternal());
+    unawaitedWorkaroundForDartPre214(_publishInternal());
     return queueItem.completer.future;
   }
 

--- a/lib/src/platform/src/rest/rest_channel.dart
+++ b/lib/src/platform/src/rest/rest_channel.dart
@@ -4,6 +4,7 @@ import 'dart:collection';
 import 'package:flutter/services.dart';
 
 import '../../../../ably_flutter.dart';
+import '../../../common/src/backwards_compatibility.dart';
 import '../../../error/error.dart';
 import '../../../generated/platform_constants.dart';
 import '../../../message/message.dart';
@@ -69,7 +70,7 @@ class RestChannel extends PlatformObject implements RestChannelInterface {
     ];
     final queueItem = PublishQueueItem(Completer<void>(), messages);
     _publishQueue.add(queueItem);
-    unawaited(_publishInternal());
+    unawaitedWorkaroundForDartPre214(_publishInternal());
     return queueItem.completer.future;
   }
 

--- a/test/realtime/channel_test.dart
+++ b/test/realtime/channel_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter/src/common/src/backwards_compatibility.dart';
 import 'package:ably_flutter/src/generated/platform_constants.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -86,7 +87,7 @@ void main() {
         return Future.value('token');
       }
 
-      unawaited(
+      unawaitedWorkaroundForDartPre214(
         fakeAsync((async) async {
           final options = ClientOptions()
             ..authCallback = timingOutOnceThenSucceedsAuthCallback

--- a/test/rest/channel_test.dart
+++ b/test/rest/channel_test.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter/src/common/src/backwards_compatibility.dart';
 import 'package:ably_flutter/src/generated/platform_constants.dart';
 import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -83,7 +84,7 @@ void main() {
         return Future.value('token');
       }
 
-      unawaited(
+      unawaitedWorkaroundForDartPre214(
         fakeAsync((async) async {
           final options = ClientOptions()
             ..authCallback = timingOutOnceThenSucceedsAuthCallback


### PR DESCRIPTION
A customer has asked us to add support for Flutter 2.2.3 to avoid them upgrading to Flutter 2.5 in a [slack message](https://ably-real-time.slack.com/archives/C0178QGC093/p1635945748037800). Unfortunately, currently, we are using `unawaited` introduced in Dart 2.14, which is first available in Flutter 2.5.0. 

As a solution, we copied the 1 line of implementation into this SDK, and import this instead.

We are also planning to add tests using older Flutter versions in CI to avoid this problem in the future, but there are some challenges in doing so, which we will tackle in a separate (currently draft) PR: https://github.com/ably/ably-flutter/pull/197