### PR TITLE
Send deviceToken to Ably clients which already have been instantiated

### DIFF
--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -142,7 +142,6 @@ import ably_flutter
     override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
         NSLog("application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription)
         AblyInstanceStore.sharedInstance().didFailToRegisterForRemoteNotificationsWithError_error = error;
-
     }
 }
 

--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -98,6 +98,45 @@ try {
 }
 ```
 
+- On iOS, conflicts with other dependencies or your native code might cause Ably to never receive the APNs device token. 
+  This will cause calls to `activate` to never complete (The future never completes with a success or error). 
+  In this case, you should provide Ably Flutter with the device token manually in your `didRegisterForRemoteNotificationsWithDeviceToken` and `didFailToRegisterForRemoteNotificationsWithError` in your AppDelegate.
+  - In `AppDelegate.m` (Objective-C),  
+```objective-c
+#import "AblyFlutter.h"
+
+@implementation AppDelegate
+
+...
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [AblyInstanceStore.sharedInstance didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    AblyInstanceStore.sharedInstance.didFailToRegisterForRemoteNotificationsWithError_error = error;
+}
+
+@end
+```
+  - In `AppDelegate.swift` (Swift),
+```swift
+import ably_flutter
+
+class AppDelegate : FlutterAppDelegate {
+    ...
+
+    override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        AblyInstanceStore.sharedInstance().didRegisterForRemoteNotificationsWithDeviceToken_deviceToken(deviceToken)
+    }
+    
+    override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        AblyInstanceStore.sharedInstance().didFailToRegisterForRemoteNotificationsWithError_error = error;
+    }
+}
+
+```
+
 - Listen to push events: You should listen to the `Push.pushEvents.onUpdateFailed` stream to be informed when a new token update (FCM registration token / APNs device token) fails to be updated with Ably. If this update process fails, Ably servers will attempt to use the old tokens to send messages to devices and potentially fail.
     - Optional: listen to `Push.pushEvents.onActivate` and `Push.pushEvents.onDeactivate`. This is optional because `Push.activate` and `Push.deactivate` will return when it succeeds, and throw when it fails.
 

--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -121,17 +121,28 @@ try {
 ```
   - In `AppDelegate.swift` (Swift),
 ```swift
+import UIKit
+import Flutter
 import ably_flutter
 
-class AppDelegate : FlutterAppDelegate {
-    ...
-
+@UIApplicationMain
+@objc class AppDelegate: FlutterAppDelegate {
+  override func application(
+    _ application: UIApplication,
+    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
+  ) -> Bool {
+    GeneratedPluginRegistrant.register(with: self)
+    return super.application(application, didFinishLaunchingWithOptions: launchOptions)
+  }
+    
     override func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
-        AblyInstanceStore.sharedInstance().didRegisterForRemoteNotificationsWithDeviceToken_deviceToken(deviceToken)
+        AblyInstanceStore.sharedInstance().didRegisterForRemoteNotifications(withDeviceToken: deviceToken)
     }
     
     override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        NSLog("application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription)
         AblyInstanceStore.sharedInstance().didFailToRegisterForRemoteNotificationsWithError_error = error;
+
     }
 }
 

--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -1,6 +1,5 @@
 #import "AppDelegate.h"
 #import "GeneratedPluginRegistrant.h"
-#import "AblyFlutter.h"
 
 @implementation AppDelegate
 
@@ -14,6 +13,10 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     [GeneratedPluginRegistrant registerWithRegistry:self];
     // Override point for customization after application launch.
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    NSLog(@"application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription);
 }
 
 @end

--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -16,13 +16,4 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
-- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    [AblyInstanceStore.sharedInstance didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-}
-
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-    NSLog(@"application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription);
-    AblyInstanceStore.sharedInstance.didFailToRegisterForRemoteNotificationsWithError_error = error;
-}
-
 @end

--- a/example/ios/Runner/AppDelegate.m
+++ b/example/ios/Runner/AppDelegate.m
@@ -1,5 +1,6 @@
 #import "AppDelegate.h"
 #import "GeneratedPluginRegistrant.h"
+#import "AblyFlutter.h"
 
 @implementation AppDelegate
 
@@ -15,8 +16,13 @@ didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
     return [super application:application didFinishLaunchingWithOptions:launchOptions];
 }
 
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
+    [AblyInstanceStore.sharedInstance didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+}
+
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
     NSLog(@"application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription);
+    AblyInstanceStore.sharedInstance.didFailToRegisterForRemoteNotificationsWithError_error = error;
 }
 
 @end

--- a/ios/Classes/AblyFlutter.h
+++ b/ios/Classes/AblyFlutter.h
@@ -10,8 +10,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property(nonatomic) AblyInstanceStore * instanceStore;
 @property(nonatomic) FlutterMethodChannel *channel;
-@property(nonatomic, nullable) NSData * didRegisterForRemoteNotificationsWithDeviceToken_deviceToken;
-@property(nonatomic, nullable) NSError * didFailToRegisterForRemoteNotificationsWithError_error;
 
 @end
 

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -715,8 +715,10 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutter *const ably, Flutt
 #pragma mark - Push Notifications Registration - UIApplicationDelegate
 /// Save the deviceToken provided so we can pass it to the first Ably client which gets created, in createRealtime or createRest.
 -(void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken {
-    // This deviceToken will be used when a new Ably client (either realtime or rest) is made.
+    // Set deviceToken on future Ably clients (either realtime or rest) are made.
     _didRegisterForRemoteNotificationsWithDeviceToken_deviceToken = deviceToken;
+    // Set deviceToken on all existing Ably clients.
+    [_instanceStore didRegisterForRemoteNotificationsWithDeviceToken: deviceToken];
 }
 
 /// Save the error if it occurred during APNs device registration provided so we can pass it to the first Ably client which gets created, in createRealtime or createRest.

--- a/ios/Classes/AblyInstanceStore.h
+++ b/ios/Classes/AblyInstanceStore.h
@@ -25,6 +25,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 -(ARTPaginatedResult *) getPaginatedResult:(NSNumber *const) handle;
 
+-(void) didRegisterForRemoteNotificationsWithDeviceToken:(NSData *const) deviceToken;
+
 -(void)reset;
 
 @end

--- a/ios/Classes/AblyInstanceStore.h
+++ b/ios/Classes/AblyInstanceStore.h
@@ -27,6 +27,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 -(void) didRegisterForRemoteNotificationsWithDeviceToken:(NSData *const) deviceToken;
 
+@property(nonatomic, nullable) NSData * didRegisterForRemoteNotificationsWithDeviceToken_deviceToken;
+
+@property(nonatomic, nullable) NSError * didFailToRegisterForRemoteNotificationsWithError_error;
+
 -(void)reset;
 
 @end

--- a/ios/Classes/AblyInstanceStore.m
+++ b/ios/Classes/AblyInstanceStore.m
@@ -65,6 +65,18 @@
     return _paginatedResults[handle];
 }
 
+// Set device token on all existing clients
+-(void) didRegisterForRemoteNotificationsWithDeviceToken:(NSData *const) deviceToken {
+    for (id restHandle in _restInstances) {
+        ARTRest *const rest = _restInstances[restHandle];
+        [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken rest:rest];
+    }
+    for (id realtimeHandle in _realtimeInstances) {
+        ARTRealtime *const realtime = _realtimeInstances[realtimeHandle];
+        [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken realtime:realtime];
+    }
+}
+
 -(void)reset {
     for (ARTRealtime *const r in _realtimeInstances.allValues) {
         [r close];

--- a/ios/Classes/AblyInstanceStore.m
+++ b/ios/Classes/AblyInstanceStore.m
@@ -67,6 +67,8 @@
 
 // Set device token on all existing clients
 -(void) didRegisterForRemoteNotificationsWithDeviceToken:(NSData *const) deviceToken {
+    _didRegisterForRemoteNotificationsWithDeviceToken_deviceToken = deviceToken;
+    
     for (id restHandle in _restInstances) {
         ARTRest *const rest = _restInstances[restHandle];
         [ARTPush didRegisterForRemoteNotificationsWithDeviceToken:deviceToken rest:rest];

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -6,21 +6,21 @@ public class PushHandlers: NSObject {
 
     @objc
     public static let activate: FlutterHandler = { ably, call, result in
-        if (PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate != nil) {
-            returnMethodAlreadyRunningError(result: result, methodName: "activate")
-        } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
+        if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForActivate = result
             push.activate()
+        } else {
+            result(FlutterError(code: "PushHandlers#activate", message: "Cannot get push from client", details: nil))
         }
     }
 
     @objc
     public static let deactivate: FlutterHandler = { ably, call, result in
-        if (PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate != nil) {
-            returnMethodAlreadyRunningError(result: result, methodName: "deactivate")
-        } else if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
+        if let push = getPush(instanceStore: ably.instanceStore, call: call, result: result) {
             PushActivationEventHandlers.getInstance(methodChannel: ably.channel).flutterResultForDeactivate = result
             push.deactivate()
+        } else {
+            result(FlutterError(code: "PushHandlers#deactivate", message: "Cannot get push from client", details: nil))
         }
     }
 
@@ -29,11 +29,6 @@ public class PushHandlers: NSObject {
         UNUserNotificationCenter.current().getNotificationSettings { [result] settings in
             result(settings)
         }
-    }
-
-    private static func returnMethodAlreadyRunningError(result: FlutterResult, methodName: String) {
-        let error = FlutterError(code: "methodAlreadyRunning", message: "\(methodName) already running. Do not attempt to call \(methodName) before the previous call completes", details: nil)
-        result(error)
     }
 
     @objc


### PR DESCRIPTION
This PR does 2 things:
- It fixes https://github.com/ably/ably-flutter/issues/276
- It allows users to give Ably flutter the device token if they're having issues activating push with Ably. This happens because in some cases (e.g. a customer), `didRegisterForRemoteNotifications` does not get called in Ably Flutter when running on iOS. This might happen due to method swizzling by other dependencies. This is a **workaround** for users who cannot fix the fact `didRegisterForRemoteNotifications` is not being called in Ably Flutter.