### PR TITLE
Encrypted channels integration testing

### DIFF
--- a/test_integration/lib/config/test_constants.dart
+++ b/test_integration/lib/config/test_constants.dart
@@ -1,3 +1,14 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
 class TestConstants {
   static const Duration publishToHistoryDelay = Duration(seconds: 2);
+  static const String encryptedMessagePassword = 'test-password';
+  static Uint8List get encryptedChannelKey {
+    final data = utf8.encode(encryptedMessagePassword);
+    final digest = sha256.convert(data);
+    return Uint8List.fromList(digest.bytes);
+  }
 }

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -2,6 +2,7 @@ import 'package:ably_flutter_integration_test/config/test_names.dart';
 import 'package:ably_flutter_integration_test/factory/reporter.dart';
 import 'package:ably_flutter_integration_test/test/basic_test.dart';
 import 'package:ably_flutter_integration_test/test/helpers_test.dart';
+import 'package:ably_flutter_integration_test/test/realtime/realtime_encrypted_publish_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_events_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_history_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_presence_enter_update_leave.dart';
@@ -40,6 +41,7 @@ final testFactory = <String, TestFactory>{
   TestName.restPresenceHistory: testRestPresenceHistory,
   // realtime tests
   TestName.realtimePublish: testRealtimePublish,
+  TestName.realtimeEncryptedPublish: testRealtimeEncryptedPublish,
   TestName.realtimeEvents: testRealtimeEvents,
   TestName.realtimeSubscribe: testRealtimeSubscribe,
   TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -12,6 +12,7 @@ import 'package:ably_flutter_integration_test/test/realtime/realtime_publish_tes
 import 'package:ably_flutter_integration_test/test/realtime/realtime_publish_with_auth_callback_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_subscribe.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_capability_test.dart';
+import 'package:ably_flutter_integration_test/test/rest/rest_encrypted_publish_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_history_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_presence_get_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_presence_history_test.dart';
@@ -29,7 +30,9 @@ final testFactory = <String, TestFactory>{
   TestName.appKeyProvisioning: testAppKeyProvision,
   // rest tests
   TestName.restPublish: testRestPublish,
+  TestName.restEncryptedPublish: testRestEncryptedPublish,
   TestName.restPublishSpec: testRestPublishSpec,
+  TestName.restEncryptedPublishSpec: testRestEncryptedPublishSpec,
   TestName.restCapabilities: testRestCapabilities,
   TestName.restHistory: testRestHistory,
   TestName.restPublishWithAuthCallback: testRestPublishWithAuthCallback,

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -11,7 +11,9 @@ class TestName {
       'testHelperUnhandledExceptionTest';
 
   static const String restPublish = 'restPublish';
+  static const String restEncryptedPublish = 'restEncryptedPublish';
   static const String restPublishSpec = 'restPublishSpec';
+  static const String restEncryptedPublishSpec = 'restEncryptedPublishSpec';
   static const String restCapabilities = 'restCapabilities';
   static const String restHistory = 'restHistory';
   static const String restPublishWithAuthCallback =

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -24,6 +24,7 @@ class TestName {
   static const String restPresenceHistory = 'restPresenceHistory';
 
   static const String realtimePublish = 'realtimePublish';
+  static const String realtimeEncryptedPublish = 'realtimeEncryptedPublish';
   static const String realtimeEvents = 'realtimeEvents';
   static const String realtimeSubscribe = 'realtimeSubscribe';
   static const String realtimeHistory = 'realtimeHistory';

--- a/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
@@ -1,0 +1,31 @@
+import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/config/test_constants.dart';
+import 'package:ably_flutter_integration_test/factory/reporter.dart';
+import 'package:ably_flutter_integration_test/provisioning.dart';
+import 'package:ably_flutter_integration_test/utils/realtime.dart';
+
+Future<Map<String, dynamic>> testRealtimeEncryptedPublish({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  reporter.reportLog('init start');
+  final appKey = await provision('sandbox-');
+
+  final cipherParams =
+      await Crypto.getDefaultParams(key: TestConstants.encryptedChannelKey);
+
+  final channelOptions = RealtimeChannelOptions(cipherParams: cipherParams);
+
+  final rest = Realtime(
+      options: ClientOptions.fromKey(appKey.toString())
+        ..environment = 'sandbox'
+        ..clientId = 'someClientId');
+
+  final channel = rest.channels.get('test');
+  await channel.setOptions(channelOptions);
+
+  await publishMessages(channel);
+  return {
+    'handle': await rest.handle,
+  };
+}

--- a/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
@@ -1,0 +1,140 @@
+import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/config/test_constants.dart';
+import 'package:ably_flutter_integration_test/factory/reporter.dart';
+import 'package:ably_flutter_integration_test/provisioning.dart';
+import 'package:ably_flutter_integration_test/utils/data.dart';
+import 'package:ably_flutter_integration_test/utils/rest.dart';
+
+Future<Map<String, dynamic>> testRestEncryptedPublish({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  reporter.reportLog('init start');
+  final appKey = await provision('sandbox-');
+
+  final cipherParams =
+      await Crypto.getDefaultParams(key: TestConstants.encryptedChannelKey);
+
+  final channelOptions = RestChannelOptions(cipherParams: cipherParams);
+
+  final rest = Rest(
+    options: ClientOptions.fromKey(appKey.toString())
+      ..environment = 'sandbox'
+      ..clientId = 'someClientId'
+      ..logLevel = LogLevel.verbose,
+  );
+
+  final channel = rest.channels.get('test');
+  await channel.setOptions(channelOptions);
+
+  await publishMessages(channel);
+  return {
+    'handle': await rest.handle,
+  };
+}
+
+Future<Map<String, dynamic>> testRestEncryptedPublishSpec({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  const clientId = 'clientId';
+  final appKey = await provision('sandbox-');
+
+  final cipherParams =
+      await Crypto.getDefaultParams(key: TestConstants.encryptedChannelKey);
+
+  final channelOptions = RestChannelOptions(cipherParams: cipherParams);
+
+  // Rest instance where client id is specified in the instance itself
+  final restWithClientId = Rest(
+    options: ClientOptions.fromKey(appKey.toString())
+      ..environment = 'sandbox'
+      ..clientId = clientId
+      ..logLevel = LogLevel.verbose,
+  );
+
+  final channelWithClientId = restWithClientId.channels.get('test');
+  await channelWithClientId.setOptions(channelOptions);
+
+  // Send simple message data
+  await channelWithClientId.publish();
+  await channelWithClientId.publish(name: 'name');
+  await channelWithClientId.publish(data: 'data');
+  await channelWithClientId.publish(name: 'name', data: 'data');
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send single message object
+  await channelWithClientId.publish(
+    message: Message(
+      name: 'single-message-name',
+      data: 'single-message-data',
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send multiple message objects at once
+  await channelWithClientId.publish(messages: [
+    Message(name: 'multi-message-name-1', data: 'multi-message-data-1'),
+    Message(name: 'multi-message-name-2', data: 'multi-message-data-2'),
+  ]);
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send message with [clientId] defined
+  await channelWithClientId.publish(
+    message: Message(
+      name: 'single-message-with-client-id-name',
+      data: 'single-message-with-client-id-data',
+      clientId: clientId,
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Retrieve history of encrypted channel where client id was specified
+  final historyOfChannelWithClientId = await getHistory(
+    channelWithClientId,
+    RestHistoryParams(direction: 'forwards'),
+  );
+
+  // Rest instance where client id has to be specified in messages
+  final restWithoutClientId = Rest(
+    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
+  );
+
+  // Send message with client ID provided
+  final channelWithoutClientId = restWithoutClientId.channels.get('test2');
+  await channelWithoutClientId.publish(
+    message: Message(
+      name: 'single-message-with-client-id',
+      clientId: clientId,
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Retrieve history of encrypted channel where client id was not specified
+  final historyOfChannelWithoutClientId = await getHistory(
+    channelWithoutClientId,
+    RestHistoryParams(direction: 'forwards'),
+  );
+
+  // Send message with extras to push-enabled channel
+  final pushEnabledChannelWithClientId =
+      restWithClientId.channels.get('pushenabled:test:extras');
+  await pushEnabledChannelWithClientId.publish(
+    message: Message(
+      name: 'single-message-push-enabled-name',
+      data: 'single-message-push-enabled-data',
+      extras: const MessageExtras({...pushPayload}),
+    ),
+  );
+
+  // Retrieve history of encrypted push-enabled channel
+  final historyOfPushEnabledChannel =
+      await getHistory(pushEnabledChannelWithClientId);
+
+  return {
+    'handle': await restWithClientId.handle,
+    'historyOfChannelWithClientId': historyOfChannelWithClientId,
+    'historyOfChannelWithoutClientId': historyOfChannelWithoutClientId,
+    'historyOfPushEnabledChannel': historyOfPushEnabledChannel,
+  };
+}

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -23,6 +23,19 @@ void testRealtimePublish(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRealtimeEncryptedPublish(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.realtimeEncryptedPublish);
+  late TestControlResponseMessage response;
+  setUpAll(() async {
+    response = await requestDataForTest(getDriver(), message);
+  });
+
+  test('publishes encrypted message without any response', () {
+    expect(response.payload['handle'], isA<int>());
+    expect(response.payload['handle'], greaterThan(0));
+  });
+}
+
 void testRealtimeEvents(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeEvents);
   late TestControlResponseMessage response;

--- a/test_integration/test_driver/test_implementation/rest_tests.dart
+++ b/test_integration/test_driver/test_implementation/rest_tests.dart
@@ -16,6 +16,18 @@ void testRestPublish(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRestEncryptedPublish(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.restEncryptedPublish);
+  late TestControlResponseMessage response;
+  setUpAll(
+      () async => response = await requestDataForTest(getDriver(), message));
+
+  test('rest instance has a valid handle on encrypted publish', () {
+    expect(response.payload['handle'], isA<int>());
+    expect(response.payload['handle'], greaterThan(0));
+  });
+}
+
 void testRestPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.restPublishSpec);
   late TestControlResponseMessage response;
@@ -149,6 +161,78 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
     expect(messagesWithExtras[0]['data'], 'data');
     checkMessageExtras(messagesWithExtras[0]['extras']['extras'] as Map);
     expect(messagesWithExtras[0]['extras']['delta'], null);
+  });
+}
+
+void testRestEncryptedPublishSpec(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.restEncryptedPublishSpec);
+  late TestControlResponseMessage response;
+  late List historyOfChannelWithClientId;
+  late List historyOfChannelWithoutClientId;
+  late List historyOfPushEnabledChannel;
+
+  setUpAll(() async {
+    response = await requestDataForTest(getDriver(), message);
+
+    historyOfChannelWithClientId =
+        response.payload['historyOfChannelWithClientId'] as List;
+    historyOfChannelWithoutClientId =
+        response.payload['historyOfChannelWithoutClientId'] as List;
+    historyOfPushEnabledChannel =
+        response.payload['historyOfPushEnabledChannel'] as List;
+  });
+
+  group('RSl1', () {
+    test('publishes without a name and data', () {
+      expect(historyOfChannelWithClientId[0]['name'], null);
+      expect(historyOfChannelWithClientId[0]['data'], null);
+    });
+    test('publishes without data', () {
+      expect(historyOfChannelWithClientId[1]['name'], 'name');
+      expect(historyOfChannelWithClientId[1]['data'], null);
+    });
+    test('publishes without a name', () {
+      expect(historyOfChannelWithClientId[2]['name'], null);
+      expect(historyOfChannelWithClientId[2]['data'], 'data');
+    });
+    test('publishes with name and data', () {
+      expect(historyOfChannelWithClientId[3]['name'], 'name');
+      expect(historyOfChannelWithClientId[3]['data'], 'data');
+    });
+    test('publishes single message object', () {
+      expect(historyOfChannelWithClientId[4]['name'], 'single-message-name');
+      expect(historyOfChannelWithClientId[4]['data'], 'single-message-data');
+    });
+    test('publishes multiple message objects', () {
+      expect(historyOfChannelWithClientId[5]['name'], 'multi-message-name-1');
+      expect(historyOfChannelWithClientId[5]['data'], 'multi-message-data-1');
+      expect(historyOfChannelWithClientId[6]['name'], 'multi-message-name-2');
+      expect(historyOfChannelWithClientId[6]['data'], 'multi-message-data-2');
+    });
+    test('publishes multiple messages at once', () {
+      expect(
+          historyOfChannelWithClientId[5]['timestamp'] ==
+              historyOfChannelWithClientId[6]['timestamp'],
+          true);
+      expect(
+          historyOfChannelWithClientId[5]['timestamp'] !=
+              historyOfChannelWithClientId[4]['timestamp'],
+          true);
+    });
+  });
+
+  test('RSL6a2 publishes message extras', () {
+    expect(
+      historyOfPushEnabledChannel[0]['name'],
+      'single-message-push-enabled-name',
+    );
+    expect(
+      historyOfPushEnabledChannel[0]['data'],
+      'single-message-push-enabled-data',
+    );
+    checkMessageExtras(
+        historyOfPushEnabledChannel[0]['extras']['extras'] as Map);
+    expect(historyOfPushEnabledChannel[0]['extras']['delta'], null);
   });
 }
 

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -18,8 +18,10 @@ final _tests =
   },
   TestModules.rest: {
     'should publish': testRestPublish,
+    'should publish encrypted': testRestEncryptedPublish,
     'should retrieve history': testRestHistory,
     'conforms to publish spec': testRestPublishSpec,
+    'conforms to publish spec when encrypted': testRestEncryptedPublishSpec,
     'should publish with AuthCallback': testRestPublishWithAuthCallback,
     'should get Presence Members': testRestPresenceGet,
     'should get Presence History': testRestPresenceHistory,

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -28,7 +28,8 @@ final _tests =
     'conforms to capabilitySpec': testCapabilityMatrix,
   },
   TestModules.realtime: {
-    'realtime#channels#channel#publish': testRealtimePublish,
+    'should publish': testRealtimePublish,
+    'should publish encrypted': testRealtimeEncryptedPublish,
     'should subscribe to connection and channel': testRealtimeEvents,
     'should subscribe to messages': testRealtimeSubscribe,
     'should retrieve history': testRealtimeHistory,


### PR DESCRIPTION
This should close #302 and probably also #205. I've added integration tests for:

* Publishing to encrypted REST channel
* Publishing to encrypted realtime channel
* Spec requirements for publishing on encrypted REST channel

These tests should help us catch any issues with encryption implementation for channels, like #296. I did not include spec requirements for publishing realtime channel, because currently there are no spec tests for realtime channels, so I'd need to create them first, before testing the encrypted version. I've created a separate issue for this: #332.