### PR TITLE
Explicitly check types when deserializing (Handle `NSNull` case)

### DIFF
--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -578,7 +578,7 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutter *const ably, Flutt
                     message:[NSString stringWithFormat:@"Error getting first page; err = %@", [error message]]
                     details:error
                     ]);
-        }else{
+        } else {
             NSNumber *const paginatedResultHandle = [instanceStore setPaginatedResult:paginatedResult handle:handle];
             result([[AblyFlutterMessage alloc] initWithMessage:paginatedResult handle: paginatedResultHandle]);
         }

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -155,17 +155,33 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
 };
 
 +(ARTTokenDetails *)tokenDetailsFromDictionary: (NSDictionary *) dictionary {
-    __block NSString *token = nil;
-    __block NSDate *expires = nil;
-    __block NSDate *issued = nil;
-    __block NSString *capability = nil;
-    __block NSString *clientId = nil;
+    NSString *token = nil;
+    NSDate *expires = nil;
+    NSDate *issued = nil;
+    NSString *capability = nil;
+    NSString *clientId = nil;
     
-    ON_VALUE(^(const id value) { token = value; }, dictionary, TxTokenDetails_token);
-    ON_VALUE(^(const id value) { expires = value; }, dictionary, TxTokenDetails_expires);
-    ON_VALUE(^(const id value) { issued = value; }, dictionary, TxTokenDetails_issued);
-    ON_VALUE(^(const id value) { capability = value; }, dictionary, TxTokenDetails_capability);
-    ON_VALUE(^(const id value) { clientId = value; }, dictionary, TxTokenDetails_clientId);
+    if ([dictionary[TxTokenDetails_token] isKindOfClass: [NSString class]]) {
+        token = dictionary[TxTokenDetails_token];
+    }
+    
+    if ([dictionary[TxTokenDetails_expires] isKindOfClass: [NSNumber class]]) {
+        NSNumber *const timeInMilliseconds = dictionary[TxTokenDetails_issued];
+        expires = [NSDate dateWithTimeIntervalSince1970:timeInMilliseconds.doubleValue];
+    }
+    
+    if ([dictionary[TxTokenDetails_issued] isKindOfClass: [NSNumber class]]) {
+        NSNumber *const timeInMilliseconds = dictionary[TxTokenDetails_issued];
+        issued = [NSDate dateWithTimeIntervalSince1970:timeInMilliseconds.doubleValue];
+    }
+    
+    if ([dictionary[TxTokenDetails_capability] isKindOfClass: [NSString class]]) {
+        capability = dictionary[TxTokenDetails_capability];
+    }
+    
+    if ([dictionary[TxTokenDetails_clientId] isKindOfClass: [NSString class]]) {
+        clientId = dictionary[TxTokenDetails_clientId];
+    }
     
     return [[ARTTokenDetails alloc] initWithToken:token expires:expires issued:issued capability:capability clientId:clientId];
 }

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -381,7 +381,8 @@ class TxPushRequestPermission {
   static const String alert = 'alert';
   static const String carPlay = 'carPlay';
   static const String criticalAlert = 'criticalAlert';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String provisional = 'provisional';
   static const String announcement = 'announcement';
 }
@@ -397,7 +398,8 @@ class TxUNNotificationSettings {
   static const String alertStyle = 'alertStyle';
   static const String showPreviewsSetting = 'showPreviewsSetting';
   static const String criticalAlertSetting = 'criticalAlertSetting';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String announcementSetting = 'announcementSetting';
   static const String scheduledDeliverySetting = 'scheduledDeliverySetting';
   static const String timeSensitiveSetting = 'timeSensitiveSetting';


### PR DESCRIPTION
When deserializing TokenDetails from the Dart side, we used `ON_VALUE`, a macro which will run the block (aka. closure) when the value is not **nil**. Unfortunately, this means the macro will run the block when the value is `NSNull`. If a user doesn't set TokenDetails, the properties would be `NSNull`, not `nil`, as per ["Platform channel data types support and codecs"](https://docs.flutter.dev/development/platform-integration/platform-channels#codec). 
![CleanShot 2021-11-23 at 15 09 35](https://user-images.githubusercontent.com/24711048/143049987-c93132cf-9cbc-4268-a281-84929941f255.png)

This results in crashing once we try to read these properties in Swift later on, e.g. Calling `ARTRealtime.device` and reading the `ARTLocalDevice`'s `clientId` property. 

An alternative for this fix would to update the macro to check for `NSNull` too. However, I didn't want to modify `ON_VALUE`, which is macro used 21 times in the file. We would be re-writing this file in Swift in the near future.

# Another bug fix:
I also actually convert the NSNumber into a NSDate properly. Instead of just casting `expires` and `issued` to `NSDate`. If specified, they would be `NSNumber`, not `NSDate`, so the code I added actually converts it to an `NSDate`. 