### PR TITLE
Correct the migration guide.

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -2,7 +2,9 @@
 
 This guide lists the changes needed to upgrade from one version of Ably to a newer one when there are breaking changes.
 
-## [Upgrading from v1.2.6]
+## [Upgrading from v1.2.8]
+
+Changes made at v1.2.9:
 
 - `ably.Push.pushEvents` is renamed to `ably.Push.activationEvents`, to be more meaningful. It provides access to events related to setting up push notification, such as activation, deactivation and notification permission. This was done to help future users clearly distinguish between `activationEvents` and `notificationEvents`.
 - When instantiating `Rest` or `Realtime` with an API key, replace `ably.Rest(key: yourApiKey)` with `ably.Rest.fromKey(yourApiKey)`. This was done because using `ably.Rest(key: yourApiKey, options: clientOptions)` was misleading (`yourApiKey` was ignored).


### PR DESCRIPTION
It incorrectly inferred that `activationEvents` was renamed to `pushEvents` in a version earlier than the change was actually made in.

Spotted for us by a customer, see this [internal Slack message](https://ably-real-time.slack.com/archives/C012DA29VM0/p1642757125051200?thread_ts=1642401386.021100&cid=C012DA29VM0).