### PR TITLE
Channel resumed parameter now has to be non-null

### DIFF
--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -87,7 +87,7 @@ NS_ASSUME_NONNULL_END
 }
 
 #define WRITE_VALUE(DICTIONARY, JSON_KEY, VALUE) { \
-if (VALUE) { \
+if ( (VALUE) != nil ) { \
 [DICTIONARY setObject:VALUE forKey:JSON_KEY]; \
 } \
 }
@@ -228,7 +228,7 @@ static AblyCodecEncoder encodeChannelStateChange = ^NSMutableDictionary*(ARTChan
                 TxChannelStateChange_event,
                 [AblyFlutterWriter encodeChannelEvent: [stateChange event]]);
 
-    WRITE_VALUE(dictionary, TxChannelStateChange_resumed, [stateChange resumed]?@([stateChange resumed]):nil);
+    WRITE_VALUE(dictionary, TxChannelStateChange_resumed, [NSNumber numberWithBool: [stateChange resumed]]);
     WRITE_VALUE(dictionary, TxChannelStateChange_reason, encodeErrorInfo([stateChange reason]));
     return dictionary;
 };

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -1014,7 +1014,7 @@ class Codec extends StandardMessageCodec {
         _readFromJson<String>(jsonMap, TxChannelStateChange.previous));
     final event = _decodeChannelEvent(
         _readFromJson<String>(jsonMap, TxChannelStateChange.event));
-    final resumed = _readFromJson<bool>(jsonMap, TxChannelStateChange.resumed);
+    final resumed = _readFromJson<bool>(jsonMap, TxChannelStateChange.resumed)!;
     final errorInfo =
         toJsonMap(_readFromJson<Map>(jsonMap, TxChannelStateChange.reason));
     final reason = (errorInfo == null) ? null : _decodeErrorInfo(errorInfo);

--- a/lib/src/realtime/src/channel_state_event.dart
+++ b/lib/src/realtime/src/channel_state_event.dart
@@ -30,7 +30,7 @@ class ChannelStateChange {
   ErrorInfo? reason;
 
   /// https://docs.ably.com/client-lib-development-guide/features/#TH4
-  final bool? resumed;
+  final bool resumed;
 
   /// initializes with [resumed] set to false
   ChannelStateChange(


### PR DESCRIPTION
This is supposed to fix bug #297, the original fix was issued on #270 but I don't think the approach there was correct, so I changed a few things.

The issue was caused by this definition of Obj-C macro:

```objc
#define WRITE_VALUE(DICTIONARY, JSON_KEY, VALUE) { 
    if (VALUE) {
        [DICTIONARY setObject:VALUE forKey:JSON_KEY];
    } 
}
```

which is supposed to write JSON key only if `VALUE` parameter is not `nil`. By accident, if the parameter is not `nil`, but it happens to be `0` or any other falsey value, the key also isn't written 😆  I've updated the base method to only check for `nil` and also write `false` values.

The other error was with tenary operators and booleans. The expression:

```objc
[stateChange resumed]?@([stateChange resumed]):nil
```

evaluates to `nil` if `resumed` is `nil` or `false`, therefore `false` values were never written 😄 