### PR TITLE
LogHandler removal & logging improvements

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyEventStreamHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyEventStreamHandler.java
@@ -2,7 +2,6 @@ package io.ably.flutter.plugin;
 
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 
 import java.util.Map;
 
@@ -14,6 +13,7 @@ import io.ably.lib.realtime.Presence;
 import io.ably.lib.types.AblyException;
 import io.ably.lib.types.Message;
 import io.ably.lib.types.PresenceMessage;
+import io.ably.lib.util.Log;
 import io.flutter.plugin.common.EventChannel;
 
 

--- a/android/src/main/java/io/ably/flutter/plugin/AblyFlutter.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyFlutter.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 
@@ -15,6 +14,7 @@ import io.ably.flutter.plugin.push.RemoteMessageCallback;
 import io.ably.flutter.plugin.push.PushActivationEventHandlers;
 import io.ably.flutter.plugin.push.PushMessagingEventHandlers;
 import io.ably.flutter.plugin.util.CipherParamsStorage;
+import io.ably.lib.util.Log;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding;

--- a/android/src/main/java/io/ably/flutter/plugin/BackgroundMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/BackgroundMethodCallHandler.java
@@ -2,14 +2,14 @@ package io.ably.flutter.plugin;
 
 import static io.ably.flutter.plugin.generated.PlatformConstants.PlatformMethod.pushBackgroundFlutterApplicationReadyOnAndroid;
 
-import android.util.Log;
-
 import androidx.annotation.NonNull;
 
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodCodec;
+
+import io.ably.lib.util.Log;
 
 /**
  * Receives method calls on the background method channel from the Dart side's

--- a/android/src/main/java/io/ably/flutter/plugin/StreamsChannel.java
+++ b/android/src/main/java/io/ably/flutter/plugin/StreamsChannel.java
@@ -21,7 +21,6 @@
 package io.ably.flutter.plugin;
 
 import android.annotation.SuppressLint;
-import android.util.Log;
 
 import androidx.annotation.UiThread;
 
@@ -36,6 +35,7 @@ import io.flutter.plugin.common.EventChannel;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodCodec;
 
+import io.ably.lib.util.Log;
 
 final class StreamsChannel {
 

--- a/android/src/main/java/io/ably/flutter/plugin/push/FirebaseMessagingReceiver.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/FirebaseMessagingReceiver.java
@@ -7,7 +7,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -18,6 +17,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import io.ably.flutter.plugin.AblyFlutter;
+import io.ably.lib.util.Log;
 
 public class FirebaseMessagingReceiver extends BroadcastReceiver {
   private static final String TAG = FirebaseMessagingReceiver.class.getName();

--- a/android/src/main/java/io/ably/flutter/plugin/push/ManualFlutterApplicationRunner.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/ManualFlutterApplicationRunner.java
@@ -5,7 +5,6 @@ import static io.ably.flutter.plugin.generated.PlatformConstants.PlatformMethod.
 
 import android.content.Context;
 import android.content.Intent;
-import android.util.Log;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,6 +13,7 @@ import com.google.firebase.messaging.RemoteMessage;
 
 import io.ably.flutter.plugin.AblyMessageCodec;
 import io.ably.flutter.plugin.util.CipherParamsStorage;
+import io.ably.lib.util.Log;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.plugin.common.MethodCall;

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushActivationEventHandlers.java
@@ -5,12 +5,12 @@ import static io.ably.flutter.plugin.push.PushActivationReceiver.PUSH_DEACTIVATE
 import static io.ably.flutter.plugin.push.PushActivationReceiver.PUSH_UPDATE_FAILED_ACTION;
 
 import android.content.Context;
-import android.util.Log;
 
 import androidx.annotation.Nullable;
 
 import io.ably.flutter.plugin.generated.PlatformConstants;
 import io.ably.lib.types.ErrorInfo;
+import io.ably.lib.util.Log;
 import io.flutter.plugin.common.MethodChannel;
 
 public class PushActivationEventHandlers {

--- a/android/src/main/java/io/ably/flutter/plugin/push/PushMessagingEventHandlers.java
+++ b/android/src/main/java/io/ably/flutter/plugin/push/PushMessagingEventHandlers.java
@@ -5,7 +5,7 @@ import static io.ably.flutter.plugin.generated.PlatformConstants.PlatformMethod.
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.util.Log;
+
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -14,6 +14,7 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.google.firebase.messaging.RemoteMessage;
 
 import io.ably.flutter.plugin.generated.PlatformConstants;
+import io.ably.lib.util.Log;
 import io.flutter.plugin.common.MethodChannel;
 
 /**

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 46;
+	objectVersion = 50;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -157,7 +157,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "The Chromium Authors";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/example/ios/Runner/AppDelegate.swift
+++ b/example/ios/Runner/AppDelegate.swift
@@ -12,6 +12,6 @@ import Flutter
   }
     
     override func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
-        print("application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription)
+        NSLog("application:didFailToRegisterForRemoteNotificationsWithError was called with error: %@", error.localizedDescription)
     }
 }

--- a/example/lib/ui/ably_service.dart
+++ b/example/lib/ui/ably_service.dart
@@ -10,20 +10,16 @@ class AblyService {
 
   AblyService() {
     realtime = ably.Realtime(
-        options: ably.ClientOptions.fromKey(apiKey)
-          ..clientId = Constants.clientId
-          ..logLevel = ably.LogLevel.verbose
-          ..autoConnect = false
-          ..logHandler = ({msg, exception}) {
-            print('Custom logger :: $msg $exception');
-          });
+      options: ably.ClientOptions.fromKey(apiKey)
+        ..clientId = Constants.clientId
+        ..logLevel = ably.LogLevel.verbose
+        ..autoConnect = false,
+    );
     rest = ably.Rest(
-        options: ably.ClientOptions.fromKey(apiKey)
-          ..clientId = Constants.clientId
-          ..logLevel = ably.LogLevel.verbose
-          ..logHandler = ({msg, exception}) {
-            print('Custom logger :: $msg $exception');
-          });
+      options: ably.ClientOptions.fromKey(apiKey)
+        ..clientId = Constants.clientId
+        ..logLevel = ably.LogLevel.verbose,
+    );
     pushNotificationService = PushNotificationService(realtime, rest);
   }
 }

--- a/ios/Classes/handlers/PushActivationEventHandlers.swift
+++ b/ios/Classes/handlers/PushActivationEventHandlers.swift
@@ -40,7 +40,7 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
         if let result = flutterResultForActivate {
             result(error)
         } else {
-            print("Did not return a value asynchronously because flutterResultForActivate was nil. The app might have been restarted since calling activate.")
+            NSLog("Did not return a value asynchronously because flutterResultForActivate was nil. The app might have been restarted since calling activate.")
         }
     }
     
@@ -53,7 +53,7 @@ public class PushActivationEventHandlers: NSObject, ARTPushRegistererDelegate {
         if let result = flutterResultForDeactivate {
             result(error)
         } else {
-            print("Did not return a value asynchronously because flutterResultForDeactivate was nil. The app might have been restarted since calling deactivate.")
+            NSLog("Did not return a value asynchronously because flutterResultForDeactivate was nil. The app might have been restarted since calling deactivate.")
         }
     }
     

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -28,7 +28,7 @@ class ClientOptions extends AuthOptions {
   @Deprecated(
     'Not used, as log messages are handled by the default mechanism '
     'in the underlying SDK. This instance variable will be removed '
-    'in future.',
+    'in a future release.',
   )
   LogHandler? logHandler;
 

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -19,6 +19,19 @@ class ClientOptions extends AuthOptions {
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3a
   String? clientId;
 
+  /// Custom log handler
+  ///
+  /// For discussion about removing this component see
+  /// https://github.com/ably/ably-flutter/issues/238
+  ///
+  /// https://docs.ably.com/client-lib-development-guide/features/#TO3c
+  @Deprecated(
+    'Not used, as log messages are handled by the default mechanism '
+    'in the underlying SDK. This instance variable will be removed '
+    'in future.',
+  )
+  LogHandler? logHandler;
+
   /// Controls the level of verbosity of log messages from the library
   ///
   /// Use constants from [LogLevel] to pass arguments

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -19,11 +19,6 @@ class ClientOptions extends AuthOptions {
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3a
   String? clientId;
 
-  /// Custom log handler
-  ///
-  /// https://docs.ably.com/client-lib-development-guide/features/#TO3c
-  LogHandler? logHandler;
-
   /// Controls the level of verbosity of log messages from the library
   ///
   /// Use constants from [LogLevel] to pass arguments

--- a/lib/src/logging/logging.dart
+++ b/lib/src/logging/logging.dart
@@ -1,2 +1,1 @@
-export 'src/log_handler.dart';
 export 'src/log_level.dart';

--- a/lib/src/logging/logging.dart
+++ b/lib/src/logging/logging.dart
@@ -1,1 +1,2 @@
+export 'src/log_handler.dart';
 export 'src/log_level.dart';

--- a/lib/src/logging/src/log_handler.dart
+++ b/lib/src/logging/src/log_handler.dart
@@ -1,9 +1,0 @@
-import 'package:ably_flutter/ably_flutter.dart';
-
-/// Custom handler to handle SDK log messages
-///
-/// https://docs.ably.com/client-lib-development-guide/features/#TO3c
-typedef LogHandler = void Function({
-  String? msg,
-  AblyException? exception,
-});

--- a/lib/src/logging/src/log_handler.dart
+++ b/lib/src/logging/src/log_handler.dart
@@ -8,7 +8,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 /// https://docs.ably.com/client-lib-development-guide/features/#TO3c
 @Deprecated(
   'All usages of this type are marked as deprecated '
-  'so it will be removed in future releases',
+  'so it will be removed in a future release.',
 )
 typedef LogHandler = void Function({
   String? msg,

--- a/lib/src/logging/src/log_handler.dart
+++ b/lib/src/logging/src/log_handler.dart
@@ -1,0 +1,16 @@
+import 'package:ably_flutter/ably_flutter.dart';
+
+/// Custom handler to handle SDK log messages
+///
+/// For discussion about removing this component see
+/// https://github.com/ably/ably-flutter/issues/238
+///
+/// https://docs.ably.com/client-lib-development-guide/features/#TO3c
+@Deprecated(
+  'All usages of this type are marked as deprecated '
+  'so it will be removed in future releases',
+)
+typedef LogHandler = void Function({
+  String? msg,
+  AblyException? exception,
+});

--- a/test/models/client_options.dart
+++ b/test/models/client_options.dart
@@ -10,7 +10,6 @@ void main() {
     final clientOptions = ClientOptions();
     expect(clientOptions.clientId, isNull);
     expect(clientOptions.logLevel, LogLevel.info);
-    expect(clientOptions.logHandler, isNull);
     expect(clientOptions.tls, isNull);
     expect(clientOptions.restHost, isNull);
     expect(clientOptions.realtimeHost, isNull);

--- a/test_integration/lib/test/realtime/realtime_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_history_test.dart
@@ -11,15 +11,12 @@ Future<Map<String, dynamic>> testRealtimeHistory({
 }) async {
   reporter.reportLog('init start');
   final appKey = await provision('sandbox-');
-  final logMessages = <List<String?>>[];
 
   final realtime = Realtime(
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   );
   final channel = realtime.channels.get('test');
   await publishMessages(channel);
@@ -81,6 +78,5 @@ Future<Map<String, dynamic>> testRealtimeHistory({
     'historyAll': historyAll,
     't1': time1.toIso8601String(),
     't2': time2.toIso8601String(),
-    'log': logMessages,
   };
 }

--- a/test_integration/lib/test/realtime/realtime_presence_enter_update_leave.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_enter_update_leave.dart
@@ -13,9 +13,7 @@ ClientOptions getClientOptions(
     ClientOptions.fromKey(appKey)
       ..environment = 'sandbox'
       ..clientId = clientId
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]);
+      ..logLevel = LogLevel.verbose;
 
 Future<Map<String, dynamic>> testRealtimePresenceEnterUpdateLeave({
   required Reporter reporter,

--- a/test_integration/lib/test/realtime/realtime_presence_get.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_get.dart
@@ -14,9 +14,7 @@ ClientOptions getClientOptions(
     ClientOptions.fromKey(appKey)
       ..environment = 'sandbox'
       ..clientId = clientId
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]);
+      ..logLevel = LogLevel.verbose;
 
 Future<Map<String, dynamic>> testRealtimePresenceGet({
   required Reporter reporter,

--- a/test_integration/lib/test/realtime/realtime_presence_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_history_test.dart
@@ -16,9 +16,7 @@ Future<Map<String, dynamic>> testRealtimePresenceHistory({
   final options = ClientOptions.fromKey(appKey.toString())
     ..environment = 'sandbox'
     ..clientId = 'someClientId'
-    ..logLevel = LogLevel.verbose
-    ..logHandler =
-        ({msg, exception}) => logMessages.add([msg, exception.toString()]);
+    ..logLevel = LogLevel.verbose;
 
   final realtime = Realtime(options: options);
   final channel = realtime.channels.get('test');

--- a/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
@@ -22,9 +22,7 @@ Future<Map<String, dynamic>> testRealtimePresenceSubscribe({
     options: ClientOptions.fromKey(appKey)
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   ).channels.get('test').presence;
 
   final allMessages = <PresenceMessage>[];

--- a/test_integration/lib/test/realtime/realtime_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_publish_test.dart
@@ -14,8 +14,7 @@ Future<Map<String, dynamic>> testRealtimePublish({
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler = ({msg, exception}) => logMessages.add([msg, '$exception']),
+      ..logLevel = LogLevel.verbose,
   );
   await publishMessages(realtime.channels.get('test'));
   await realtime.close();

--- a/test_integration/lib/test/realtime/realtime_time_test.dart
+++ b/test_integration/lib/test/realtime/realtime_time_test.dart
@@ -14,9 +14,7 @@ Future<Map<String, dynamic>> testRealtimeTime({
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   );
 
   final realtimeTime = await realtime.time();

--- a/test_integration/lib/test/rest/rest_history_test.dart
+++ b/test_integration/lib/test/rest/rest_history_test.dart
@@ -11,15 +11,12 @@ Future<Map<String, dynamic>> testRestHistory({
 }) async {
   reporter.reportLog('init start');
   final appKey = await provision('sandbox-');
-  final logMessages = <List<String?>>[];
 
   final rest = Rest(
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   );
   final channel = rest.channels.get('test');
   await publishMessages(channel);
@@ -69,6 +66,5 @@ Future<Map<String, dynamic>> testRestHistory({
     'historyAll': historyAll,
     't1': time1.toIso8601String(),
     't2': time2.toIso8601String(),
-    'log': logMessages,
   };
 }

--- a/test_integration/lib/test/rest/rest_presence_get_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_get_test.dart
@@ -14,9 +14,7 @@ ClientOptions getClientOptions(
     ClientOptions.fromKey(appKey)
       ..environment = 'sandbox'
       ..clientId = clientId
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]);
+      ..logLevel = LogLevel.verbose;
 
 Future<Map<String, dynamic>> testRestPresenceGet({
   required Reporter reporter,

--- a/test_integration/lib/test/rest/rest_presence_history_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_history_test.dart
@@ -17,9 +17,7 @@ Future<Map<String, dynamic>> testRestPresenceHistory({
   final options = ClientOptions.fromKey(appKey.toString())
     ..environment = 'sandbox'
     ..clientId = 'someClientId'
-    ..logLevel = LogLevel.verbose
-    ..logHandler =
-        ({msg, exception}) => logMessages.add([msg, exception.toString()]);
+    ..logLevel = LogLevel.verbose;
 
   final rest = Rest(options: options);
   final channel = rest.channels.get('test');

--- a/test_integration/lib/test/rest/rest_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_publish_test.dart
@@ -18,9 +18,7 @@ Future<Map<String, dynamic>> testRestPublish({
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   );
   await publishMessages(rest.channels.get('test'));
   return {

--- a/test_integration/lib/test/rest/rest_time_test.dart
+++ b/test_integration/lib/test/rest/rest_time_test.dart
@@ -14,9 +14,7 @@ Future<Map<String, dynamic>> testRestTime({
     options: ClientOptions.fromKey(appKey.toString())
       ..environment = 'sandbox'
       ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose
-      ..logHandler =
-          ({msg, exception}) => logMessages.add([msg, exception.toString()]),
+      ..logLevel = LogLevel.verbose,
   );
 
   final restTime = await rest.time();


### PR DESCRIPTION
This should resolve #238, although it does not use the mentioned `LogHandler`. Instead, the changes contain:

* Removing the `LogHandler` entirely from Dart code
* Replacing Android native logging with `Log` implementation from `ably-java`. Luckily, their implementation is the same so it was only a matter of imports
* Replacing ios `print` and `NSLog` calls with `ARTLog` implementation from `ably-cocoa`. This was not possible everywhere, because unlike `Log` from `ably-java` the `ARTLog` isn't a singleton, so I only updated a few places

With these changes, most of the logging from Android and iOS platform native code should respect logging level set in Ably `ClientOptions`.