### PR TITLE
Simplified GitHub actions flow

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -12,7 +12,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
 
       - name: 'Install dependencies'
         run: |

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -21,9 +21,7 @@ jobs:
       - name: 'Install dependencies'
         run: |
           flutter pub get
-          cd test_integration
-          flutter pub get
-          cd ..
+          cd test_integration && flutter pub get
 
       - name: 'Check formatting issues in the code'
         run: flutter format --set-exit-if-changed .

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -14,7 +14,6 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
           cache: true
 
       # This step requires fetch of test_integration packages because flutter format and 

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -17,20 +17,22 @@ jobs:
           channel: 'stable'
           cache: true
 
+      # This step requires fetch of test_integration packages because flutter format and 
+      # flutter analyze check test_integration package too
       - name: 'Install dependencies'
         run: |
           flutter pub get
-          cd test_integration && flutter pub get && cd ..
-          cd example && flutter pub get && cd ..
+          cd test_integration
+          flutter pub get
+          cd ..
 
       - name: 'Check formatting issues in the code'
         run: flutter format --set-exit-if-changed .
-
-      - name: 'Flutter analyze help'
-        run: 'flutter analyze --help'
         
+      # Suppressing info - deprecated entries fall under info, and CI shouldn't fail if there are any Deprecated APIs
+      # FIXME(ikurek): We should probably just configure linter to ignore deprecation, instead of disabling errors here
       - name: 'Statically analyze the Dart code for any errors'
-        run: 'flutter analyze --no-pub --no-fatal-infos .'  # suppressing info - deprecated entries fall under info, and CI shouldn't fail if there are any Deprecated APIs
+        run: 'flutter analyze --no-pub --no-fatal-infos .'
 
       - name: 'Run unit tests'
         run: flutter test --no-pub

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: 'Install dependencies'
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: Get Flutter Packages
         run: flutter pub get

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,6 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
           cache: true
 
       - name: Get Flutter Packages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
         with:
-          channel: stable
+          channel: 'stable'
 
       - name: Get Flutter Packages
         run: flutter pub get

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,8 +20,7 @@ jobs:
         run: flutter pub get
 
       - name: Install dartdoc global package via pub tool in the Flutter context
-        run: |
-          flutter pub global activate dartdoc
+        run: flutter pub global activate dartdoc
 
       - name: Build Documentation
         run: |

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -23,7 +23,6 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
           cache: true
 
       # test_integration package depends on ably_flutter, so before we run integration 
@@ -57,7 +56,6 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          channel: 'stable'
           cache: true
 
       - name: 'Run Flutter Driver tests'

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -26,11 +26,17 @@ jobs:
           channel: 'stable'
           cache: true
 
+      # test_integration package depends on ably_flutter, so before we run integration 
+      # tests it's best to perform dependency update in both packages, to make sure that
+      # integration tests are run with exactly the same dependencies as specified in 
+      # current version of ably_flutter package
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
         run: |
           flutter pub get
-          cd test_integration && ./run_integration_tests.sh
+          cd test_integration
+          flutter pub get
+          ./run_integration_tests.sh
 
   android:
     strategy:
@@ -62,4 +68,6 @@ jobs:
           script: |
             /Users/runner/Library/Android/sdk/tools/bin/avdmanager list
             flutter pub get
-            cd test_integration && ./run_integration_tests.sh
+            cd test_integration
+            flutter pub get
+            ./run_integration_tests.sh

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -24,6 +24,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
@@ -51,6 +52,7 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
+          cache: true
 
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -21,7 +21,9 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
 
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
@@ -46,7 +48,9 @@ jobs:
         with:
           java-version: '8.x'
 
-      - uses: subosito/flutter-action@v1
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
 
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -33,9 +33,7 @@ jobs:
         timeout-minutes: 30
         run: |
           flutter pub get
-          cd test_integration
-          flutter pub get
-          ./run_integration_tests.sh
+          cd test_integration && ./run_integration_tests.sh
 
   android:
     strategy:
@@ -66,6 +64,4 @@ jobs:
           script: |
             /Users/runner/Library/Android/sdk/tools/bin/avdmanager list
             flutter pub get
-            cd test_integration
-            flutter pub get
-            ./run_integration_tests.sh
+            cd test_integration && ./run_integration_tests.sh


### PR DESCRIPTION
Closes #325 and closes #317 , and additionally updates `flutter-action` step version to `2`. This should greatly reduce the CI runtime by reducing the number of components downloaded with each run