### PR TITLE
Separate activation broadcast receiver from channel handler class

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyFlutter.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyFlutter.java
@@ -37,6 +37,7 @@ public class AblyFlutter implements FlutterPlugin, ActivityAware, PluginRegistry
     public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {
         applicationContext = flutterPluginBinding.getApplicationContext();
         setupChannels(flutterPluginBinding.getBinaryMessenger(), applicationContext);
+        PushActivationEventHandlers.getInstance().registerReceiver();
     }
 
     // This static function is optional and equivalent to onAttachedToEngine. It supports the old
@@ -70,7 +71,9 @@ public class AblyFlutter implements FlutterPlugin, ActivityAware, PluginRegistry
     }
 
     @Override
-    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+    public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+        PushActivationEventHandlers.getInstance().unregisterReceiver();
+    }
 
     private static MethodCodec createCodec(CipherParamsStorage cipherParamsStorage) {
         return new StandardMethodCodec(new AblyMessageCodec(cipherParamsStorage));

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -628,7 +628,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
     try {
       Integer handle = (Integer) message.message;
-      PushActivationEventHandlers.setResultForActivate(result);
+      PushActivationEventHandlers.getInstance().setResultForActivate(result);
       instanceStore.getPush(handle).activate();
     } catch (AblyException e) {
       handleAblyException(result, e);
@@ -639,7 +639,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
     try {
       Integer handle = (Integer) message.message;
-      PushActivationEventHandlers.setResultForDeactivate(result);
+      PushActivationEventHandlers.getInstance().setResultForDeactivate(result);
       instanceStore.getPush(handle).deactivate();
     } catch (AblyException e) {
       handleAblyException(result, e);

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
@@ -31,7 +31,7 @@ public class PushActivationEventHandlers {
         pushActivationReceiver = new PushActivationReceiver();
     }
 
-    public static void instantiate(Context context, MethodChannel methodChannel) {
+    public static synchronized void instantiate(Context context, MethodChannel methodChannel) {
         if (instance == null) {
             instance = new PushActivationEventHandlers(context, methodChannel);
         }

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
@@ -31,12 +31,16 @@ public class PushActivationEventHandlers {
     }
   }
 
-  public static void setResultForActivate(MethodChannel.Result result) {
-    instance.resultForActivate = result;
+  public static PushActivationEventHandlers getInstance() {
+    return instance;
   }
 
-  public static void setResultForDeactivate(MethodChannel.Result result) {
-    instance.resultForDeactivate = result;
+  public  void setResultForActivate(MethodChannel.Result result) {
+    resultForActivate = result;
+  }
+
+  public void setResultForDeactivate(MethodChannel.Result result) {
+    resultForDeactivate = result;
   }
 
   public PushActivationEventHandlers(Context context, MethodChannel methodChannel) {

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
@@ -41,15 +41,21 @@ public class PushActivationEventHandlers {
         return instance;
     }
 
+    public void registerReceiver(){
+        pushActivationReceiver.register(context,this::activationResultReceived);
+    }
+    public void unregisterReceiver(){
+        pushActivationReceiver.unregister(context);
+    }
+
     public void setResultForActivate(MethodChannel.Result result) {
         resultForActivate = result;
-        pushActivationReceiver.register(context,this::activationResultReceived);
     }
 
     public void setResultForDeactivate(MethodChannel.Result result) {
         resultForDeactivate = result;
-        pushActivationReceiver.register(context,this::activationResultReceived);
     }
+
     private void activationResultReceived(String action, ErrorInfo errorInfo) {
         switch (action) {
             case PUSH_ACTIVATE_ACTION:
@@ -57,7 +63,6 @@ public class PushActivationEventHandlers {
                 if (resultForActivate != null) {
                     Log.d(TAG, "resultForActivate received on PUSH_ACTIVATE_ACTION.");
                     returnMethodCallResult(resultForActivate, errorInfo);
-                    pushActivationReceiver.unregister(context);
                 } else {
                     Log.e(TAG, "resultForActivate is null on PUSH_ACTIVATE_ACTION.");
                 }
@@ -67,7 +72,6 @@ public class PushActivationEventHandlers {
                 if (resultForDeactivate != null) {
                     Log.d(TAG, "resultForDeactivate received on PUSH_DEACTIVATE_ACTION.");
                     returnMethodCallResult(resultForDeactivate, errorInfo);
-                    pushActivationReceiver.unregister(context);
                 } else {
                     Log.e(TAG, "resultForDeactivate is null on PUSH_DEACTIVATE_ACTION.");
                 }

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
@@ -1,110 +1,93 @@
 package io.ably.flutter.plugin.push;
 
-import android.content.Context;
-import android.content.Intent;
-import android.content.IntentFilter;
+import static io.ably.flutter.plugin.push.PushActivationReceiver.PUSH_ACTIVATE_ACTION;
+import static io.ably.flutter.plugin.push.PushActivationReceiver.PUSH_DEACTIVATE_ACTION;
+import static io.ably.flutter.plugin.push.PushActivationReceiver.PUSH_UPDATE_FAILED_ACTION;
 
+import android.content.Context;
 import android.util.Log;
+
 import androidx.annotation.Nullable;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import io.ably.flutter.plugin.generated.PlatformConstants;
 import io.ably.lib.types.ErrorInfo;
-import io.ably.lib.util.IntentUtils;
 import io.flutter.plugin.common.MethodChannel;
 
 public class PushActivationEventHandlers {
-  private static final String TAG = PushActivationEventHandlers.class.getName();
-  private static final String PUSH_ACTIVATE_ACTION = "io.ably.broadcast.PUSH_ACTIVATE";
-  private static final String PUSH_DEACTIVATE_ACTION = "io.ably.broadcast.PUSH_DEACTIVATE";
-  private static final String PUSH_UPDATE_FAILED_ACTION = "io.ably.broadcast.PUSH_UPDATE_FAILED";
+    private static final String TAG = PushActivationEventHandlers.class.getName();
 
-  static PushActivationEventHandlers instance;
-  final private BroadcastReceiver broadcastReceiver;
-  final private MethodChannel methodChannel;
-  private MethodChannel.Result resultForActivate;
-  private MethodChannel.Result resultForDeactivate;
+    private static PushActivationEventHandlers instance;
 
-  public static void instantiate(Context context, MethodChannel methodChannel) {
-    if (instance == null) {
-      instance = new PushActivationEventHandlers(context, methodChannel);
-    }
-  }
+    private MethodChannel.Result resultForActivate;
+    private MethodChannel.Result resultForDeactivate;
 
-  public static PushActivationEventHandlers getInstance() {
-    return instance;
-  }
+    private final PushActivationReceiver pushActivationReceiver;
+    private final MethodChannel methodChannel;
+    private final Context context;
 
-  public  void setResultForActivate(MethodChannel.Result result) {
-    resultForActivate = result;
-  }
-
-  public void setResultForDeactivate(MethodChannel.Result result) {
-    resultForDeactivate = result;
-  }
-
-  public PushActivationEventHandlers(Context context, MethodChannel methodChannel) {
-    this.methodChannel = methodChannel;
-    broadcastReceiver = new BroadcastReceiver(context);
-  }
-
-  class BroadcastReceiver extends android.content.BroadcastReceiver {
-    BroadcastReceiver(Context context) {
-      register(context);
+    private PushActivationEventHandlers(Context context, MethodChannel methodChannel) {
+        this.methodChannel = methodChannel;
+        this.context = context;
+        pushActivationReceiver = new PushActivationReceiver();
     }
 
-    private void register(Context context) {
-      IntentFilter filter = new IntentFilter();
-      filter.addAction(PUSH_ACTIVATE_ACTION);
-      filter.addAction(PUSH_DEACTIVATE_ACTION);
-      filter.addAction(PUSH_UPDATE_FAILED_ACTION);
-      LocalBroadcastManager.getInstance(context).registerReceiver(this, filter);
+    public static void instantiate(Context context, MethodChannel methodChannel) {
+        if (instance == null) {
+            instance = new PushActivationEventHandlers(context, methodChannel);
+        }
     }
 
-    @Override
-    public void onReceive(Context context, Intent intent) {
-      String action = intent.getAction();
-      @Nullable ErrorInfo errorInfo = IntentUtils.getErrorInfo(intent);
-      switch (action) {
-        case PUSH_ACTIVATE_ACTION:
-          callCallbackOnDartSide(PlatformConstants.PlatformMethod.pushOnActivate, errorInfo);
-          if (resultForActivate != null) {
-            Log.d(TAG, "resultForActivate received on PUSH_ACTIVATE_ACTION.");
-            returnMethodCallResult(resultForActivate, errorInfo);
-            resultForActivate = null;
-          } else {
-            Log.e(TAG, "resultForActivate is null on PUSH_ACTIVATE_ACTION.");
-          }
-          break;
-        case PUSH_DEACTIVATE_ACTION:
-          callCallbackOnDartSide(PlatformConstants.PlatformMethod.pushOnDeactivate, errorInfo);
-          if (resultForDeactivate != null) {
-            Log.d(TAG, "resultForDeactivate received on PUSH_DEACTIVATE_ACTION.");
-            returnMethodCallResult(resultForDeactivate, errorInfo);
-            resultForDeactivate = null;
-          } else {
-            Log.e(TAG, "resultForDeactivate is null on PUSH_DEACTIVATE_ACTION.");
-          }
-          break;
-        case PUSH_UPDATE_FAILED_ACTION:
-          callCallbackOnDartSide(PlatformConstants.PlatformMethod.pushOnUpdateFailed, errorInfo);
-          break;
-        default:
-          Log.e(TAG, String.format("Received unknown intent action: %s", action));
-          break;
-      }
+    public static PushActivationEventHandlers getInstance() {
+        return instance;
+    }
+
+    public void setResultForActivate(MethodChannel.Result result) {
+        resultForActivate = result;
+        pushActivationReceiver.register(context,this::activationResultReceived);
+    }
+
+    public void setResultForDeactivate(MethodChannel.Result result) {
+        resultForDeactivate = result;
+        pushActivationReceiver.register(context,this::activationResultReceived);
+    }
+    private void activationResultReceived(String action, ErrorInfo errorInfo) {
+        switch (action) {
+            case PUSH_ACTIVATE_ACTION:
+                methodChannel.invokeMethod(PlatformConstants.PlatformMethod.pushOnActivate, errorInfo);
+                if (resultForActivate != null) {
+                    Log.d(TAG, "resultForActivate received on PUSH_ACTIVATE_ACTION.");
+                    returnMethodCallResult(resultForActivate, errorInfo);
+                    pushActivationReceiver.unregister(context);
+                } else {
+                    Log.e(TAG, "resultForActivate is null on PUSH_ACTIVATE_ACTION.");
+                }
+                break;
+            case PUSH_DEACTIVATE_ACTION:
+                methodChannel.invokeMethod(PlatformConstants.PlatformMethod.pushOnDeactivate, errorInfo);
+                if (resultForDeactivate != null) {
+                    Log.d(TAG, "resultForDeactivate received on PUSH_DEACTIVATE_ACTION.");
+                    returnMethodCallResult(resultForDeactivate, errorInfo);
+                    pushActivationReceiver.unregister(context);
+                } else {
+                    Log.e(TAG, "resultForDeactivate is null on PUSH_DEACTIVATE_ACTION.");
+                }
+                break;
+            case PUSH_UPDATE_FAILED_ACTION:
+                methodChannel.invokeMethod(PlatformConstants.PlatformMethod.pushOnUpdateFailed, errorInfo);
+                break;
+            default:
+                Log.e(TAG, String.format("Received unknown intent action from receiver: %s", action));
+                break;
+        }
+
     }
 
     private void returnMethodCallResult(MethodChannel.Result result, @Nullable ErrorInfo errorInfo) {
-      if (errorInfo != null) {
-        result.error(String.valueOf(errorInfo.code), errorInfo.message, errorInfo);
-      } else {
-        result.success(null);
-      }
+        if (errorInfo != null) {
+            result.error(String.valueOf(errorInfo.code), errorInfo.message, errorInfo);
+        } else {
+            result.success(null);
+        }
     }
 
-    private void callCallbackOnDartSide(String platformMethod, @Nullable ErrorInfo errorInfo) {
-      methodChannel.invokeMethod(platformMethod, errorInfo);
-    }
-  }
 }

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationReceiver.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationReceiver.java
@@ -1,0 +1,46 @@
+package io.ably.flutter.plugin.push;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.localbroadcastmanager.content.LocalBroadcastManager;
+
+import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.util.IntentUtils;
+
+class PushActivationReceiver extends android.content.BroadcastReceiver {
+    static final String PUSH_ACTIVATE_ACTION = "io.ably.broadcast.PUSH_ACTIVATE";
+    static final String PUSH_DEACTIVATE_ACTION = "io.ably.broadcast.PUSH_DEACTIVATE";
+    static final String PUSH_UPDATE_FAILED_ACTION = "io.ably.broadcast.PUSH_UPDATE_FAILED";
+
+    interface Callback {
+        void onReceive(String action, ErrorInfo errorInfo);
+    }
+
+    private Callback callback;
+
+    public void register(@NonNull Context context, @NonNull Callback callback) {
+        IntentFilter filter = new IntentFilter();
+        filter.addAction(PUSH_ACTIVATE_ACTION);
+        filter.addAction(PUSH_DEACTIVATE_ACTION);
+        filter.addAction(PUSH_UPDATE_FAILED_ACTION);
+        this.callback = callback;
+        LocalBroadcastManager.getInstance(context).registerReceiver(this, filter);
+    }
+
+    public void unregister(Context context) {
+        LocalBroadcastManager.getInstance(context).unregisterReceiver(this);
+    }
+
+    @Override
+    public void onReceive(Context context, Intent intent) {
+        String action = intent.getAction();
+        @Nullable ErrorInfo errorInfo = IntentUtils.getErrorInfo(intent);
+        if (callback != null) {
+            callback.onReceive(action, errorInfo);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes **activation handling** code by 
* Fixes some issues with `PushActivationHandlers` singleton, by providing an instance method and converting some static methods into instance methods
* Moves activation broadcast receiver to a separate file, creating methods for registering with callback and unregistering.
* Respects the FlutterEngine lifecycle by registering the receiver when it's attached to engine and deregisters it when it's detached. 



Closes https://github.com/ably/ably-flutter/issues/304

Please note that changes here won't cause a manual application launch, meaning that any message from broadcast receiver will be received only when the Flutter engine is attached. I did this to prevent further bugs raising from inconsistencies related to Flutter engine lifecycle. 
However this is still a temporary solution. A full solution would be to separate third party push plugin so that we can reuse code directly from Firebase library (https://github.com/ably/ably-flutter/issues/292) or completely refactor push notification code on our plugin

Note: Java library will send activation results using broadcasts. That method might have been chosen for native Android apps, but it could be nice if we could have a async alternative that would give results through callback. If so we wouldn't need to deal with broadcast receivers on our plugin.