### PR TITLE
Run dispose implementation (clearing rest/realtime client instances) immediately, not with `dispatch_async`

### DIFF
--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -131,17 +131,6 @@
         [NSException raise:NSInvalidArgumentException format:@"completionHandler cannot be nil."];
     }
     
-    dispatch_assert_queue(dispatch_get_main_queue());
-
-    // This is contrived for now but the point is that we can introduce a clean,
-    // asynchronous close via a background queue here if required.
-    dispatch_async(dispatch_get_main_queue(), ^{
-        [self dispose];
-        completionHandler();
-    });
-}
-
--(void)dispose {
     for (ARTRealtime *const r in _realtimeInstances.allValues) {
         [r close];
     }


### PR DESCRIPTION
I'm moving this code from running in the background, to instead run synchronously. 

This fixes a race condition bug where dispose is first called from the Dart side to clear all the instances of realtime and rest. Unfortunately the actual implementation of `dispose` might only happen afterwards, because of `dispatch_async`. By that time, a user might have created a new realtime instance. Then, this dispose method finally gets called, and their client is deleted, almost immediately after they create it.

This was actually discovered because I **removed** the button `create realtime`, and created the realtime client on launch instead. User applications would likely create a realtime instance either on application launch or user log in too.