### PR TITLE
`Resumed` being sent as `nil` when it is false

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -879,7 +879,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
         jsonMap, PlatformConstants.TxChannelStateChange.previous, encodeChannelState(c.previous));
     writeValueToJson(
         jsonMap, PlatformConstants.TxChannelStateChange.event, encodeChannelEvent(c.event));
-    writeValueToJson(jsonMap, PlatformConstants.TxChannelStateChange.resumed, c.resumed);
+    jsonMap.put(PlatformConstants.TxChannelStateChange.resumed, c.resumed);
     writeValueToJson(
         jsonMap, PlatformConstants.TxChannelStateChange.reason, encodeErrorInfo(c.reason));
     return jsonMap;

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -228,7 +228,7 @@ static AblyCodecEncoder encodeChannelStateChange = ^NSMutableDictionary*(ARTChan
                 TxChannelStateChange_event,
                 [AblyFlutterWriter encodeChannelEvent: [stateChange event]]);
 
-    WRITE_VALUE(dictionary, TxChannelStateChange_resumed, [stateChange resumed]?@([stateChange resumed]):nil);
+    dictionary[TxChannelStateChange_resumed] = [NSNumber numberWithBool: [stateChange resumed]];
     WRITE_VALUE(dictionary, TxChannelStateChange_reason, encodeErrorInfo([stateChange reason]));
     return dictionary;
 };

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -1014,7 +1014,7 @@ class Codec extends StandardMessageCodec {
         _readFromJson<String>(jsonMap, TxChannelStateChange.previous));
     final event = _decodeChannelEvent(
         _readFromJson<String>(jsonMap, TxChannelStateChange.event));
-    final resumed = _readFromJson<bool>(jsonMap, TxChannelStateChange.resumed);
+    final resumed = jsonMap[TxChannelStateChange.resumed] as bool;
     final errorInfo =
         toJsonMap(_readFromJson<Map>(jsonMap, TxChannelStateChange.reason));
     final reason = (errorInfo == null) ? null : _decodeErrorInfo(errorInfo);

--- a/lib/src/realtime/src/channel_state_event.dart
+++ b/lib/src/realtime/src/channel_state_event.dart
@@ -30,7 +30,7 @@ class ChannelStateChange {
   ErrorInfo? reason;
 
   /// https://docs.ably.com/client-lib-development-guide/features/#TH4
-  final bool? resumed;
+  final bool resumed;
 
   /// initializes with [resumed] set to false
   ChannelStateChange(


### PR DESCRIPTION
A customer has faced an issue with `resumed` being nullable (and null), and therefore crashes the app (IIRC). Unfortunately, in Objective-C, if the boolean is `False`, `nil` is sent to the Dart side.

In this PR, I fix this bug, and update the Dart interface to be consistent with platform: `resumed` is a field/property that is never `null`. 

