### PR TITLE
Fix app crashing when receiving multiple push notifications

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/push/PushMessagingEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushMessagingEventHandlers.java
@@ -51,7 +51,6 @@ final public class PushMessagingEventHandlers {
     @Override
     public void onReceive(Context context, Intent intent) {
       String action = intent.getAction();
-      Bundle intentExtras = intent.getExtras();
       RemoteMessage message = new RemoteMessage(intent.getExtras());
       switch (action) {
         case PUSH_ON_MESSAGE_RECEIVED:

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -142,6 +142,7 @@ class _MyAppState extends State<MyApp> {
 
   Future<void> createAblyRest() async {
     final clientOptions = ably.ClientOptions.fromKey(_apiKey)
+      ..clientId = Constants.clientId
       ..logLevel = ably.LogLevel.verbose
       ..logHandler = ({msg, exception}) {
         print('Custom logger :: $msg $exception');


### PR DESCRIPTION
When the app receives multiple push notifications, a crash occurs. This is because the broadcast receiver is not unregistered. In this fix, I refactor the code slightly, whilst making sure to unregister the receiver.

I also noticed the Rest client did not have a clientId set, so I did that here too instead of creating an entirely new PR.