### PR TITLE
Sample app default google-services file

### DIFF
--- a/PushNotifications.md
+++ b/PushNotifications.md
@@ -39,7 +39,7 @@ To get push notifications setup in your own app, read [Setting up your own app](
 - Create a Firebase project, and in the Project settings, add an android app with your unique application ID. Follow the steps provided on the setup process, or the following:
     - You can leave `Debug signing certificate SHA-1` empty.
     - Download the generated `google-services.json` file
-    - Place `google-services.json` in `example/android/app/`. We have `gitignore`d this file since it is associated with our Firebase project, but it is [not sensitive](https://stackoverflow.com/questions/37358340/should-i-add-the-google-services-json-from-firebase-to-my-repository), so you can commit it to share it with other developers/colleagues.
+    - Replace the default `google-services.json` in `example/android/app/` with the one generated for your project
 - Provide ably with the FCM server key: In your [firebase project settings](https://knowledge.ably.com/where-can-i-find-my-google/firebase-cloud-messaging-api-key), create or use an existing cloud messaging server key, and enter it in your Ably app's dashboard (App > Notifications tab > Push Notifications Setup > Setup Push Notifications).
 
 ### iOS

--- a/README.md
+++ b/README.md
@@ -52,12 +52,6 @@ Features that we do not currently support, but we do plan to add in the future:
 
 ### Running example app
 
-On iOS, the example application can be run without any additional configuration. For Android, a Firebase instance configuration is required to build the app. In order run the application on Android device:
-
-- Create a Firebase project following [official Firebase guide](https://firebase.google.com/docs/android/setup#create-firebase-project) (you can also use an existing one)
-- Register the sample app with your Firebase project using `io.ably.flutter.example` as package name
-- Download `google_services.json` file from Firebase and put it into [example/android/app](example/android/app) directory
-
 There are two different ways the example application can be configured to use Ably services:
 
 1. Without the Ably SKD key: the application will request a sandbox key provision from Ably server at startup, but be aware that:
@@ -95,6 +89,8 @@ Under the run/ debug configuration drop down menu, click `Edit Configurations...
   - To choose a specific device when more than one are connected: get your device ID using `flutter devices`, and then running `flutter run --dart-define=ABLY_API_KEY=put_your_ably_api_key_here --device-id replace_with_device_id`
 
 ### Push Notifications
+
+By default, push-related components in the sample app won't work on Android, because of a dummy [google-services.json](example/android/app/src/google-services.json) file. In order to use push messaging features of Ably SDK, additional FCM/APNS configuration is required.
 
 See [PushNotifications.md](PushNotifications.md) for detailed information on getting PN working with the example app.
 

--- a/example/android/app/src/google-services.json
+++ b/example/android/app/src/google-services.json
@@ -1,0 +1,39 @@
+{
+  "project_info": {
+    "project_number": "",
+    "project_id": "",
+    "storage_bucket": ""
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "",
+        "android_client_info": {
+          "package_name": "io.ably.flutter.example"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
@@ -21,9 +21,13 @@ class PushNotificationsActivationSliver extends HookWidget {
       BuildContext context, ably.AblyException error) async {
     await showDialog(
       context: context,
-      builder: (context) => CupertinoAlertDialog(
-        title: const Text('Error'),
-        content: Text(error.message ?? 'No error message'),
+      builder: (context) => AlertDialog(
+        title: const Text('Push notification error'),
+        content:
+            Text('Failed to perform operation on push notification service. '
+                'Please verify your push notification setup with Readme '
+                'files in the ably-flutter repository.\n\n'
+                '${error.errorInfo?.message}'),
       ),
     );
   }

--- a/example/lib/ui/push_notifications/push_notifications_subscriptions_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_subscriptions_sliver.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/push_notifications/push_notification_service.dart';
 import 'package:ably_flutter_example/ui/bool_stream_button.dart';
+import 'package:ably_flutter_example/ui/utilities.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -77,13 +78,25 @@ class PushNotificationsSubscriptionsSliver extends StatelessWidget {
                 Expanded(
                   child: BoolStreamButton(
                       stream: _pushNotificationService.hasPushChannelStream,
-                      onPressed: _pushNotificationService.subscribeDevice,
+                      onPressed: () async {
+                        try {
+                          await _pushNotificationService.subscribeDevice();
+                        } on ably.AblyException catch (ablyException) {
+                          showPushActivationError(context, ablyException);
+                        }
+                      },
                       child: const Text('Subscribe device')),
                 ),
                 Expanded(
                   child: BoolStreamButton(
                     stream: _pushNotificationService.hasPushChannelStream,
-                    onPressed: _pushNotificationService.unsubscribeDevice,
+                    onPressed: () async {
+                      try {
+                        await _pushNotificationService.unsubscribeDevice();
+                      } on ably.AblyException catch (ablyException) {
+                        showPushActivationError(context, ablyException);
+                      }
+                    },
                     child: const Text('Unsubscribe device'),
                   ),
                 ),
@@ -104,13 +117,25 @@ class PushNotificationsSubscriptionsSliver extends StatelessWidget {
                 Expanded(
                   child: BoolStreamButton(
                       stream: _pushNotificationService.hasPushChannelStream,
-                      onPressed: _pushNotificationService.subscribeClient,
+                      onPressed: () async {
+                        try {
+                          await _pushNotificationService.subscribeClient();
+                        } on ably.AblyException catch (ablyException) {
+                          showPushActivationError(context, ablyException);
+                        }
+                      },
                       child: const Text('Subscribe client')),
                 ),
                 Expanded(
                   child: BoolStreamButton(
                       stream: _pushNotificationService.hasPushChannelStream,
-                      onPressed: _pushNotificationService.unsubscribeClient,
+                      onPressed: () async {
+                        try {
+                          await _pushNotificationService.unsubscribeClient();
+                        } on ably.AblyException catch (ablyException) {
+                          showPushActivationError(context, ablyException);
+                        }
+                      },
                       child: const Text('Unsubscribe client')),
                 )
               ],
@@ -151,4 +176,20 @@ class PushNotificationsSubscriptionsSliver extends StatelessWidget {
     }
     return const SizedBox.shrink();
   }
+
+  void showPushActivationError(
+    BuildContext context,
+    ably.AblyException exception,
+  ) async =>
+      await showDialog(
+        context: context,
+        builder: (context) => AlertDialog(
+          title: const Text('Push notification error'),
+          content:
+              Text('Failed to perform operation on push notification service. '
+                  'Please verify your push notification setup with Readme '
+                  'files in the ably-flutter repository.\n\n'
+                  '${exception.errorInfo?.message}'),
+        ),
+      );
 }


### PR DESCRIPTION
This should resolve https://github.com/ably/ably-flutter/issues/318 and make the sample app work without any additional configuration. It;s based on `feature/example-app/provisioning` because they both alter sample application and readme files and I wanted to avoid conflicts.

The most important change is the dummy `google-services.json` file. I've decided to use this approach, since it seemed to be the most reasonable one. File structure is compliant with Firebase requirements, but it doesn't contain any data inside. This is just enough to run the app, as long as no Firebase services are needed. 

Google states that these files do not contain any sensitive information, but I'm not a fan of putting any server instance data or API keys inside the repository. In our use case, it doesn't really matter if Firebase is able to connect in the sample app or not, since it won't be able to connect to push services anyway, because Firebase instance has to be linked with Ably instance first, and that can't be done with any sample instance of Firebase that we would use.

I've also added error popups for the sample app, to indicate errors related to push notifications.