### PR TITLE
Hide API key secret inside API key UI

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -674,7 +674,7 @@ class _MyAppState extends State<MyApp> {
                           ]),
                     )
                   else
-                    Text('API key: ${redactApiKey(_apiKey)}'),
+                    Text('API key: ${hideApiKeySecret(_apiKey)}'),
                   const Divider(),
                   const Text(
                     'Realtime',
@@ -792,7 +792,7 @@ class _MyAppState extends State<MyApp> {
         ),
       );
 
-  String redactApiKey(String apiKey) {
+  String hideApiKeySecret(String apiKey) {
     // What is an API Key?: https://faqs.ably.com/what-is-an-app-api-key
     final keyComponents = apiKey.split(':');
     if (keyComponents.length != 2) {
@@ -800,6 +800,6 @@ class _MyAppState extends State<MyApp> {
     }
     final publicApiKey = keyComponents[0];
     final apiKeySecret = keyComponents[1];
-    return publicApiKey + ':' + '*' * apiKeySecret.length;
+    return '$publicApiKey:${'*' * apiKeySecret.length}';
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:ably_flutter_example/push_notifications/push_notification_handle
 import 'package:ably_flutter_example/push_notifications/push_notification_service.dart';
 import 'package:ably_flutter_example/ui/message_encryption/message_encryption_sliver.dart';
 import 'package:ably_flutter_example/ui/push_notifications/push_notifications_sliver.dart';
+import 'package:ably_flutter_example/ui/text_row.dart';
 import 'package:ably_flutter_example/ui/utilities.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
@@ -648,9 +649,9 @@ class _MyAppState extends State<MyApp> {
                     'System Details',
                     style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
                   ),
-                  Text('Running on: $_platformVersion\n'),
-                  Text('Ably version: $_ablyVersion\n'),
-                  Text('Ably Client ID: ${Constants.clientId}\n'),
+                  TextRow('Running on', _platformVersion),
+                  TextRow('Ably version', _ablyVersion),
+                  TextRow('Ably Client ID', Constants.clientId),
                   if (_apiKey == '')
                     RichText(
                       text: const TextSpan(
@@ -674,7 +675,7 @@ class _MyAppState extends State<MyApp> {
                           ]),
                     )
                   else
-                    Text('API key: ${hideApiKeySecret(_apiKey)}'),
+                    TextRow('API key', hideApiKeySecret(_apiKey)),
                   const Divider(),
                   const Text(
                     'Realtime',

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -674,7 +674,7 @@ class _MyAppState extends State<MyApp> {
                           ]),
                     )
                   else
-                    Text('API key: $_apiKey'),
+                    Text('API key: ${redactApiKey(_apiKey)}'),
                   const Divider(),
                   const Text(
                     'Realtime',
@@ -791,4 +791,12 @@ class _MyAppState extends State<MyApp> {
           ),
         ),
       );
+
+  String redactApiKey(String apiKey) {
+    // What is an API Key?: https://faqs.ably.com/what-is-an-app-api-key
+    final keyComponents = apiKey.split(':');
+    final publicApiKey = keyComponents[0];
+    final apiKeySecret = keyComponents[1];
+    return publicApiKey + ':' + '*' * apiKeySecret.length;
+  }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -795,6 +795,9 @@ class _MyAppState extends State<MyApp> {
   String redactApiKey(String apiKey) {
     // What is an API Key?: https://faqs.ably.com/what-is-an-app-api-key
     final keyComponents = apiKey.split(':');
+    if (keyComponents.length != 2) {
+      return apiKey;
+    }
     final publicApiKey = keyComponents[0];
     final apiKeySecret = keyComponents[1];
     return publicApiKey + ':' + '*' * apiKeySecret.length;


### PR DESCRIPTION
In this UI enhancement, I hide the API secret key from the API key string. This allows me to show the example app to more people without worrying that I am leaking API keys. This should allow other users to share screenshots more safely too:
<img width="317" alt="CleanShot 2021-11-18 at 23 31 25@2x" src="https://user-images.githubusercontent.com/24711048/142513145-cc029d83-18f5-4af4-8195-f44243524b00.png">

I also replaced the Text widget with I previously created called `TextRow`, so it now the labels are in blue:
<img width="418" alt="CleanShot 2021-11-18 at 23 41 27@2x" src="https://user-images.githubusercontent.com/24711048/142514103-856d3bed-5489-4539-bb29-db6ca40ea793.png">

This is the same widget used when receiving push messages or encrypted messages:
<img width="402" alt="CleanShot 2021-11-18 at 23 43 49@2x" src="https://user-images.githubusercontent.com/24711048/142514289-8e7fd0c1-b02a-4c5e-96d0-0b6d4d1fa477.png">

