### PR TITLE
Handle error cases on iOS correctly, and simplify code

### DIFF
--- a/ios/Classes/handlers/PushActivationEventHandlers.swift
+++ b/ios/Classes/handlers/PushActivationEventHandlers.swift
@@ -19,10 +19,11 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
         return instance!
     }
     
-    // FlutterResult to return result as Future<void> or throws an error. This is the convenient API.
+    // FlutterResults to return result as Future<void> or throws an error. This is the convenient API.
+    // These fields are set in [PushHandlers.swift] when the method call is invoked
     public var flutterResultForActivate: FlutterResult? = nil;
     public var flutterResultForDeactivate: FlutterResult? = nil;
-    // There is no result stored for didAblyPushRegistrationFail, because there is dart side method call to return values to.
+    // There is no result stored for didAblyPushRegistrationFail, because there is no dart side method call to return values to.
     
     // MethodChannel to send result to handlers implemented in dart side. This provides values to the listeners
     // implement on the dart side. We need this for activate and deactivate because the new token can be provided.

--- a/ios/Classes/handlers/PushActivationEventHandlers.swift
+++ b/ios/Classes/handlers/PushActivationEventHandlers.swift
@@ -19,7 +19,7 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
         return instance!
     }
     
-    // FlutterResults to return result as Future<void> or throws an error. This is the convenient API.
+    // FlutterResult to return result as Future<void> or throws an error. This is the convenient API.
     public var flutterResultForActivate: FlutterResult? = nil;
     public var flutterResultForDeactivate: FlutterResult? = nil;
     // There is no result stored for didAblyPushRegistrationFail, because there is dart side method call to return values to.
@@ -34,43 +34,29 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
         defer {
             flutterResultForActivate = nil
         }
-        
-        guard let result = flutterResultForActivate else {
-            let error = FlutterError(code: "didActivateAblyPush_error", message: "Failed to asynchronously return a value because flutterResultForActivate was nil", details: nil)
-            methodChannel.invokeMethod(AblyPlatformMethod_pushOnActivate, arguments: error, result: nil)
-            return
-        }
-        if let error = error {
-            result(FlutterError(code: String(error.code), message: error.message, details: error))
-        } else {
-            result(nil)
-        }
+
         methodChannel.invokeMethod(AblyPlatformMethod_pushOnActivate, arguments: error, result: nil)
+        if let result = flutterResultForActivate {
+            result(error)
+        } else {
+            print("Did not return a value asynchronously because flutterResultForActivate was nil. The app might have been restarted since calling activate.")
+        }
     }
     
     public func didDeactivateAblyPush(_ error: ARTErrorInfo?) {
         defer {
             flutterResultForDeactivate = nil
         }
-        
-        guard let result = flutterResultForDeactivate else {
-            let error = FlutterError(code: "didDeactivateAblyPush_error", message: "Failed to asynchronously return a value because flutterResultForDeactivate was nil", details: nil)
-            methodChannel.invokeMethod(AblyPlatformMethod_pushOnDeactivate, arguments: error, result: nil)
-            return
-        }
-        if let error = error {
-            result(FlutterError(code: String(error.code), message: error.message, details: error))
-        } else {
-            result(nil)
-        }
+
         methodChannel.invokeMethod(AblyPlatformMethod_pushOnDeactivate, arguments: error, result: nil)
+        if let result = flutterResultForDeactivate {
+            result(error)
+        } else {
+            print("Did not return a value asynchronously because flutterResultForDeactivate was nil. The app might have been restarted since calling deactivate.")
+        }
     }
     
     public func didAblyPushRegistrationFail(_ error: ARTErrorInfo?) {
-        if let error = error {
-            methodChannel.invokeMethod(AblyPlatformMethod_pushOnUpdateFailed, arguments: error, result: nil)
-        } else {
-            methodChannel.invokeMethod(AblyPlatformMethod_pushOnUpdateFailed, arguments: FlutterError(code: "40000", message: "Ably push update failed, but no error was provided", details: nil), result: nil)
-        }
+        methodChannel.invokeMethod(AblyPlatformMethod_pushOnUpdateFailed, arguments: error, result: nil)
     }
 }


### PR DESCRIPTION
This PR fixes the success and error handling for push. Its handling push activation (`didActivateAblyPush`, deactivation `didDeactivateAblyPush` and update `didAblyPushRegistrationFail ` success/error given by Ably Cocoa.

In some cases, an error would be caused because we try to send a `FlutterError` through a `MethodChannel`. This is not a type that can be serialized through a `MethodChannel`. Instead, this fix uses the `ARTErrorInfo`, which has been used elsewhere to send back errors to platform side. It also avoids extraneous logic: mostly passing the errorInfo given by Ably Cocoa to the dart side. 

TLDR: Removing complexity and just passing errors (or `nil`) directly. 