### PR TITLE
Update to `ably-cocoa` v.1.2.8

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.7):
+  - Ably (1.2.8):
     - AblyDeltaCodec (= 1.3.2)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.8):
-    - Ably (= 1.2.7)
+    - Ably (= 1.2.8)
     - Flutter
   - AblyDeltaCodec (1.3.2)
   - device_info_plus (0.0.1):
@@ -44,8 +44,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/fluttertoast/ios"
 
 SPEC CHECKSUMS:
-  Ably: f627c0c2e4489785b74d33d2c1287edeb9c6a7be
-  ably_flutter: 5fb4de0b34249fef68621d0bd50470703ea8e707
+  Ably: f5de469bc7b0804cb11b6b5c4c9c76e9ee5991db
+  ably_flutter: f7a5de66f3d06474e06e244537b6da4fcd4065c7
   AblyDeltaCodec: 783d017270de70bbbc0a84e4235297b225d33636
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a

--- a/ios/ably_flutter.podspec
+++ b/ios/ably_flutter.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Ably', '1.2.7'
+  s.dependency 'Ably', '1.2.8'
   s.platform = :ios
   s.ios.deployment_target  = '10.0'
 

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.7):
+  - Ably (1.2.8):
     - AblyDeltaCodec (= 1.3.2)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.8):
-    - Ably (= 1.2.7)
+    - Ably (= 1.2.8)
     - Flutter
   - AblyDeltaCodec (1.3.2)
   - Flutter (1.0.0)
@@ -26,12 +26,12 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  Ably: f627c0c2e4489785b74d33d2c1287edeb9c6a7be
-  ably_flutter: 5fb4de0b34249fef68621d0bd50470703ea8e707
+  Ably: f5de469bc7b0804cb11b6b5c4c9c76e9ee5991db
+  ably_flutter: f7a5de66f3d06474e06e244537b6da4fcd4065c7
   AblyDeltaCodec: 783d017270de70bbbc0a84e4235297b225d33636
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   msgpack: c85f6251873059738472ae136951cec5f30f3251
 
 PODFILE CHECKSUM: f2c6cc511583caab2c65ac3f5766428391d93d34
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2


### PR DESCRIPTION
This involved (some steps may have not been required):

1. Modifying version in `ios/ably_flutter.podspec`
2. `flutter clean` from root
3. `flutter pub get` from root
4. `flutter pub get` from `example/`
5. `flutter pub get` from `test_integration/`
6. `pod repo update`
7. `pod update Ably && pod install` from `example/ios`, updating `Podfile.lock` in that folder
8. `pod update Ably && pod install` from `test_integration/ios`, updating `Podfile.lock` in that folder

Fixes #287 