### PR TITLE
Add default values to ClientOptions

### DIFF
--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -4,7 +4,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TO1
 class ClientOptions extends AuthOptions {
-  /// initializes [ClientOptions] with log level set to info
+  /// Set fields on [ClientOptions] to configure it.
   ClientOptions();
 
   /// initializes [ClientOptions] with a key and log level set to info

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -166,7 +166,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 10s
   /// https://docs.ably.com/client-lib-development-guide/features/#DF1b
-  int? realtimeRequestTimeout;
+  int realtimeRequestTimeout = 10;
 
   /// After a failed request to the default endpoint,
   /// followed by a successful request to a fallback endpoint,

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -32,7 +32,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// Use constants from [LogLevel] to pass arguments
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3b
-  int? logLevel;
+  int logLevel = LogLevel.warn;
 
   /// for development environments only
   ///
@@ -53,7 +53,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// By default, a TLS connection is used to connect to Ably
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3d
-  bool? tls;
+  bool tls = true;
 
   /// for development environments only
   ///
@@ -63,29 +63,29 @@ class ClientOptions extends AuthOptions {
   /// Automatically connect to Ably when client is instantiated.
   ///
   /// This is true by default. If false, will wait for an explicit
-  /// [ConnectionInterface]#connect to be called before connecting
+  /// [Connection.connect] to be called before connecting
   /// https://docs.ably.com/client-lib-development-guide/features/#RTC1b
-  bool? autoConnect;
+  bool autoConnect = true;
 
   /// Decides whether to use MsgPack binary encoding or JSON encoding.
   ///
   /// Defaults to true. If false, JSON encoding is used for REST and Realtime
   /// operations, instead of the default binary msgpack encoding.
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3f
-  bool? useBinaryProtocol;
+  bool useBinaryProtocol = true;
 
   /// When true, messages will be queued whilst the connection is disconnected.
   ///
   /// True by default.
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3g
-  bool? queueMessages;
+  bool queueMessages = true;
 
   /// When true, messages published on channels by this client will be
   /// echoed back to this client.
   ///
   /// This is true by default.
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3h
-  bool? echoMessages;
+  bool echoMessages = true;
 
   /// Can be used to explicitly recover a connection.
   ///
@@ -122,7 +122,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 15,000 (15 seconds)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l1
-  int? disconnectedRetryTimeout;
+  int disconnectedRetryTimeout = 15000;
 
   /// When the connection enters the [ConnectionState.suspended] state,
   /// after this delay in milliseconds, if the state is still
@@ -131,7 +131,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 30,000 (30 seconds)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l2
-  int? suspendedRetryTimeout;
+  int suspendedRetryTimeout = 30000;
 
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3n
   bool? idempotentRestPublishing;
@@ -147,20 +147,20 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 4,000 (4s)
   /// https://docs.ably.com/client-lib-development-guide/features/#RTC1f
-  int? httpOpenTimeout;
+  int httpOpenTimeout = 4000;
 
   /// Timeout for any single HTTP request and response
   ///
   /// default 10,000 (10s)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l4
-  int? httpRequestTimeout;
+  int httpRequestTimeout = 10000;
 
   /// Max number of fallback hosts to use as a fallback when an HTTP request
   /// to the primary host is unreachable or indicates that it is unserviceable
   ///
   /// default 3
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l5
-  int? httpMaxRetryCount;
+  int httpMaxRetryCount = 3;
 
   /// When a realtime client library is establishing a connection with Ably,
   /// or sending a HEARTBEAT, CONNECT, ATTACH, DETACH or CLOSE ProtocolMessage
@@ -179,7 +179,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 600000 (10 minutes)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l10
-  int? fallbackRetryTimeout;
+  int fallbackRetryTimeout = 600000;
 
   /// When a channel becomes [ChannelState.suspended] following a server
   /// initiated [ChannelState.detached], after this delay in milliseconds,
@@ -189,7 +189,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 15,000 (15s)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l7
-  int? channelRetryTimeout;
+  int channelRetryTimeout = 15000;
 
 // TODO(tiholic) unimplemented:
 //

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -5,16 +5,12 @@ import 'package:ably_flutter/ably_flutter.dart';
 /// https://docs.ably.com/client-lib-development-guide/features/#TO1
 class ClientOptions extends AuthOptions {
   /// initializes [ClientOptions] with log level set to info
-  ClientOptions() {
-    logLevel = LogLevel.info;
-  }
+  ClientOptions();
 
   /// initializes [ClientOptions] with a key and log level set to info
   ///
   /// See [AuthOptions.fromKey] for more details
-  ClientOptions.fromKey(String key) : super.fromKey(key) {
-    logLevel = LogLevel.info;
-  }
+  ClientOptions.fromKey(String key) : super.fromKey(key);
 
   /// Optional clientId that can be used to specify the identity for this client
   ///
@@ -32,7 +28,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// Use constants from [LogLevel] to pass arguments
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3b
-  int logLevel = LogLevel.warn;
+  int logLevel = LogLevel.info;
 
   /// for development environments only
   ///

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -166,7 +166,7 @@ class ClientOptions extends AuthOptions {
   ///
   /// default 10s
   /// https://docs.ably.com/client-lib-development-guide/features/#DF1b
-  int realtimeRequestTimeout = 10;
+  int? realtimeRequestTimeout;
 
   /// After a failed request to the default endpoint,
   /// followed by a successful request to a fallback endpoint,

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -535,7 +535,7 @@ class Codec extends StandardMessageCodec {
       jsonMap,
       TxClientOptions.defaultTokenParams,
     ));
-    return ClientOptions()
+    final clientOptions = ClientOptions()
       // AuthOptions (super class of ClientOptions)
       ..authUrl = _readFromJson<String>(
         jsonMap,
@@ -611,8 +611,6 @@ class Codec extends StandardMessageCodec {
       ..httpOpenTimeout = jsonMap[TxClientOptions.httpOpenTimeout] as int
       ..httpRequestTimeout = jsonMap[TxClientOptions.httpRequestTimeout] as int
       ..httpMaxRetryCount = jsonMap[TxClientOptions.httpMaxRetryCount] as int
-      ..realtimeRequestTimeout =
-          jsonMap[TxClientOptions.realtimeRequestTimeout] as int
       ..fallbackHosts = _readFromJson<List<String>>(
         jsonMap,
         TxClientOptions.fallbackHosts,
@@ -631,6 +629,12 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.transportParams,
       );
+
+    if (jsonMap[TxClientOptions.realtimeRequestTimeout] != null) {
+      clientOptions.realtimeRequestTimeout =
+          jsonMap[TxClientOptions.realtimeRequestTimeout] as int;
+    }
+    return clientOptions;
   }
 
   /// Decodes value [jsonMap] to [TokenDetails]

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -573,15 +573,9 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.clientId,
       )
-      ..logLevel = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.logLevel,
-      )
+      ..logLevel = jsonMap[TxClientOptions.logLevel] as int
       //TODO handle logHandler
-      ..tls = _readFromJson<bool>(
-        jsonMap,
-        TxClientOptions.tls,
-      )
+      ..tls = jsonMap[TxClientOptions.tls] as bool
       ..restHost = _readFromJson<String>(
         jsonMap,
         TxClientOptions.restHost,
@@ -598,22 +592,10 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.tlsPort,
       )
-      ..autoConnect = _readFromJson<bool>(
-        jsonMap,
-        TxClientOptions.autoConnect,
-      )
-      ..useBinaryProtocol = _readFromJson<bool>(
-        jsonMap,
-        TxClientOptions.useBinaryProtocol,
-      )
-      ..queueMessages = _readFromJson<bool>(
-        jsonMap,
-        TxClientOptions.queueMessages,
-      )
-      ..echoMessages = _readFromJson<bool>(
-        jsonMap,
-        TxClientOptions.echoMessages,
-      )
+      ..autoConnect = jsonMap[TxClientOptions.autoConnect] as bool
+      ..useBinaryProtocol = jsonMap[TxClientOptions.useBinaryProtocol] as bool
+      ..queueMessages = jsonMap[TxClientOptions.queueMessages] as bool
+      ..echoMessages = jsonMap[TxClientOptions.echoMessages] as bool
       ..recover = _readFromJson<String>(
         jsonMap,
         TxClientOptions.recover,
@@ -626,22 +608,11 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.idempotentRestPublishing,
       )
-      ..httpOpenTimeout = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.httpOpenTimeout,
-      )
-      ..httpRequestTimeout = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.httpRequestTimeout,
-      )
-      ..httpMaxRetryCount = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.httpMaxRetryCount,
-      )
-      ..realtimeRequestTimeout = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.realtimeRequestTimeout,
-      )
+      ..httpOpenTimeout = jsonMap[TxClientOptions.httpOpenTimeout] as int
+      ..httpRequestTimeout = jsonMap[TxClientOptions.httpRequestTimeout] as int
+      ..httpMaxRetryCount = jsonMap[TxClientOptions.httpMaxRetryCount] as int
+      ..realtimeRequestTimeout =
+          jsonMap[TxClientOptions.realtimeRequestTimeout] as int
       ..fallbackHosts = _readFromJson<List<String>>(
         jsonMap,
         TxClientOptions.fallbackHosts,
@@ -650,16 +621,10 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.fallbackHostsUseDefault,
       )
-      ..fallbackRetryTimeout = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.fallbackRetryTimeout,
-      )
+      ..fallbackRetryTimeout = jsonMap[TxClientOptions.fallbackRetryTimeout] as int
       ..defaultTokenParams =
           (tokenParams == null) ? null : _decodeTokenParams(tokenParams)
-      ..channelRetryTimeout = _readFromJson<int>(
-        jsonMap,
-        TxClientOptions.channelRetryTimeout,
-      )
+      ..channelRetryTimeout = jsonMap[TxClientOptions.channelRetryTimeout] as int
       ..transportParams = _readFromJson<Map<String, String>>(
         jsonMap,
         TxClientOptions.transportParams,

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -608,6 +608,8 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.idempotentRestPublishing,
       )
+      ..realtimeRequestTimeout =
+          jsonMap[TxClientOptions.realtimeRequestTimeout] as int?
       ..httpOpenTimeout = jsonMap[TxClientOptions.httpOpenTimeout] as int
       ..httpRequestTimeout = jsonMap[TxClientOptions.httpRequestTimeout] as int
       ..httpMaxRetryCount = jsonMap[TxClientOptions.httpMaxRetryCount] as int
@@ -629,11 +631,6 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.transportParams,
       );
-
-    if (jsonMap[TxClientOptions.realtimeRequestTimeout] != null) {
-      clientOptions.realtimeRequestTimeout =
-          jsonMap[TxClientOptions.realtimeRequestTimeout] as int;
-    }
     return clientOptions;
   }
 

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -621,10 +621,12 @@ class Codec extends StandardMessageCodec {
         jsonMap,
         TxClientOptions.fallbackHostsUseDefault,
       )
-      ..fallbackRetryTimeout = jsonMap[TxClientOptions.fallbackRetryTimeout] as int
+      ..fallbackRetryTimeout =
+          jsonMap[TxClientOptions.fallbackRetryTimeout] as int
       ..defaultTokenParams =
           (tokenParams == null) ? null : _decodeTokenParams(tokenParams)
-      ..channelRetryTimeout = jsonMap[TxClientOptions.channelRetryTimeout] as int
+      ..channelRetryTimeout =
+          jsonMap[TxClientOptions.channelRetryTimeout] as int
       ..transportParams = _readFromJson<Map<String, String>>(
         jsonMap,
         TxClientOptions.transportParams,

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -37,7 +37,7 @@ class Realtime extends PlatformObject {
     );
     _realtimeInstances[handle] = this;
 
-    if (io.Platform.isAndroid && !options.autoConnect) {
+    if (io.Platform.isAndroid && options.autoConnect) {
       // On Android, clientOptions.autoConnect is set to `false` to prevent
       // the authCallback being called before we get the realtime handle.
       // If this happens, we won't be able to identify which realtime client

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -37,7 +37,7 @@ class Realtime extends PlatformObject {
     );
     _realtimeInstances[handle] = this;
 
-    if (io.Platform.isAndroid && options.autoConnect != false) {
+    if (io.Platform.isAndroid && !options.autoConnect) {
       // On Android, clientOptions.autoConnect is set to `false` to prevent
       // the authCallback being called before we get the realtime handle.
       // If this happens, we won't be able to identify which realtime client


### PR DESCRIPTION
It is nice to avoid optionals, and to be NNBD: non null by default. In this PR, I set the default values and make fields non-optional. 

Closes https://github.com/ably/ably-flutter/issues/230