### PR TITLE
VS code launch configurations

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,14 +2,51 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "example",
+            "name": "Example App",
             "cwd": "example",
             "request": "launch",
             "type": "dart",
             "flutterMode": "debug",
             "args": [
-                "--dart-define",
-                "ABLY_API_KEY=replace_with_your_api_key"
+                "--observatory-port=8888",
+                "--dart-define=ABLY_API_KEY=replace_with_your_api_key",
+            ],
+        },
+        {
+            "name": "Unit Tests",
+            "type": "dart",
+            "request": "launch",
+            "program": "test/",
+        },
+        {
+            "name": "Integration Tests: Launch App",
+            "cwd": "test_integration",
+            "request": "launch",
+            "type": "dart",
+            "flutterMode": "debug",
+            "program": "lib/main.dart",
+            "args": [
+                "--observatory-port=8888",
+                "--disable-service-auth-codes"
+            ],
+        },
+        {
+            "name": "Integration Tests: Launch Driver",
+            "cwd": "test_integration",
+            "request": "launch",
+            "type": "dart",
+            "program": "test_driver/main_test.dart",
+            "env": {
+                "VM_SERVICE_URL": "http://127.0.0.1:8888/"
+            },
+        },
+    ],
+    "compounds": [
+        {
+            "name": "Integration Tests",
+            "configurations": [
+                "Integration Tests: Launch App",
+                "Integration Tests: Launch Driver"
             ],
         }
     ]

--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
 
 - Under `Run and Debug`,
   - Select the gear icon to view [launch.json](.vscode/launch.json)
+  - Find `Example App` launch configuration
   - Add your Ably API key to the `configurations.args`, i.e. replace `replace_with_your_api_key` with your own Ably API key.
-  - To choose a specific device when more than one are connected: to launch on a specific device, make sure it is the only device plugged in. To run on a specific device when you have multiple plugged in, add another element to the `configuration.args` value, with `--device-id=replace_with_device_id`
-    - Make sure to replace `replace_with_your_device` with your device ID from `flutter devices`
--  select the `example` configuration
+  - Choose a specific device to launch the app:
+    - to launch on a specific device, make sure it is the only device plugged in.
+    - to run on a specific device when you have multiple plugged in, add another element to the `configuration.args` value, with `--device-id=replace_with_device_id`. Make sure to replace `replace_with_your_device` with your device ID from `flutter devices`.
+- From `Run and Debug` select the `Example App` configuration and run it
 
 #### Command Line using the Flutter Tool
 

--- a/test_integration/README.md
+++ b/test_integration/README.md
@@ -12,7 +12,7 @@ This project has only one integration test target, `main.dart`.
 To run all tests: 
  - run `flutter drive --target lib/main.dart`, or 
  - run `flutter drive` which runs them all (one and only, `main.dart`).
- - Android Studio: Run the `Integration Test` run configuration. It is a compound run configuration which runs both `Integration Test Driver` and `Integration Test App`.
+ - Android Studio / VS Code: Run the `Integration Test` run configuration. It is a compound run configuration which runs both `Integration Test Driver` and `Integration Test App`.
 
 ### Test Module
 


### PR DESCRIPTION
I've included additional run configurations for VS Code, to match those available on Android Studio. This `launch.json` includes additional configuration for:

* integration tests app
* integration tests driver
* compound configuration for integration tests (runs both app and driver)
* unit tests

There are also small changes to readme files to include information about VS Code launch configurations. This should close #330 