### PR TITLE
Example app: Extract System Details sliver into new widget

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -9,7 +9,7 @@ import 'package:ably_flutter_example/push_notifications/push_notification_handle
 import 'package:ably_flutter_example/push_notifications/push_notification_service.dart';
 import 'package:ably_flutter_example/ui/message_encryption/message_encryption_sliver.dart';
 import 'package:ably_flutter_example/ui/push_notifications/push_notifications_sliver.dart';
-import 'package:ably_flutter_example/ui/text_row.dart';
+import 'package:ably_flutter_example/ui/system_details_sliver.dart';
 import 'package:ably_flutter_example/ui/utilities.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/material.dart';
@@ -30,9 +30,6 @@ class MyApp extends StatefulWidget {
 const defaultChannel = Constants.channelName;
 
 class _MyAppState extends State<MyApp> {
-  String _platformVersion = 'Unknown';
-  String _ablyVersion = 'Unknown';
-
   final String _apiKey = const String.fromEnvironment(Constants.ablyApiKey);
   ably.Realtime? _realtime;
   ably.Rest? _rest;
@@ -112,29 +109,10 @@ class _MyAppState extends State<MyApp> {
       });
     }
 
-    // Platform messages may fail, so we use a try/catch PlatformException.
-    try {
-      platformVersion = await ably.platformVersion();
-    } on ably.AblyException {
-      platformVersion = 'Failed to get platform version.';
-    }
-    try {
-      ablyVersion = await ably.version();
-    } on ably.AblyException {
-      ablyVersion = 'Failed to get Ably version.';
-    }
-
     // If the widget was removed from the tree while the asynchronous platform
     // message was in flight, we want to discard the reply rather than calling
     // setState to update our non-existent appearance.
     if (!mounted) return;
-
-    print('queueing set state');
-    setState(() {
-      print('set state');
-      _platformVersion = platformVersion;
-      _ablyVersion = ablyVersion;
-    });
 
     createAblyRealtime();
     await createAblyRest();
@@ -645,37 +623,7 @@ class _MyAppState extends State<MyApp> {
                 padding:
                     const EdgeInsets.symmetric(vertical: 24, horizontal: 36),
                 children: [
-                  const Text(
-                    'System Details',
-                    style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
-                  ),
-                  TextRow('Running on', _platformVersion),
-                  TextRow('Ably version', _ablyVersion),
-                  TextRow('Ably Client ID', Constants.clientId),
-                  if (_apiKey == '')
-                    RichText(
-                      text: const TextSpan(
-                          style: TextStyle(color: Colors.black),
-                          children: [
-                            TextSpan(
-                                text: 'Warning: ',
-                                style: TextStyle(
-                                    color: Colors.red,
-                                    fontWeight: FontWeight.bold)),
-                            TextSpan(text: 'API key is not configured, use '),
-                            TextSpan(
-                                text: '`flutter run --dart-define='
-                                    'ABLY_API_KEY=your_api_key`',
-                                style: TextStyle()),
-                            TextSpan(
-                                text:
-                                    "or add this to the 'additional run args' "
-                                    'in the run configuration in '
-                                    'Android Studio.')
-                          ]),
-                    )
-                  else
-                    TextRow('API key', hideApiKeySecret(_apiKey)),
+                  SystemDetailsSliver(_apiKey),
                   const Divider(),
                   const Text(
                     'Realtime',
@@ -792,15 +740,4 @@ class _MyAppState extends State<MyApp> {
           ),
         ),
       );
-
-  String hideApiKeySecret(String apiKey) {
-    // What is an API Key?: https://faqs.ably.com/what-is-an-app-api-key
-    final keyComponents = apiKey.split(':');
-    if (keyComponents.length != 2) {
-      return apiKey;
-    }
-    final publicApiKey = keyComponents[0];
-    final apiKeySecret = keyComponents[1];
-    return '$publicApiKey:${'*' * apiKeySecret.length}';
-  }
 }

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -14,14 +14,14 @@ class SystemDetailsSliver extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final _platformVersion = useState<String?>(null);
-    final _ablyVersion = useState<String?>(null);
+    final platformVersion = useState<String?>(null);
+    final ablyVersion = useState<String?>(null);
 
     useEffect(() {
       ably
           .platformVersion()
-          .then((version) => _platformVersion.value = version);
-      ably.version().then((version) => _ablyVersion.value = version);
+          .then((version) => platformVersion.value = version);
+      ably.version().then((version) => ablyVersion.value = version);
     }, []);
 
     return Column(
@@ -31,8 +31,8 @@ class SystemDetailsSliver extends HookWidget {
           'System Details',
           style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
         ),
-        TextRow('Running on', _platformVersion.value),
-        TextRow('Ably version', _ablyVersion.value),
+        TextRow('Running on', platformVersion.value),
+        TextRow('Ably version', ablyVersion.value),
         TextRow('Ably Client ID', Constants.clientId),
         if (apiKey == '')
           RichText(

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -20,7 +20,7 @@ class SystemDetailsSliver extends HookWidget {
     useEffect(() {
       ably.platformVersion().then((version) => _platformVersion.value = version);
       ably.version().then((version) => _ablyVersion.value = version);
-    });
+    }, []);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -18,7 +18,9 @@ class SystemDetailsSliver extends HookWidget {
     final _ablyVersion = useState<String?>(null);
 
     useEffect(() {
-      ably.platformVersion().then((version) => _platformVersion.value = version);
+      ably
+          .platformVersion()
+          .then((version) => _platformVersion.value = version);
       ably.version().then((version) => _ablyVersion.value = version);
     }, []);
 
@@ -40,16 +42,14 @@ class SystemDetailsSliver extends HookWidget {
                   TextSpan(
                       text: 'Warning: ',
                       style: TextStyle(
-                          color: Colors.red,
-                          fontWeight: FontWeight.bold)),
+                          color: Colors.red, fontWeight: FontWeight.bold)),
                   TextSpan(text: 'API key is not configured, use '),
                   TextSpan(
                       text: '`flutter run --dart-define='
                           'ABLY_API_KEY=your_api_key`',
                       style: TextStyle()),
                   TextSpan(
-                      text:
-                      "or add this to the 'additional run args' "
+                      text: "or add this to the 'additional run args' "
                           'in the run configuration in '
                           'Android Studio.')
                 ]),

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -18,9 +18,7 @@ class SystemDetailsSliver extends HookWidget {
     final ablyVersion = useState<String?>(null);
 
     useEffect(() {
-      ably
-          .platformVersion()
-          .then((version) => platformVersion.value = version);
+      ably.platformVersion().then((version) => platformVersion.value = version);
       ably.version().then((version) => ablyVersion.value = version);
     }, []);
 

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -1,0 +1,73 @@
+import 'package:ably_flutter_example/ui/text_row.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:ably_flutter/ably_flutter.dart' as ably;
+
+import '../constants.dart';
+
+class SystemDetailsSliver extends HookWidget {
+  String apiKey;
+
+  SystemDetailsSliver(this.apiKey);
+
+  @override
+  Widget build(BuildContext context) {
+    final _platformVersion = useState<String?>(null);
+    final _ablyVersion = useState<String?>(null);
+
+    useEffect(() {
+      ably.platformVersion().then((version) => _platformVersion.value = version);
+      ably.version().then((version) => _ablyVersion.value = version);
+    });
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text(
+          'System Details',
+          style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold),
+        ),
+        TextRow('Running on', _platformVersion.value),
+        TextRow('Ably version', _ablyVersion.value),
+        TextRow('Ably Client ID', Constants.clientId),
+        if (apiKey == '')
+          RichText(
+            text: const TextSpan(
+                style: TextStyle(color: Colors.black),
+                children: [
+                  TextSpan(
+                      text: 'Warning: ',
+                      style: TextStyle(
+                          color: Colors.red,
+                          fontWeight: FontWeight.bold)),
+                  TextSpan(text: 'API key is not configured, use '),
+                  TextSpan(
+                      text: '`flutter run --dart-define='
+                          'ABLY_API_KEY=your_api_key`',
+                      style: TextStyle()),
+                  TextSpan(
+                      text:
+                      "or add this to the 'additional run args' "
+                          'in the run configuration in '
+                          'Android Studio.')
+                ]),
+          )
+        else
+          TextRow('API key', hideApiKeySecret(apiKey)),
+      ],
+    );
+  }
+
+  String hideApiKeySecret(String apiKey) {
+    // What is an API Key?: https://faqs.ably.com/what-is-an-app-api-key
+    final keyComponents = apiKey.split(':');
+    if (keyComponents.length != 2) {
+      return apiKey;
+    }
+    final publicApiKey = keyComponents[0];
+    final apiKeySecret = keyComponents[1];
+    return '$publicApiKey:${'*' * apiKeySecret.length}';
+  }
+}


### PR DESCRIPTION
The example app UI remains the same. In this PR, I refactor the system details section you see below into a separate widget.

![Screenshot 2021-11-19 at 10 15 36](https://user-images.githubusercontent.com/24711048/142606021-0bc255de-37d7-47d2-8fd0-f274abea2810.png)
