### PR TITLE
Add integration test for API level 31

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -36,7 +36,7 @@ jobs:
   android:
     strategy:
       matrix:
-        api-level: [21, 24, 30]
+        api-level: [21, 24, 31]
       fail-fast: false
 
     # ubuntu-latest cannot be used as it is only a docker container, and unfortunately running

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -57,6 +57,9 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          # Specifying google_apis because default does not work. See https://github.com/ReactiveCircus/android-emulator-runner/issues/202
+          target: google_apis 
+          arch: x86_64
           script: |
             /Users/runner/Library/Android/sdk/cmdline-tools/latest/bin/avdmanager list
             flutter pub get

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: subosito/flutter-action@v1
 
-      - name: 'Run Flutter Driver tests'
+      - name: 'Run integration tests on iOS'
         timeout-minutes: 30
         run: |
           flutter pub get
@@ -36,7 +36,7 @@ jobs:
   android:
     strategy:
       matrix:
-        api-level: [21, 29]
+        api-level: [21, 29, 31]
       fail-fast: false
 
     # ubuntu-latest cannot be used as it is only a docker container, and unfortunately running
@@ -52,12 +52,12 @@ jobs:
 
       - uses: subosito/flutter-action@v1
 
-      - name: 'Run Flutter Driver tests'
+      - name: 'Run integration tests on Android ${{ matrix.device }}'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
           script: |
-            /Users/runner/Library/Android/sdk/tools/bin/avdmanager list
+            /Users/runner/Library/Android/sdk/cmdline-tools/latest/bin/avdmanager list
             flutter pub get
             cd test_integration && ./run_integration_tests.sh

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -36,7 +36,7 @@ jobs:
   android:
     strategy:
       matrix:
-        api-level: [21, 29, 31]
+        api-level: [21, 24, 30]
       fail-fast: false
 
     # ubuntu-latest cannot be used as it is only a docker container, and unfortunately running


### PR DESCRIPTION
Newer versions of Android are available, and we should test the SDK on them. Here, I run integration tests on Android API level 31 (latest) and 24 (anecdotally, this is where some changes were made on Android where I have seen things to suddenly stop working)).

I needed to specify architecture and target to allow Android API level 30 and 31 emulators to work. I also needed to update the command usde (avdmanager) because `/Users/runner/Library/Android/sdk/tools/bin/avdmanager` is no longer available for newer versions of Android SDK.