### PR TITLE
iOS simulator enhancement for Push activation/deactivation

### DIFF
--- a/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
@@ -59,7 +59,8 @@ class PushNotificationsActivationSliver extends HookWidget {
           TextSpan(
               text: 'APNs is not available on iOS simulators, so you cannot '
                   'activate the device Ably, since this step requires the'
-                  ' APNs device token.',
+                  ' APNs device token. Calling activate/deactivate will '
+                  'throw an exception.',
               style: TextStyle(color: Colors.black))
         ])),
       );

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -9,18 +9,28 @@ public class PushHandlers: NSObject {
         if PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate != nil {
             returnMethodAlreadyRunningError(result: result, methodName: "activate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
-            PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate = result
-            push.activate()
+            #if targetEnvironment(simulator)
+            print("Device activated for push immediately because you application is running in simulator. APNs does not work on a simulator.")
+                result(nil)
+            #else
+                PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate = result
+                push.activate()
+            #endif
         }
     }
 
     @objc
     public static let deactivate: FlutterHandler = { ably, call, result in
-        if PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate != nil {
+        if (PushActivationEventHandlers.getInstance(methodChannel: plugin.ably.channel!).flutterResultForDeactivate != nil) {
             returnMethodAlreadyRunningError(result: result, methodName: "deactivate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
-            PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate = result
-            push.deactivate()
+            #if targetEnvironment(simulator)
+            print("Device deactivated for push immediately because you application is running in simulator. APNs does not work on a simulator.")
+                result(nil)
+            #else
+                PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate = result
+                push.deactivate()
+            #endif
         }
     }
 

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -20,7 +20,7 @@ public class PushHandlers: NSObject {
 
     @objc
     public static let deactivate: FlutterHandler = { ably, call, result in
-        if PushActivationEventHandlers.getInstance(methodChannel: plugin.ably.channel!).flutterResultForDeactivate != nil {
+        if PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate != nil {
             returnMethodAlreadyRunningError(result: result, methodName: "deactivate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -11,11 +11,9 @@ public class PushHandlers: NSObject {
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)
                 result(FlutterError(code: "PushHandlers_activate", message: "Device activation for push notifications does not work on iOS simulator because APNs is not supported.", details: nil))
-                return
             #else
                 PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate = result
                 push.activate()
-                return
             #endif
         }
     }
@@ -27,7 +25,6 @@ public class PushHandlers: NSObject {
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)
                 result(FlutterError(code: "PushHandlers_deactivate", message: "Device deactivation for push notifications does not work on iOS simulator because APNs is not supported.", details: nil))
-                return
             #else
                 PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate = result
                 push.deactivate()

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -22,7 +22,7 @@ public class PushHandlers: NSObject {
 
     @objc
     public static let deactivate: FlutterHandler = { ably, call, result in
-        if (PushActivationEventHandlers.getInstance(methodChannel: plugin.ably.channel!).flutterResultForDeactivate != nil) {
+        if PushActivationEventHandlers.getInstance(methodChannel: plugin.ably.channel!).flutterResultForDeactivate != nil {
             returnMethodAlreadyRunningError(result: result, methodName: "deactivate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -10,11 +10,12 @@ public class PushHandlers: NSObject {
             returnMethodAlreadyRunningError(result: result, methodName: "activate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)
-            print("Device activated for push immediately because you application is running in simulator. APNs does not work on a simulator.")
-                result(nil)
+                result(FlutterError(code: "PushHandlers_activate", message: "Device activation for push notifications does not work on iOS simulator because APNs is not supported.", details: nil))
+                return
             #else
                 PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate = result
                 push.activate()
+                return
             #endif
         }
     }
@@ -25,8 +26,8 @@ public class PushHandlers: NSObject {
             returnMethodAlreadyRunningError(result: result, methodName: "deactivate")
         } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             #if targetEnvironment(simulator)
-            print("Device deactivated for push immediately because you application is running in simulator. APNs does not work on a simulator.")
-                result(nil)
+                result(FlutterError(code: "PushHandlers_deactivate", message: "Device deactivation for push notifications does not work on iOS simulator because APNs is not supported.", details: nil))
+                return
             #else
                 PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate = result
                 push.deactivate()


### PR DESCRIPTION
Currently, when calling `realtime.push.activate/deactivate` on iOS simulators, the method never returns because Ably Cocoa never completes its callbacks.

This means users had to code around the problem, either by adding a timeout if it were a simulator, or avoiding calling the method at all if it were the simulator. This is annoying and leads to more complex for users.

To fix this, we check for the iOS simulator on the iOS side, and throw and error immediately instead of never completing the future.

# Alternative
We could create a random APNs token if running on iOS simulator, so that subscriptions can still be created. However, this might pollute the data, since these device registrations would be for simulators, and completely useless.