### PR TITLE
Explicitly check types of tokenDetails, instead of using macro which …

### DIFF
--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -157,18 +157,34 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
 };
 
 +(ARTTokenDetails *)tokenDetailsFromDictionary: (NSDictionary *) dictionary {
-    __block NSString *token = nil;
-    __block NSDate *expires = nil;
-    __block NSDate *issued = nil;
-    __block NSString *capability = nil;
-    __block NSString *clientId = nil;
-    
-    ON_VALUE(^(const id value) { token = value; }, dictionary, TxTokenDetails_token);
-    ON_VALUE(^(const id value) { expires = value; }, dictionary, TxTokenDetails_expires);
-    ON_VALUE(^(const id value) { issued = value; }, dictionary, TxTokenDetails_issued);
-    ON_VALUE(^(const id value) { capability = value; }, dictionary, TxTokenDetails_capability);
-    ON_VALUE(^(const id value) { clientId = value; }, dictionary, TxTokenDetails_clientId);
-    
+    NSString *token = nil;
+    NSDate *expires = nil;
+    NSDate *issued = nil;
+    NSString *capability = nil;
+    NSString *clientId = nil;
+
+    if ([dictionary[TxTokenDetails_token] isKindOfClass: [NSString class]]) {
+        token = dictionary[TxTokenDetails_token];
+    }
+
+    if ([dictionary[TxTokenDetails_expires] isKindOfClass: [NSNumber class]]) {
+        NSNumber *const timeInMilliseconds = dictionary[TxTokenDetails_issued];
+        expires = [NSDate dateWithTimeIntervalSince1970:timeInMilliseconds.doubleValue];
+    }
+
+    if ([dictionary[TxTokenDetails_issued] isKindOfClass: [NSNumber class]]) {
+        NSNumber *const timeInMilliseconds = dictionary[TxTokenDetails_issued];
+        issued = [NSDate dateWithTimeIntervalSince1970:timeInMilliseconds.doubleValue];
+    }
+
+    if ([dictionary[TxTokenDetails_capability] isKindOfClass: [NSString class]]) {
+        capability = dictionary[TxTokenDetails_capability];
+    }
+
+    if ([dictionary[TxTokenDetails_clientId] isKindOfClass: [NSString class]]) {
+        clientId = dictionary[TxTokenDetails_clientId];
+    }
+
     return [[ARTTokenDetails alloc] initWithToken:token expires:expires issued:issued capability:capability clientId:clientId];
 }
 


### PR DESCRIPTION
I've copied the fixes from https://github.com/ably/ably-flutter/pull/251 because there were too many PRs waiting to be reviewed before this bug could be fixed. We want to release this for a customer.

Please see https://github.com/ably/ably-flutter/pull/251

@lukasz-szyszkowski has already approved that one.