### PR TITLE
Remove a duplicate class and use the other one instead

### DIFF
--- a/lib/src/platform/platform_internal.dart
+++ b/lib/src/platform/platform_internal.dart
@@ -1,6 +1,7 @@
 // This is a file which `ably_flutter.dart` should not export to library users,
 // but other library files can import to gain access to internal APIs
 
+export 'src/publish_queue_item.dart';
 export 'src/push_activation_events_native.dart';
 export 'src/push_channel_native.dart';
 export 'src/push_native.dart';

--- a/lib/src/platform/src/publish_queue_item.dart
+++ b/lib/src/platform/src/publish_queue_item.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import '../../../message/message.dart';
+import '../../message/message.dart';
 
 /// An item for used to enqueue a message to be published after an ongoing
 /// authCallback is completed

--- a/lib/src/platform/src/realtime/realtime_channel.dart
+++ b/lib/src/platform/src/realtime/realtime_channel.dart
@@ -61,7 +61,7 @@ class RealtimeChannel extends PlatformObject
     );
   }
 
-  final _publishQueue = Queue<_PublishQueueItem>();
+  final _publishQueue = Queue<PublishQueueItem>();
   Completer<void>? _authCallbackCompleter;
 
   @override
@@ -74,7 +74,7 @@ class RealtimeChannel extends PlatformObject
     messages ??= [
       if (message == null) Message(name: name, data: data) else message
     ];
-    final queueItem = _PublishQueueItem(Completer<void>(), messages);
+    final queueItem = PublishQueueItem(Completer<void>(), messages);
     _publishQueue.add(queueItem);
     unawaitedWorkaroundForDartPre214(_publishInternal());
     return queueItem.completer.future;
@@ -229,13 +229,4 @@ class RealtimePlatformChannels
     super.release(name);
     (realtime as Realtime).invoke(PlatformMethod.releaseRealtimeChannel, name);
   }
-}
-
-/// An item for used to enqueue a message to be published after an ongoing
-/// authCallback is completed
-class _PublishQueueItem {
-  List<Message> messages;
-  final Completer<void> completer;
-
-  _PublishQueueItem(this.completer, this.messages);
 }

--- a/lib/src/platform/src/rest/rest_channel.dart
+++ b/lib/src/platform/src/rest/rest_channel.dart
@@ -10,7 +10,7 @@ import '../../../generated/platform_constants.dart';
 import '../../../message/message.dart';
 import '../../../rest/rest.dart';
 import '../../platform.dart';
-import 'publish_queue_item.dart';
+import '../publish_queue_item.dart';
 
 /// Plugin based implementation of Rest channel
 class RestChannel extends PlatformObject implements RestChannelInterface {


### PR DESCRIPTION
This is a small fix, there was duplicate class, and I'm just deleting one. The file being referenced instead is https://github.com/ably/ably-flutter/blob/main/lib/src/platform/src/rest/publish_queue_item.dart