### PR TITLE
Simplify state in example app

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -32,8 +32,6 @@ class _MyAppState extends State<MyApp> {
   String _ablyVersion = 'Unknown';
 
   final String _apiKey = const String.fromEnvironment(Constants.ablyApiKey);
-  OpState _realtimeCreationState = OpState.notStarted;
-  OpState _restCreationState = OpState.notStarted;
   ably.Realtime? _realtime;
   ably.Rest? _rest;
   ably.ConnectionState? _realtimeConnectionState;
@@ -83,7 +81,7 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    initPlatformState();
+    asyncInitState();
   }
 
   @override
@@ -100,9 +98,7 @@ class _MyAppState extends State<MyApp> {
   }
 
   // Platform messages are asynchronous, so we initialize in an async method.
-  Future<void> initPlatformState() async {
-    print('initPlatformState()');
-
+  Future<void> asyncInitState() async {
     String platformVersion;
     String ablyVersion;
 
@@ -136,13 +132,12 @@ class _MyAppState extends State<MyApp> {
       _platformVersion = platformVersion;
       _ablyVersion = ablyVersion;
     });
+
+    createAblyRealtime();
+    await createAblyRest();
   }
 
   Future<void> createAblyRest() async {
-    setState(() {
-      _restCreationState = OpState.inProgress;
-    });
-
     final clientOptions = ably.ClientOptions.fromKey(_apiKey)
       ..logLevel = ably.LogLevel.verbose
       ..logHandler = ({msg, exception}) {
@@ -154,16 +149,12 @@ class _MyAppState extends State<MyApp> {
       rest = ably.Rest(options: clientOptions);
     } on Exception catch (error) {
       print('Error creating Ably Rest: $error');
-      setState(() {
-        _restCreationState = OpState.failed;
-      });
       rethrow;
     }
     _pushNotificationService.setRestClient(rest);
 
     setState(() {
       _rest = rest;
-      _restCreationState = OpState.succeeded;
     });
 
     const name = 'Hello';
@@ -186,10 +177,6 @@ class _MyAppState extends State<MyApp> {
   }
 
   void createAblyRealtime() {
-    setState(() {
-      _realtimeCreationState = OpState.inProgress;
-    });
-
     final clientOptions = ably.ClientOptions.fromKey(_apiKey)
       ..clientId = Constants.clientId
       ..logLevel = ably.LogLevel.verbose
@@ -206,13 +193,9 @@ class _MyAppState extends State<MyApp> {
       _pushNotificationService.setRealtimeClient(realtime);
       setState(() {
         _realtime = realtime;
-        _realtimeCreationState = OpState.succeeded;
       });
     } on Exception catch (error) {
       print('Error creating Ably Realtime: $error');
-      setState(() {
-        _realtimeCreationState = OpState.failed;
-      });
       rethrow;
     }
   }
@@ -274,39 +257,6 @@ class _MyAppState extends State<MyApp> {
         return const Color.fromARGB(255, 255, 128, 128);
     }
   }
-
-  static Widget button(
-    final OpState state,
-    void Function() action,
-    String actionDescription,
-    String operatingDescription,
-    String doneDescription,
-  ) =>
-      FlatButton(
-        onPressed: (state == OpState.notStarted || state == OpState.failed)
-            ? action
-            : null,
-        color: opStateColor(state),
-        disabledColor: opStateColor(state),
-        child: Text(
-          opStateDescription(
-            state,
-            actionDescription,
-            operatingDescription,
-            doneDescription,
-          ),
-        ),
-      );
-
-  Widget createRestButton() => button(_restCreationState, createAblyRest,
-      'Create Ably Rest', 'Create Ably Rest', 'Ably Rest Created');
-
-  Widget createRealtimeButton() => button(
-      _realtimeCreationState,
-      createAblyRealtime,
-      'Create Ably Realtime',
-      'Creating Ably Realtime',
-      'Ably Realtime Created');
 
   Widget createRTConnectButton() => FlatButton(
         padding: EdgeInsets.zero,
@@ -745,11 +695,6 @@ class _MyAppState extends State<MyApp> {
                     'Realtime',
                     style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   ),
-                  createRealtimeButton(),
-                  Text(
-                    'Realtime:'
-                    ' ${_realtime?.toString() ?? 'Realtime not created yet.'}',
-                  ),
                   Text('Connection State: $_realtimeConnectionState'),
                   Text('Channel State: $_realtimeChannelState'),
                   Row(
@@ -829,9 +774,6 @@ class _MyAppState extends State<MyApp> {
                     'Rest',
                     style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   ),
-                  createRestButton(),
-                  Text('Rest: '
-                      '${_rest?.toString() ?? 'Ably Rest not created yet.'}'),
                   sendRestMessage(),
                   Text(
                     'Rest: press this button to publish a new message with'

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.2"
+    version: "1.2.3"
   async:
     dependency: "direct main"
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.1"
+    version: "2.8.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   clock:
     dependency: transitive
     description:
@@ -204,7 +204,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   path:
     dependency: transitive
     description:
@@ -300,7 +300,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.4.2"
   timezone:
     dependency: transitive
     description:


### PR DESCRIPTION
With this change, users of the example app no longer need to create instances of Realtime and Rest. These get created automatically. This simplifies the state for the entire app, as the rest of the app can rely on Realtime and Rest instances existing. This allows me to avoid adding more complicated state management tools, like Bloc, getx, provider, etc for my upcoming symmetric encryption PR.

The UI changes from (before, left) and after (right): 
![Frame 109](https://user-images.githubusercontent.com/24711048/140364820-4369c2cc-a3e6-4338-969d-c0152e2a8325.png)


