### PR TITLE
Readme enchancements for example app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ doc/
 
 # And VS Code will create this folder if you tell it to
 .vscode
+!.vscode/launch.json
 
 **/.idea/dictionaries/
 **/.idea/workspace.xml

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "example",
+            "cwd": "example",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "debug",
+            "args": [
+                "--dart-define",
+                "ABLY_API_KEY=replace_with_your_api_key"
+            ],
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 #### Visual Studio Code
 
 - Under `Run and Debug`,
-  - Select the gear icon to view `launch.json`
+  - Select the gear icon to view [launch.json](.vscode/launch.json)
   - Add your Ably API key to the `configurations.args`, i.e. replace `replace_with_your_api_key` with your own Ably API key.
   - To choose a specific device when more than one are connected: to launch on a specific device, make sure it is the only device plugged in. To run on a specific device when you have multiple plugged in, add another element to the `configuration.args` value, with `--device-id=replace_with_device_id`
     - Make sure to replace `replace_with_your_device` with your device ID from `flutter devices`

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Features that we do not currently support, but we do plan to add in the future:
 
 - To run the example app, you need an Ably API key. Create a free account on [ably.com](https://ably.com/) and then use your API key from there in the example app.
 - Clone the project
+- For Android, a Firebase instance configuration is required to build the app. In order run the application on Android device:
+  - Create a Firebase project following [official Firebase guide](https://firebase.google.com/docs/android/setup#create-firebase-project) (you can also use an existing one)
+  - Register the sample app with your Firebase project using `io.ably.flutter.example` as package name
+  - Download `google_services.json` file from Firebase and put it into [example/android/app](example/android/app) directory
 
 #### Android Studio / IntelliJ Idea
 


### PR DESCRIPTION
I've noticed that example app requirements aren't complete, so I did a few changes to make running ample app easier:
* Added a missing `launch.json` file. It was mentioned in the docs, but it wasn't commited, most probably because of gitignore covering the whole `vscode` folder
* Added a short note about Firebase instance configuration being required for Android builds. If there's no configuration file in the reposiotry, building the sample app fails, so I think it's worth to have that information in readme file