### PR TITLE
Switched CI integration tests to run on ubuntu instead of macos

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -61,6 +61,5 @@ jobs:
           api-level: ${{ matrix.api-level }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           script: |
-            /Users/runner/Library/Android/sdk/tools/bin/avdmanager list
             flutter pub get
             cd test_integration && ./run_integration_tests.sh

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -41,9 +41,7 @@ jobs:
         api-level: [21, 29]
       fail-fast: false
 
-    # ubuntu-latest cannot be used as it is only a docker container, and unfortunately running
-    # hardware acceleration in container is not allowed by android emulator.
-    runs-on: 'macos-latest'
+    runs-on: 'ubuntu-latest'
 
     steps:
       - uses: actions/checkout@v2
@@ -61,6 +59,7 @@ jobs:
         uses: reactivecircus/android-emulator-runner@v2
         with:
           api-level: ${{ matrix.api-level }}
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
           script: |
             /Users/runner/Library/Android/sdk/tools/bin/avdmanager list
             flutter pub get


### PR DESCRIPTION
This is related to #232 but I'm not sure if it will solve the problem entirely. So I'm not closing the issue for now and I'll watch the CI for a while to see if the errors still occur.

Besides switching from `macos` runner to `ubuntu` I've also added a few additional params to the virtual machine (copy/paste from [`ably/java`'s integration test config](https://github.com/ably/ably-java/blob/main/.github/workflows/emulate.yml) but it should be fine for our use case).