### PR TITLE
Realtime channel integration tests

### DIFF
--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -46,6 +46,7 @@ final testFactory = <String, TestFactory>{
   TestName.realtimePublish: testRealtimePublish,
   TestName.realtimeEncryptedPublish: testRealtimeEncryptedPublish,
   TestName.realtimePublishSpec: testRealtimePublishSpec,
+  TestName.realtimeEncryptedPublishSpec: testRealtimeEncryptedPublishSpec,
   TestName.realtimeEvents: testRealtimeEvents,
   TestName.realtimeSubscribe: testRealtimeSubscribe,
   TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -45,6 +45,7 @@ final testFactory = <String, TestFactory>{
   // realtime tests
   TestName.realtimePublish: testRealtimePublish,
   TestName.realtimeEncryptedPublish: testRealtimeEncryptedPublish,
+  TestName.realtimePublishSpec: testRealtimePublishSpec,
   TestName.realtimeEvents: testRealtimeEvents,
   TestName.realtimeSubscribe: testRealtimeSubscribe,
   TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -27,6 +27,8 @@ class TestName {
   static const String realtimePublish = 'realtimePublish';
   static const String realtimeEncryptedPublish = 'realtimeEncryptedPublish';
   static const String realtimePublishSpec = 'realtimePublishSpec';
+  static const String realtimeEncryptedPublishSpec =
+      'realtimeEncryptedPublishSpec';
   static const String realtimeEvents = 'realtimeEvents';
   static const String realtimeSubscribe = 'realtimeSubscribe';
   static const String realtimeHistory = 'realtimeHistory';

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -26,6 +26,7 @@ class TestName {
 
   static const String realtimePublish = 'realtimePublish';
   static const String realtimeEncryptedPublish = 'realtimeEncryptedPublish';
+  static const String realtimePublishSpec = 'realtimePublishSpec';
   static const String realtimeEvents = 'realtimeEvents';
   static const String realtimeSubscribe = 'realtimeSubscribe';
   static const String realtimeHistory = 'realtimeHistory';

--- a/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
@@ -52,22 +52,19 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
       ..logLevel = LogLevel.verbose,
   );
 
-  // Create encrypted  & plaintext channels with client ID
-  final encryptedChannelWithClientId =
-      realtimeWithClientId.channels.get('test');
-  await encryptedChannelWithClientId.setOptions(channelOptions);
-  final plaintextChannelWithClientId =
-      realtimeWithClientId.channels.get('test');
+  // Create encrypted channel with client ID
+  final encryptedChannel = realtimeWithClientId.channels.get('test');
+  await encryptedChannel.setOptions(channelOptions);
 
   // Send simple message data
-  await encryptedChannelWithClientId.publish();
-  await encryptedChannelWithClientId.publish(name: 'name');
-  await encryptedChannelWithClientId.publish(data: 'data');
-  await encryptedChannelWithClientId.publish(name: 'name', data: 'data');
+  await encryptedChannel.publish();
+  await encryptedChannel.publish(name: 'name');
+  await encryptedChannel.publish(data: 'data');
+  await encryptedChannel.publish(name: 'name', data: 'data');
   await Future.delayed(TestConstants.publishToHistoryDelay);
 
   // Send single message object
-  await encryptedChannelWithClientId.publish(
+  await encryptedChannel.publish(
     message: Message(
       name: 'single-message-name',
       data: 'single-message-data',
@@ -76,14 +73,14 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
   await Future.delayed(TestConstants.publishToHistoryDelay);
 
   // Send multiple message objects at once
-  await encryptedChannelWithClientId.publish(messages: [
+  await encryptedChannel.publish(messages: [
     Message(name: 'multi-message-name-1', data: 'multi-message-data-1'),
     Message(name: 'multi-message-name-2', data: 'multi-message-data-2'),
   ]);
   await Future.delayed(TestConstants.publishToHistoryDelay);
 
   // Send message with [clientId] defined
-  await encryptedChannelWithClientId.publish(
+  await encryptedChannel.publish(
     message: Message(
       name: 'single-message-with-client-id-name',
       data: 'single-message-with-client-id-data',
@@ -92,56 +89,19 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
   );
   await Future.delayed(TestConstants.publishToHistoryDelay);
 
-  // Retrieve history of channels where client id was specified
-  final historyOfEncryptedChannelWithClientId = await getHistory(
-    encryptedChannelWithClientId,
-    RealtimeHistoryParams(direction: 'forwards'),
-  );
-  final historyOfPlaintextChannelWithClientId = await getHistory(
-    plaintextChannelWithClientId,
-    RealtimeHistoryParams(direction: 'forwards'),
-  );
-
-  // Realtime instance where client id has to be specified in messages
-  final realtimeWithoutClientId = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
-  );
-
-  // Create encrypted channel without client ID
-  final encryptedChannelWithoutClientId =
-      realtimeWithoutClientId.channels.get('test2');
-  await encryptedChannelWithoutClientId.setOptions(channelOptions);
-  final plaintextChannelWithoutClientId =
-      realtimeWithoutClientId.channels.get('test2');
-
-  // Send message with client ID provided
-  await encryptedChannelWithoutClientId.publish(
-    message: Message(
-      name: 'single-message-with-client-id',
-      clientId: clientId,
-    ),
-  );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
-
-  // Retrieve history of channels where client id was not specified
-  final historyOfEncryptedChannelWithoutClientId = await getHistory(
-    encryptedChannelWithoutClientId,
-    RealtimeHistoryParams(direction: 'forwards'),
-  );
-  final historyOfPlaintextChannelWithoutClientId = await getHistory(
-    plaintextChannelWithoutClientId,
+  // Retrieve history of channel where client id was specified
+  final historyOfEncryptedChannel = await getHistory(
+    encryptedChannel,
     RealtimeHistoryParams(direction: 'forwards'),
   );
 
   // Create encrypted channel with push capability
-  final encryptedPushEnabledChannelWithClientId =
+  final encryptedPushEnabledChannel =
       realtimeWithClientId.channels.get('pushenabled:test:extras');
-  await encryptedPushEnabledChannelWithClientId.setOptions(channelOptions);
-  final plaintextPushEnabledChannelWithClientId =
-      realtimeWithClientId.channels.get('pushenabled:test:extras');
+  await encryptedPushEnabledChannel.setOptions(channelOptions);
 
   // Send message with extras to encrypted push-enabled channel
-  await encryptedPushEnabledChannelWithClientId.publish(
+  await encryptedPushEnabledChannel.publish(
     message: Message(
       name: 'single-message-push-enabled-name',
       data: 'single-message-push-enabled-data',
@@ -151,20 +111,22 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
 
   // Retrieve history of push-enabled channels
   final historyOfEncryptedPushEnabledChannel =
-      await getHistory(encryptedPushEnabledChannelWithClientId);
+      await getHistory(encryptedPushEnabledChannel);
+
+  // Retreive plaintext history of encrypted channel
+  await encryptedChannel.setOptions(RealtimeChannelOptions());
+  final historyOfPlaintextChannel = await getHistory(
+    encryptedChannel,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+  await encryptedPushEnabledChannel.setOptions(RealtimeChannelOptions());
   final historyOfPlaintextPushEnabledChannel =
-      await getHistory(plaintextPushEnabledChannelWithClientId);
+      await getHistory(encryptedPushEnabledChannel);
 
   return {
     'handle': await realtimeWithClientId.handle,
-    'historyOfEncryptedChannelWithClientId':
-        historyOfEncryptedChannelWithClientId,
-    'historyOfPlaintextChannelWithClientId':
-        historyOfPlaintextChannelWithClientId,
-    'historyOfEncryptedChannelWithoutClientId':
-        historyOfEncryptedChannelWithoutClientId,
-    'historyOfPlaintextChannelWithoutClientId':
-        historyOfPlaintextChannelWithoutClientId,
+    'historyOfEncryptedChannel': historyOfEncryptedChannel,
+    'historyOfPlaintextChannel': historyOfPlaintextChannel,
     'historyOfEncryptedPushEnabledChannel':
         historyOfEncryptedPushEnabledChannel,
     'historyOfPlaintextPushEnabledChannel':

--- a/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
@@ -2,6 +2,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter_integration_test/config/test_constants.dart';
 import 'package:ably_flutter_integration_test/factory/reporter.dart';
 import 'package:ably_flutter_integration_test/provisioning.dart';
+import 'package:ably_flutter_integration_test/utils/data.dart';
 import 'package:ably_flutter_integration_test/utils/realtime.dart';
 
 Future<Map<String, dynamic>> testRealtimeEncryptedPublish({
@@ -16,16 +17,157 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublish({
 
   final channelOptions = RealtimeChannelOptions(cipherParams: cipherParams);
 
-  final rest = Realtime(
-      options: ClientOptions.fromKey(appKey.toString())
-        ..environment = 'sandbox'
-        ..clientId = 'someClientId');
+  final realtime = Realtime(
+    options: ClientOptions.fromKey(appKey.toString())
+      ..environment = 'sandbox'
+      ..clientId = 'someClientId',
+  );
 
-  final channel = rest.channels.get('test');
+  final channel = realtime.channels.get('test');
   await channel.setOptions(channelOptions);
 
   await publishMessages(channel);
   return {
-    'handle': await rest.handle,
+    'handle': await realtime.handle,
+  };
+}
+
+Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  const clientId = 'clientId';
+  final appKey = await provision('sandbox-');
+
+  final cipherParams =
+      await Crypto.getDefaultParams(key: TestConstants.encryptedChannelKey);
+
+  final channelOptions = RealtimeChannelOptions(cipherParams: cipherParams);
+
+  // Realtime instance where client id is specified in the instance itself
+  final realtimeWithClientId = Realtime(
+    options: ClientOptions.fromKey(appKey.toString())
+      ..environment = 'sandbox'
+      ..clientId = clientId
+      ..logLevel = LogLevel.verbose,
+  );
+
+  // Create encrypted  & plaintext channels with client ID
+  final encryptedChannelWithClientId =
+      realtimeWithClientId.channels.get('test');
+  await encryptedChannelWithClientId.setOptions(channelOptions);
+  final plaintextChannelWithClientId =
+      realtimeWithClientId.channels.get('test');
+
+  // Send simple message data
+  await encryptedChannelWithClientId.publish();
+  await encryptedChannelWithClientId.publish(name: 'name');
+  await encryptedChannelWithClientId.publish(data: 'data');
+  await encryptedChannelWithClientId.publish(name: 'name', data: 'data');
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send single message object
+  await encryptedChannelWithClientId.publish(
+    message: Message(
+      name: 'single-message-name',
+      data: 'single-message-data',
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send multiple message objects at once
+  await encryptedChannelWithClientId.publish(messages: [
+    Message(name: 'multi-message-name-1', data: 'multi-message-data-1'),
+    Message(name: 'multi-message-name-2', data: 'multi-message-data-2'),
+  ]);
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Send message with [clientId] defined
+  await encryptedChannelWithClientId.publish(
+    message: Message(
+      name: 'single-message-with-client-id-name',
+      data: 'single-message-with-client-id-data',
+      clientId: clientId,
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Retrieve history of channels where client id was specified
+  final historyOfEncryptedChannelWithClientId = await getHistory(
+    encryptedChannelWithClientId,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+  final historyOfPlaintextChannelWithClientId = await getHistory(
+    plaintextChannelWithClientId,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+
+  // Realtime instance where client id has to be specified in messages
+  final realtimeWithoutClientId = Realtime(
+    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
+  );
+
+  // Create encrypted channel without client ID
+  final encryptedChannelWithoutClientId =
+      realtimeWithoutClientId.channels.get('test2');
+  await encryptedChannelWithoutClientId.setOptions(channelOptions);
+  final plaintextChannelWithoutClientId =
+      realtimeWithoutClientId.channels.get('test2');
+
+  // Send message with client ID provided
+  await encryptedChannelWithoutClientId.publish(
+    message: Message(
+      name: 'single-message-with-client-id',
+      clientId: clientId,
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // Retrieve history of channels where client id was not specified
+  final historyOfEncryptedChannelWithoutClientId = await getHistory(
+    encryptedChannelWithoutClientId,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+  final historyOfPlaintextChannelWithoutClientId = await getHistory(
+    plaintextChannelWithoutClientId,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+
+  // Create encrypted channel with push capability
+  final encryptedPushEnabledChannelWithClientId =
+      realtimeWithClientId.channels.get('pushenabled:test:extras');
+  await encryptedPushEnabledChannelWithClientId.setOptions(channelOptions);
+  final plaintextPushEnabledChannelWithClientId =
+      realtimeWithClientId.channels.get('pushenabled:test:extras');
+
+  // Send message with extras to encrypted push-enabled channel
+  await encryptedPushEnabledChannelWithClientId.publish(
+    message: Message(
+      name: 'single-message-push-enabled-name',
+      data: 'single-message-push-enabled-data',
+      extras: const MessageExtras({...pushPayload}),
+    ),
+  );
+
+  // Retrieve history of push-enabled channels
+  final historyOfEncryptedPushEnabledChannel =
+      await getHistory(encryptedPushEnabledChannelWithClientId);
+  final historyOfPlaintextPushEnabledChannel =
+      await getHistory(plaintextPushEnabledChannelWithClientId);
+
+  return {
+    'handle': await realtimeWithClientId.handle,
+    'historyOfEncryptedChannelWithClientId':
+        historyOfEncryptedChannelWithClientId,
+    'historyOfPlaintextChannelWithClientId':
+        historyOfPlaintextChannelWithClientId,
+    'historyOfEncryptedChannelWithoutClientId':
+        historyOfEncryptedChannelWithoutClientId,
+    'historyOfPlaintextChannelWithoutClientId':
+        historyOfPlaintextChannelWithoutClientId,
+    'historyOfEncryptedPushEnabledChannel':
+        historyOfEncryptedPushEnabledChannel,
+    'historyOfPlaintextPushEnabledChannel':
+        historyOfPlaintextPushEnabledChannel,
   };
 }

--- a/test_integration/lib/test/realtime/realtime_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_publish_test.dart
@@ -1,6 +1,9 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/config/test_constants.dart';
 import 'package:ably_flutter_integration_test/factory/reporter.dart';
 import 'package:ably_flutter_integration_test/provisioning.dart';
+import 'package:ably_flutter_integration_test/utils/data.dart';
+import 'package:ably_flutter_integration_test/utils/encoders.dart';
 import 'package:ably_flutter_integration_test/utils/realtime.dart';
 
 Future<Map<String, dynamic>> testRealtimePublish({
@@ -22,5 +25,95 @@ Future<Map<String, dynamic>> testRealtimePublish({
   return {
     'handle': await realtime.handle,
     'log': logMessages,
+  };
+}
+
+Future<Map<String, dynamic>> testRealtimePublishSpec({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  final appKey = await provision('sandbox-');
+
+  final realtime = Realtime(
+    options: ClientOptions.fromKey(appKey.toString())
+      ..environment = 'sandbox'
+      ..clientId = 'someClientId'
+      ..logLevel = LogLevel.verbose,
+  );
+  final channel = realtime.channels.get('test');
+  await channel.publish();
+  await channel.publish(name: 'name1');
+  await channel.publish(data: 'data1');
+  await channel.publish(name: 'name1', data: 'data1');
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await channel.publish(
+    message: Message(name: 'message-name1', data: 'message-data1'),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await channel.publish(messages: [
+    Message(name: 'messages-name1', data: 'messages-data1'),
+    Message(name: 'messages-name2', data: 'messages-data2'),
+  ]);
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await channel.publish(
+    message: Message(
+      name: 'message-name1',
+      data: 'message-data1',
+      clientId: 'someClientId',
+    ),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+
+  // publishing message with a different client id
+  Map<String, dynamic>? exception;
+  try {
+    await channel.publish(
+        message: Message(name: 'name', clientId: 'client-id'));
+  } on AblyException catch (e) {
+    exception = encodeAblyException(e);
+  }
+  final history = await getHistory(
+    channel,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+
+  // client options - no client id, message has client id
+  final realtime2 = Realtime(
+    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
+  );
+
+  final channel2 = realtime2.channels.get('test2');
+  await channel2.publish(
+    message: Message(name: 'name-client-id', clientId: 'client-id'),
+  );
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+  final history2 = await getHistory(
+    channel2,
+    RealtimeHistoryParams(direction: 'forwards'),
+  );
+
+  final channel3 = realtime2.channels.get('©Äblý');
+  await channel3.publish(name: 'Ωπ', data: 'ΨΔ');
+
+  await Future.delayed(TestConstants.publishToHistoryDelay);
+  final history3 = await getHistory(channel3);
+
+  final channelExtras = realtime.channels.get('pushenabled:test:extras');
+  await channelExtras.publish(
+    message: Message(
+      name: 'name',
+      data: 'data',
+      extras: const MessageExtras({...pushPayload}),
+    ),
+  );
+  final historyExtras = await getHistory(channelExtras);
+
+  return {
+    'handle': await realtime.handle,
+    'publishedMessages': history,
+    'publishedMessages2': history2,
+    'publishedMessages3': history3,
+    'publishedExtras': historyExtras,
+    'exception': exception,
   };
 }

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -146,6 +146,93 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRealtimeEncryptedPublishSpec(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.realtimeEncryptedPublishSpec);
+  late TestControlResponseMessage response;
+  late List historyOfEncryptedChannelWithClientId;
+  late List historyOfPlaintextChannelWithClientId;
+  late List historyOfEncryptedChannelWithoutClientId;
+  late List historyOfPlaintextChannelWithoutClientId;
+  late List historyOfEncryptedPushEnabledChannel;
+  late List historyOfPlaintextPushEnabledChannel;
+
+  setUpAll(() async {
+    response = await requestDataForTest(getDriver(), message);
+
+    historyOfEncryptedChannelWithClientId =
+        response.payload['historyOfEncryptedChannelWithClientId'] as List;
+    historyOfPlaintextChannelWithClientId =
+        response.payload['historyOfPlaintextChannelWithClientId'] as List;
+    historyOfEncryptedChannelWithoutClientId =
+        response.payload['historyOfEncryptedChannelWithoutClientId'] as List;
+    historyOfPlaintextChannelWithoutClientId =
+        response.payload['historyOfPlaintextChannelWithoutClientId'] as List;
+    historyOfEncryptedPushEnabledChannel =
+        response.payload['historyOfEncryptedPushEnabledChannel'] as List;
+    historyOfPlaintextPushEnabledChannel =
+        response.payload['historyOfPlaintextPushEnabledChannel'] as List;
+  });
+
+  group('RSl1', () {
+    test('publishes without a name and data', () {
+      expect(historyOfEncryptedChannelWithClientId[0]['name'], null);
+      expect(historyOfEncryptedChannelWithClientId[0]['data'], null);
+    });
+    test('publishes without data', () {
+      expect(historyOfEncryptedChannelWithClientId[1]['name'], 'name');
+      expect(historyOfEncryptedChannelWithClientId[1]['data'], null);
+    });
+    test('publishes without a name', () {
+      expect(historyOfEncryptedChannelWithClientId[2]['name'], null);
+      expect(historyOfEncryptedChannelWithClientId[2]['data'], 'data');
+    });
+    test('publishes with name and data', () {
+      expect(historyOfEncryptedChannelWithClientId[3]['name'], 'name');
+      expect(historyOfEncryptedChannelWithClientId[3]['data'], 'data');
+    });
+    test('publishes single message object', () {
+      expect(historyOfEncryptedChannelWithClientId[4]['name'],
+          'single-message-name');
+      expect(historyOfEncryptedChannelWithClientId[4]['data'],
+          'single-message-data');
+    });
+    test('publishes multiple message objects', () {
+      expect(historyOfEncryptedChannelWithClientId[5]['name'],
+          'multi-message-name-1');
+      expect(historyOfEncryptedChannelWithClientId[5]['data'],
+          'multi-message-data-1');
+      expect(historyOfEncryptedChannelWithClientId[6]['name'],
+          'multi-message-name-2');
+      expect(historyOfEncryptedChannelWithClientId[6]['data'],
+          'multi-message-data-2');
+    });
+    test('publishes multiple messages at once', () {
+      expect(
+          historyOfEncryptedChannelWithClientId[5]['timestamp'] ==
+              historyOfEncryptedChannelWithClientId[6]['timestamp'],
+          true);
+      expect(
+          historyOfEncryptedChannelWithClientId[5]['timestamp'] !=
+              historyOfEncryptedChannelWithClientId[4]['timestamp'],
+          true);
+    });
+  });
+
+  test('RSL6a2 publishes message extras', () {
+    expect(
+      historyOfEncryptedPushEnabledChannel[0]['name'],
+      'single-message-push-enabled-name',
+    );
+    expect(
+      historyOfEncryptedPushEnabledChannel[0]['data'],
+      'single-message-push-enabled-data',
+    );
+    checkMessageExtras(
+        historyOfEncryptedPushEnabledChannel[0]['extras']['extras'] as Map);
+    expect(historyOfEncryptedPushEnabledChannel[0]['extras']['delta'], null);
+  });
+}
+
 void testRealtimeEvents(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeEvents);
   late TestControlResponseMessage response;

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:ably_flutter_integration_test/driver_data_handler.dart';
 import 'package:flutter_driver/flutter_driver.dart';
 import 'package:test/test.dart';
@@ -149,87 +151,50 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
 void testRealtimeEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeEncryptedPublishSpec);
   late TestControlResponseMessage response;
-  late List historyOfEncryptedChannelWithClientId;
-  late List historyOfPlaintextChannelWithClientId;
-  late List historyOfEncryptedChannelWithoutClientId;
-  late List historyOfPlaintextChannelWithoutClientId;
+  late List historyOfEncryptedChannel;
+  late List historyOfPlaintextChannel;
   late List historyOfEncryptedPushEnabledChannel;
   late List historyOfPlaintextPushEnabledChannel;
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    historyOfEncryptedChannelWithClientId =
-        response.payload['historyOfEncryptedChannelWithClientId'] as List;
-    historyOfPlaintextChannelWithClientId =
-        response.payload['historyOfPlaintextChannelWithClientId'] as List;
-    historyOfEncryptedChannelWithoutClientId =
-        response.payload['historyOfEncryptedChannelWithoutClientId'] as List;
-    historyOfPlaintextChannelWithoutClientId =
-        response.payload['historyOfPlaintextChannelWithoutClientId'] as List;
+    historyOfEncryptedChannel =
+        response.payload['historyOfEncryptedChannel'] as List;
+    historyOfPlaintextChannel =
+        response.payload['historyOfPlaintextChannel'] as List;
     historyOfEncryptedPushEnabledChannel =
         response.payload['historyOfEncryptedPushEnabledChannel'] as List;
     historyOfPlaintextPushEnabledChannel =
         response.payload['historyOfPlaintextPushEnabledChannel'] as List;
   });
 
-  group('RSl1', () {
-    test('publishes without a name and data', () {
-      expect(historyOfEncryptedChannelWithClientId[0]['name'], null);
-      expect(historyOfEncryptedChannelWithClientId[0]['data'], null);
+  group('RSL5', () {
+    test('does not encrypt name', () {
+      for (var i = 0; i < historyOfEncryptedPushEnabledChannel.length; i++) {
+        expect(historyOfEncryptedChannel[i]['name'],
+            equals(historyOfPlaintextChannel[i]['name']));
+      }
     });
-    test('publishes without data', () {
-      expect(historyOfEncryptedChannelWithClientId[1]['name'], 'name');
-      expect(historyOfEncryptedChannelWithClientId[1]['data'], null);
-    });
-    test('publishes without a name', () {
-      expect(historyOfEncryptedChannelWithClientId[2]['name'], null);
-      expect(historyOfEncryptedChannelWithClientId[2]['data'], 'data');
-    });
-    test('publishes with name and data', () {
-      expect(historyOfEncryptedChannelWithClientId[3]['name'], 'name');
-      expect(historyOfEncryptedChannelWithClientId[3]['data'], 'data');
-    });
-    test('publishes single message object', () {
-      expect(historyOfEncryptedChannelWithClientId[4]['name'],
-          'single-message-name');
-      expect(historyOfEncryptedChannelWithClientId[4]['data'],
-          'single-message-data');
-    });
-    test('publishes multiple message objects', () {
-      expect(historyOfEncryptedChannelWithClientId[5]['name'],
-          'multi-message-name-1');
-      expect(historyOfEncryptedChannelWithClientId[5]['data'],
-          'multi-message-data-1');
-      expect(historyOfEncryptedChannelWithClientId[6]['name'],
-          'multi-message-name-2');
-      expect(historyOfEncryptedChannelWithClientId[6]['data'],
-          'multi-message-data-2');
-    });
-    test('publishes multiple messages at once', () {
-      expect(
-          historyOfEncryptedChannelWithClientId[5]['timestamp'] ==
-              historyOfEncryptedChannelWithClientId[6]['timestamp'],
-          true);
-      expect(
-          historyOfEncryptedChannelWithClientId[5]['timestamp'] !=
-              historyOfEncryptedChannelWithClientId[4]['timestamp'],
-          true);
-    });
-  });
 
-  test('RSL6a2 publishes message extras', () {
-    expect(
-      historyOfEncryptedPushEnabledChannel[0]['name'],
-      'single-message-push-enabled-name',
-    );
-    expect(
-      historyOfEncryptedPushEnabledChannel[0]['data'],
-      'single-message-push-enabled-data',
-    );
-    checkMessageExtras(
-        historyOfEncryptedPushEnabledChannel[0]['extras']['extras'] as Map);
-    expect(historyOfEncryptedPushEnabledChannel[0]['extras']['delta'], null);
+    test('does encrypt data', () {
+      for (var i = 0; i < historyOfEncryptedPushEnabledChannel.length; i++) {
+        final encryptedData = historyOfEncryptedChannel[i]['data'];
+        final plaintextData = historyOfPlaintextChannel[i]['data'];
+
+        if (encryptedData != null) {
+          expect(encryptedData, isNot(equals(plaintextData)));
+          expect(plaintextData, isA<Uint8List>());
+        }
+      }
+    });
+
+    test('does not encrypt extras', () {
+      for (var i = 0; i < historyOfEncryptedPushEnabledChannel.length; i++) {
+        expect(historyOfEncryptedPushEnabledChannel[i]['name'],
+            equals(historyOfPlaintextPushEnabledChannel[i]['name']));
+      }
+    });
   });
 }
 

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -32,6 +32,7 @@ final _tests =
     'should publish': testRealtimePublish,
     'should publish encrypted': testRealtimeEncryptedPublish,
     'conforms to publish spec': testRealtimePublishSpec,
+    'conforms to publish spec when encrypted': testRealtimeEncryptedPublishSpec,
     'should subscribe to connection and channel': testRealtimeEvents,
     'should subscribe to messages': testRealtimeSubscribe,
     'should retrieve history': testRealtimeHistory,

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -31,6 +31,7 @@ final _tests =
   TestModules.realtime: {
     'should publish': testRealtimePublish,
     'should publish encrypted': testRealtimeEncryptedPublish,
+    'conforms to publish spec': testRealtimePublishSpec,
     'should subscribe to connection and channel': testRealtimeEvents,
     'should subscribe to messages': testRealtimeSubscribe,
     'should retrieve history': testRealtimeHistory,


### PR DESCRIPTION
This PR should close #332 and together with that, resolve #205 (I decided to implement them both at the same time, since they're strongly related). The changes include:
* A copy of REST channel publish spec test for real-time channels. The copy is not 1:1, since real-time channels have a few differences according to spec. [RTL6a1](https://docs.ably.com/client-lib-development-guide/features/#RTL6a1) indicates test components that were removed because they are present in REST channels, but not in real-time channels.
* A new test set for encrypted real-time publish spec [RSL5](https://docs.ably.com/client-lib-development-guide/features/#RSL5). I've followed the suggestion that @ikbalkaya gave me and utilized the channel history method to verify that messages are encrypted and decrypted correctly. Messages used in tests are coming from the same channel but in unecrypted and encrypted version, so we can verify if the `data` payload actually changes
* A rework of existing encryption publish spec for REST channels, to match the style and checks used for the same real-time spec test

This set of tests should help us indicate problems with real-time channel publishing and both real-time and rest channel encryption and encrypted history