### PR TITLE
Update to `ably-cocoa` v.1.2.10.

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.9):
+  - Ably (1.2.10):
     - AblyDeltaCodec (= 1.3.2)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.10):
-    - Ably (= 1.2.9)
+    - Ably (= 1.2.10)
     - Flutter
   - AblyDeltaCodec (1.3.2)
   - device_info_plus (0.0.1):
@@ -44,8 +44,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/fluttertoast/ios"
 
 SPEC CHECKSUMS:
-  Ably: 7a28ee5c71f31d415a767e72b3f56e5918537d16
-  ably_flutter: eb447a2905d92c26ff15f61929cfe3b935f13745
+  Ably: 80be962e2e87bac69727a26ba72b868c8e86288e
+  ably_flutter: fa419fb723e5e73739d81416ff5dff7b5e0bf309
   AblyDeltaCodec: 783d017270de70bbbc0a84e4235297b225d33636
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a

--- a/ios/ably_flutter.podspec
+++ b/ios/ably_flutter.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Ably', '1.2.9'
+  s.dependency 'Ably', '1.2.10'
   s.platform = :ios
   s.ios.deployment_target  = '10.0'
 

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.9):
+  - Ably (1.2.10):
     - AblyDeltaCodec (= 1.3.2)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.10):
-    - Ably (= 1.2.9)
+    - Ably (= 1.2.10)
     - Flutter
   - AblyDeltaCodec (1.3.2)
   - Flutter (1.0.0)
@@ -26,8 +26,8 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  Ably: 7a28ee5c71f31d415a767e72b3f56e5918537d16
-  ably_flutter: eb447a2905d92c26ff15f61929cfe3b935f13745
+  Ably: 80be962e2e87bac69727a26ba72b868c8e86288e
+  ably_flutter: fa419fb723e5e73739d81416ff5dff7b5e0bf309
   AblyDeltaCodec: 783d017270de70bbbc0a84e4235297b225d33636
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   msgpack: c85f6251873059738472ae136951cec5f30f3251


### PR DESCRIPTION
The experience of updating this dependency was even worse this time, than [before](https://github.com/ably/ably-flutter/pull/299), and definitely not as easy as [the time before that](https://github.com/ably/ably-flutter/pull/293).

So many layers of tooling. This time I ended up doing `gem update` and also reinstall of `cocoapods` gem. That may have solved it. Not sure, honestly. The pernicious error I kept getting was:

```
ios % pod update Ably
Updating local specs repositories
Analyzing dependencies
[!] CocoaPods could not find compatible versions for pod "Ably":
  In Podfile:
    ably_flutter (from `.symlinks/plugins/ably_flutter/ios`) was resolved to 1.2.10, which depends on
      Ably (= 1.2.10)

None of your spec sources contain a spec satisfying the dependency: `Ably (= 1.2.10)`.

You have either:
 * mistyped the name or version.
 * not added the source repo that hosts the Podspec to your Podfile.
?31
```

TL;DR: Updating the `ably-cocoa` dependency is a PITA!