### PR TITLE
Add workaround for firebase messaging

### DIFF
--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -3,8 +3,7 @@
 
 #### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
 
-If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict rising from the two libraries installed together.
-
+If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict that happens when the two libraries are installed together.
 ```xml
 <receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
         tools:node="remove">

--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -1,5 +1,15 @@
 # Push Notifications
 
+
+#### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
+
+If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict rising from the two libraries installed together.
+
+```xml
+<receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
+        tools:node="remove">
+</receiver>
+```
 Push Notifications allow you to reach users who have your application in the foreground, background and terminated, including when your application is not connected to Ably. Push notifications allow you to run code and show alerts to the user. On iOS, Ably connects to [APNs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) to send messages to devices. On Android, Ably connects to [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) to send messages to devices. As both services do not guarantee message delivery and may even throttle messages to specific devices based on battery level, message frequency, and other criteria, messages may arrive much later than sent or ignored.
 
 ## Known Limitations

--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -1,14 +1,15 @@
 # Push Notifications
 
-
 #### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
 
 If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict that happens when the two libraries are installed together.
+
 ```xml
 <receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
         tools:node="remove">
 </receiver>
 ```
+
 Push Notifications allow you to reach users who have your application in the foreground, background and terminated, including when your application is not connected to Ably. Push notifications allow you to run code and show alerts to the user. On iOS, Ably connects to [APNs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) to send messages to devices. On Android, Ably connects to [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) to send messages to devices. As both services do not guarantee message delivery and may even throttle messages to specific devices based on battery level, message frequency, and other criteria, messages may arrive much later than sent or ignored.
 
 ## Known Limitations

--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -1,8 +1,10 @@
 # Push Notifications
 
-#### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
+Push Notifications allow you to reach users who have your application in the foreground, background and terminated, including when your application is not connected to Ably. Push notifications allow you to run code and show alerts to the user. On iOS, Ably connects to [APNs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) to send messages to devices. On Android, Ably connects to [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) to send messages to devices. As both services do not guarantee message delivery and may even throttle messages to specific devices based on battery level, message frequency, and other criteria, messages may arrive much later than sent or ignored.
 
-If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict that happens when the two libraries are installed together.
+## Important Note regarding Firebase Messaging Plugin
+
+If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file, within the `application` element. This is a workaround that prevents a conflict that happens when the two libraries are installed together.
 
 ```xml
 <receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
@@ -10,7 +12,7 @@ If you are using the [official Firebase messaging library package](https://pub.d
 </receiver>
 ```
 
-Push Notifications allow you to reach users who have your application in the foreground, background and terminated, including when your application is not connected to Ably. Push notifications allow you to run code and show alerts to the user. On iOS, Ably connects to [APNs](https://developer.apple.com/library/archive/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/APNSOverview.html) to send messages to devices. On Android, Ably connects to [Firebase Cloud Messaging](https://firebase.google.com/docs/cloud-messaging/) to send messages to devices. As both services do not guarantee message delivery and may even throttle messages to specific devices based on battery level, message frequency, and other criteria, messages may arrive much later than sent or ignored.
+See [issue #226](https://github.com/ably/ably-flutter/issues/226).
 
 ## Known Limitations
  

--- a/README.md
+++ b/README.md
@@ -96,8 +96,6 @@ If you are using [official Firebase messaging library package](https://pub.dev/p
         tools:node="remove">
 </receiver>
 
-https://pub.dev/packages/firebase_messaging
-
 ### Troubleshooting
 
 - Running on simulator on M1 macs:

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ Warning
 
 If you are using [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, you must add following block to your Android application's manifest file under application tag. This is a workaround that prevents a conflict risen from two libraries installed together. 
 
+```xml
 <receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
         tools:node="remove">
 </receiver>
+```
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -88,16 +88,6 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 
-#### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
-
-If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict rising from the two libraries installed together. 
-
-```xml
-<receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
-        tools:node="remove">
-</receiver>
-```
-
 ### Troubleshooting
 
 - Running on simulator on M1 macs:

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 
-#### Important Note regarding Firebase and Push Notifications
+#### [Important Note regarding Firebase and Push Notifications](https://github.com/ably/ably-flutter/issues/226)
 
 If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict rising from the two libraries installed together. 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 
-###### **Please note:**
+#### Important Note regarding Firebase and Push Notifications
 
 If you are using [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, you must add following block to your Android application's manifest file under application tag. This is a workaround that prevents a conflict risen from two libraries installed together. 
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 
-Warning
+###### **Please note:**
 
 If you are using [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, you must add following block to your Android application's manifest file under application tag. This is a workaround that prevents a conflict risen from two libraries installed together. 
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 
+Warning
+
+If you are using [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, you must add following block to your Android application's manifest file under application tag. This is a workaround that prevents a conflict risen from two libraries installed together. 
+
+<receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"
+        tools:node="remove">
+</receiver>
+
+https://pub.dev/packages/firebase_messaging
+
 ### Troubleshooting
 
 - Running on simulator on M1 macs:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ See [PushNotifications.md](PushNotifications.md) for detailed information on get
 
 #### Important Note regarding Firebase and Push Notifications
 
-If you are using [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, you must add following block to your Android application's manifest file under application tag. This is a workaround that prevents a conflict risen from two libraries installed together. 
+If you are using the [official Firebase messaging library package](https://pub.dev/packages/firebase_messaging) along with this library, then you must add the following block to your Android application's manifest file within the `application` element. This is a workaround that prevents a conflict rising from the two libraries installed together. 
 
 ```xml
 <receiver android:name="io.ably.flutter.plugin.push.FirebaseMessagingReceiver"


### PR DESCRIPTION
This PR adds a warning for users who use Firebase messaging library along with Ably library