### PR TITLE
Refactor of ClientOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ client libraries.
 ### Supported functionality
 
 - Create a REST or Realtime instance by passing `ClientOptions`:
-    - `ClientOptions` can be created by passing an API token (`ClientOptions(key: key)`)
+    - `ClientOptions` can be created by passing an API token (`ClientOptions.fromKey`)
     - `defaultTokenParams`, `authCallback` and `logHandler` are not supported yet
 - Get a REST channel and publish messages
 - Listen for Realtime connection state changes using a stream subscription

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -337,7 +337,7 @@ client libraries.
 ### Supported functionality
 
 - Create a REST or Realtime instance by passing `ClientOptions`:
-    - `ClientOptions` can be created by passing an API token (`ClientOptions.fromKey`)
+    - `ClientOptions` can be created by passing an API token (`ClientOptions(key: key)`)
     - `defaultTokenParams`, `authCallback` and `logHandler` are not supported yet
 - Get a REST channel and publish messages
 - Listen for Realtime connection state changes using a stream subscription

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Authenticating using [basic authentication/ API key](https://ably.com/documentat
 ```dart
 // Specify your apiKey with `flutter run --dart-define=ABLY_API_KEY=replace_your_api_key`
 final String ablyApiKey = const String.fromEnvironment("ABLY_API_KEY");
-final clientOptions = ably.ClientOptions.fromKey(ablyApiKey);
+final clientOptions = ably.ClientOptions(key: ablyApiKey);
 clientOptions.logLevel = ably.LogLevel.verbose;  // optional
 ```
 

--- a/example/lib/ui/ably_service.dart
+++ b/example/lib/ui/ably_service.dart
@@ -11,21 +11,26 @@ class AblyService {
 
   AblyService({required this.apiKeyProvision}) {
     realtime = ably.Realtime(
-      options: ably.ClientOptions.fromKey(apiKeyProvision.key)
-        ..clientId = Constants.clientId
-        ..logLevel = ably.LogLevel.verbose
-        ..environment = apiKeyProvision.source == ApiKeySource.env
+      options: ably.ClientOptions(
+        key: apiKeyProvision.key,
+        clientId: Constants.clientId,
+        logLevel: ably.LogLevel.verbose,
+        environment: apiKeyProvision.source == ApiKeySource.env
             ? null
-            : Constants.sandboxEnvironment
-        ..autoConnect = false,
+            : Constants.sandboxEnvironment,
+        autoConnect: false,
+      ),
     );
     rest = ably.Rest(
-        options: ably.ClientOptions.fromKey(apiKeyProvision.key)
-          ..clientId = Constants.clientId
-          ..logLevel = ably.LogLevel.verbose
-          ..environment = apiKeyProvision.source == ApiKeySource.env
-              ? null
-              : Constants.sandboxEnvironment);
+      options: ably.ClientOptions(
+        key: apiKeyProvision.key,
+        clientId: Constants.clientId,
+        logLevel: ably.LogLevel.verbose,
+        environment: apiKeyProvision.source == ApiKeySource.env
+            ? null
+            : Constants.sandboxEnvironment,
+      ),
+    );
     pushNotificationService = PushNotificationService(realtime, rest);
   }
 }

--- a/lib/src/authentication/src/auth_options.dart
+++ b/lib/src/authentication/src/auth_options.dart
@@ -8,20 +8,6 @@ import 'package:ably_flutter/ably_flutter.dart';
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#AO1
 abstract class AuthOptions {
-  /// initializes an instance without any defaults
-  AuthOptions();
-
-  /// Convenience constructor, to create an AuthOptions based
-  /// on the key string obtained from the application dashboard.
-  /// param [key]: the full key string as obtained from the dashboard
-  AuthOptions.fromKey(String key) {
-    if (key.contains(':')) {
-      this.key = key;
-    } else {
-      tokenDetails = TokenDetails(key);
-    }
-  }
-
   /// A function which is called when a new token is required.
   ///
   /// The role of the callback is to either generate a signed [TokenRequest]
@@ -83,6 +69,30 @@ abstract class AuthOptions {
 
 // TODO(tiholic) missing token attribute here
 //  see: https://docs.ably.com/client-lib-development-guide/features/#AO2h
+
+  /// Initializes an instance without any defaults
+  AuthOptions({
+    this.authCallback,
+    this.authUrl,
+    this.authMethod,
+    this.key,
+    this.tokenDetails,
+    this.authHeaders,
+    this.authParams,
+    this.queryTime,
+    this.useTokenAuth,
+  });
+
+  /// Convenience constructor, to create an AuthOptions based
+  /// on the key string obtained from the application dashboard.
+  /// param [key]: the full key string as obtained from the dashboard
+  AuthOptions.fromKey(String key) {
+    if (key.contains(':')) {
+      this.key = key;
+    } else {
+      tokenDetails = TokenDetails(key);
+    }
+  }
 }
 
 /// Function-type alias implemented by a function that provides either tokens,

--- a/lib/src/authentication/src/auth_options.dart
+++ b/lib/src/authentication/src/auth_options.dart
@@ -81,11 +81,17 @@ abstract class AuthOptions {
     this.authParams,
     this.queryTime,
     this.useTokenAuth,
-  });
+  }) {
+    if (key != null && !key!.contains(':')) {
+      tokenDetails = TokenDetails(key);
+      key = null;
+    }
+  }
 
   /// Convenience constructor, to create an AuthOptions based
   /// on the key string obtained from the application dashboard.
   /// param [key]: the full key string as obtained from the dashboard
+  @Deprecated("Use AuthOptions constructor with named 'key' parameter instead")
   AuthOptions.fromKey(String key) {
     if (key.contains(':')) {
       this.key = key;

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -4,14 +4,6 @@ import 'package:ably_flutter/ably_flutter.dart';
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TO1
 class ClientOptions extends AuthOptions {
-  /// Set fields on [ClientOptions] to configure it.
-  ClientOptions();
-
-  /// initializes [ClientOptions] with a key and log level set to info
-  ///
-  /// See [AuthOptions.fromKey] for more details
-  ClientOptions.fromKey(String key) : super.fromKey(key);
-
   /// Optional clientId that can be used to specify the identity for this client
   ///
   /// In most cases it is preferable to instead specific a clientId in the token
@@ -194,6 +186,78 @@ class ClientOptions extends AuthOptions {
   /// default 15,000 (15s)
   /// https://docs.ably.com/client-lib-development-guide/features/#TO3l7
   int channelRetryTimeout = 15000;
+
+  /// Initializes an instance with defaults
+  ClientOptions({
+    AuthCallback? authCallback,
+    String? authUrl,
+    String? authMethod,
+    String? key,
+    TokenDetails? tokenDetails,
+    Map<String, String>? authHeaders,
+    Map<String, String>? authParams,
+    bool? queryTime,
+    bool? useTokenAuth,
+    this.clientId,
+    this.logHandler,
+    LogLevel? logLevel,
+    this.restHost,
+    this.realtimeHost,
+    this.port,
+    bool? tls,
+    this.tlsPort,
+    bool? autoConnect,
+    bool? useBinaryProtocol,
+    bool? queueMessages,
+    bool? echoMessages,
+    this.recover,
+    this.environment,
+    this.fallbackHosts,
+    this.fallbackHostsUseDefault,
+    this.defaultTokenParams,
+    int? disconnectedRetryTimeout,
+    int? suspendedRetryTimeout,
+    this.idempotentRestPublishing,
+    this.transportParams,
+    int? httpOpenTimeout,
+    int? httpRequestTimeout,
+    int? httpMaxRetryCount,
+    this.realtimeRequestTimeout,
+    int? fallbackRetryTimeout,
+    int? channelRetryTimeout,
+  }) : super(
+          authCallback: authCallback,
+          authUrl: authUrl,
+          authMethod: authMethod,
+          key: key,
+          tokenDetails: tokenDetails,
+          authHeaders: authHeaders,
+          authParams: authParams,
+          queryTime: queryTime,
+          useTokenAuth: useTokenAuth,
+        ) {
+    this.logLevel = logLevel ?? this.logLevel;
+    this.tls = tls ?? this.tls;
+    this.autoConnect = autoConnect ?? this.autoConnect;
+    this.useBinaryProtocol = useBinaryProtocol ?? this.useBinaryProtocol;
+    this.queueMessages = queueMessages ?? this.queueMessages;
+    this.echoMessages = echoMessages ?? this.echoMessages;
+    this.disconnectedRetryTimeout =
+        disconnectedRetryTimeout ?? this.disconnectedRetryTimeout;
+    this.suspendedRetryTimeout =
+        suspendedRetryTimeout ?? this.suspendedRetryTimeout;
+    this.httpOpenTimeout = httpOpenTimeout ?? this.httpOpenTimeout;
+    this.httpRequestTimeout = httpRequestTimeout ?? this.httpRequestTimeout;
+    this.httpMaxRetryCount = httpMaxRetryCount ?? this.httpMaxRetryCount;
+    this.fallbackRetryTimeout =
+        fallbackRetryTimeout ?? this.fallbackRetryTimeout;
+    this.channelRetryTimeout = channelRetryTimeout ?? this.channelRetryTimeout;
+  }
+
+  /// initializes [ClientOptions] with a key and log level set to info
+  ///
+  /// See [AuthOptions.fromKey] for more details
+  ClientOptions.fromKey(String key) : super.fromKey(key);
 
 // TODO(tiholic) unimplemented:
 //

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -236,6 +236,9 @@ class ClientOptions extends AuthOptions {
           queryTime: queryTime,
           useTokenAuth: useTokenAuth,
         ) {
+    /// These default value assignments are only required until
+    /// [ClientOptions.fromKey] is removed, because then defaults can be set
+    /// directly in the constructor invocation
     this.logLevel = logLevel ?? this.logLevel;
     this.tls = tls ?? this.tls;
     this.autoConnect = autoConnect ?? this.autoConnect;
@@ -257,6 +260,8 @@ class ClientOptions extends AuthOptions {
   /// initializes [ClientOptions] with a key and log level set to info
   ///
   /// See [AuthOptions.fromKey] for more details
+  @Deprecated(
+      "Use ClientOptions constructor with named 'key' parameter instead")
   ClientOptions.fromKey(String key) : super.fromKey(key);
 
 // TODO(tiholic) unimplemented:

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -535,102 +535,102 @@ class Codec extends StandardMessageCodec {
       jsonMap,
       TxClientOptions.defaultTokenParams,
     ));
-    final clientOptions = ClientOptions()
+    final clientOptions = ClientOptions(
       // AuthOptions (super class of ClientOptions)
-      ..authUrl = _readFromJson<String>(
+      authUrl: _readFromJson<String>(
         jsonMap,
         TxClientOptions.authUrl,
-      )
-      ..authMethod = _readFromJson<String>(
+      ),
+      authMethod: _readFromJson<String>(
         jsonMap,
         TxClientOptions.authMethod,
-      )
-      ..key = _readFromJson<String>(
+      ),
+      key: _readFromJson<String>(
         jsonMap,
         TxClientOptions.key,
-      )
-      ..tokenDetails =
-          (tokenDetails == null) ? null : _decodeTokenDetails(tokenDetails)
-      ..authHeaders = _readFromJson<Map<String, String>>(
+      ),
+      tokenDetails:
+          (tokenDetails == null) ? null : _decodeTokenDetails(tokenDetails),
+      authHeaders: _readFromJson<Map<String, String>>(
         jsonMap,
         TxClientOptions.authHeaders,
-      )
-      ..authParams = _readFromJson<Map<String, String>>(
+      ),
+      authParams: _readFromJson<Map<String, String>>(
         jsonMap,
         TxClientOptions.authParams,
-      )
-      ..queryTime = _readFromJson<bool>(
+      ),
+      queryTime: _readFromJson<bool>(
         jsonMap,
         TxClientOptions.queryTime,
-      )
-      ..useTokenAuth = _readFromJson<bool>(
+      ),
+      useTokenAuth: _readFromJson<bool>(
         jsonMap,
         TxClientOptions.useTokenAuth,
-      )
+      ),
 
       // ClientOptions
-      ..clientId = _readFromJson<String>(
+      clientId: _readFromJson<String>(
         jsonMap,
         TxClientOptions.clientId,
-      )
-      ..logLevel = _decodeLogLevel(jsonMap[TxClientOptions.logLevel] as String?)
+      ),
+      logLevel: _decodeLogLevel(jsonMap[TxClientOptions.logLevel] as String?),
       //TODO handle logHandler
-      ..tls = jsonMap[TxClientOptions.tls] as bool
-      ..restHost = _readFromJson<String>(
+      tls: jsonMap[TxClientOptions.tls] as bool,
+      restHost: _readFromJson<String>(
         jsonMap,
         TxClientOptions.restHost,
-      )
-      ..realtimeHost = _readFromJson<String>(
+      ),
+      realtimeHost: _readFromJson<String>(
         jsonMap,
         TxClientOptions.realtimeHost,
-      )
-      ..port = _readFromJson<int>(
+      ),
+      port: _readFromJson<int>(
         jsonMap,
         TxClientOptions.port,
-      )
-      ..tlsPort = _readFromJson<int>(
+      ),
+      tlsPort: _readFromJson<int>(
         jsonMap,
         TxClientOptions.tlsPort,
-      )
-      ..autoConnect = jsonMap[TxClientOptions.autoConnect] as bool
-      ..useBinaryProtocol = jsonMap[TxClientOptions.useBinaryProtocol] as bool
-      ..queueMessages = jsonMap[TxClientOptions.queueMessages] as bool
-      ..echoMessages = jsonMap[TxClientOptions.echoMessages] as bool
-      ..recover = _readFromJson<String>(
+      ),
+      autoConnect: jsonMap[TxClientOptions.autoConnect] as bool,
+      useBinaryProtocol: jsonMap[TxClientOptions.useBinaryProtocol] as bool,
+      queueMessages: jsonMap[TxClientOptions.queueMessages] as bool,
+      echoMessages: jsonMap[TxClientOptions.echoMessages] as bool,
+      recover: _readFromJson<String>(
         jsonMap,
         TxClientOptions.recover,
-      )
-      ..environment = _readFromJson<String>(
+      ),
+      environment: _readFromJson<String>(
         jsonMap,
         TxClientOptions.environment,
-      )
-      ..idempotentRestPublishing = _readFromJson<bool>(
+      ),
+      idempotentRestPublishing: _readFromJson<bool>(
         jsonMap,
         TxClientOptions.idempotentRestPublishing,
-      )
-      ..realtimeRequestTimeout =
-          jsonMap[TxClientOptions.realtimeRequestTimeout] as int?
-      ..httpOpenTimeout = jsonMap[TxClientOptions.httpOpenTimeout] as int
-      ..httpRequestTimeout = jsonMap[TxClientOptions.httpRequestTimeout] as int
-      ..httpMaxRetryCount = jsonMap[TxClientOptions.httpMaxRetryCount] as int
-      ..fallbackHosts = _readFromJson<List<String>>(
+      ),
+      realtimeRequestTimeout:
+          jsonMap[TxClientOptions.realtimeRequestTimeout] as int?,
+      httpOpenTimeout: jsonMap[TxClientOptions.httpOpenTimeout] as int,
+      httpRequestTimeout: jsonMap[TxClientOptions.httpRequestTimeout] as int,
+      httpMaxRetryCount: jsonMap[TxClientOptions.httpMaxRetryCount] as int,
+      fallbackHosts: _readFromJson<List<String>>(
         jsonMap,
         TxClientOptions.fallbackHosts,
-      )
-      ..fallbackHostsUseDefault = _readFromJson<bool>(
+      ),
+      fallbackHostsUseDefault: _readFromJson<bool>(
         jsonMap,
         TxClientOptions.fallbackHostsUseDefault,
-      )
-      ..fallbackRetryTimeout =
-          jsonMap[TxClientOptions.fallbackRetryTimeout] as int
-      ..defaultTokenParams =
-          (tokenParams == null) ? null : _decodeTokenParams(tokenParams)
-      ..channelRetryTimeout =
-          jsonMap[TxClientOptions.channelRetryTimeout] as int
-      ..transportParams = _readFromJson<Map<String, String>>(
+      ),
+      fallbackRetryTimeout:
+          jsonMap[TxClientOptions.fallbackRetryTimeout] as int,
+      defaultTokenParams:
+          (tokenParams == null) ? null : _decodeTokenParams(tokenParams),
+      channelRetryTimeout: jsonMap[TxClientOptions.channelRetryTimeout] as int,
+      transportParams: _readFromJson<Map<String, String>>(
         jsonMap,
         TxClientOptions.transportParams,
-      );
+      ),
+    );
     return clientOptions;
   }
 

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'dart:io' as io show Platform;
 import 'dart:collection';
+import 'dart:io' as io show Platform;
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
@@ -20,7 +20,7 @@ class Realtime extends PlatformObject {
     ClientOptions? options,
     final String? key,
   })  : assert(options != null || key != null),
-        options = options ?? ClientOptions.fromKey(key!),
+        options = options ?? ClientOptions(key: key!),
         super() {
     _connection = Connection(this);
     _channels = RealtimeChannels(this);
@@ -29,7 +29,7 @@ class Realtime extends PlatformObject {
 
   /// Create a realtime client from an API key without configuring other parameters
   factory Realtime.fromKey(String key) =>
-      Realtime(options: ClientOptions.fromKey(key));
+      Realtime(options: ClientOptions(key: key));
 
   @override
   Future<int?> createPlatformInstance() async {

--- a/lib/src/platform/src/rest/rest.dart
+++ b/lib/src/platform/src/rest/rest.dart
@@ -20,7 +20,7 @@ class Rest extends PlatformObject {
   }
 
   /// Create a rest client from an API key without configuring other parameters
-  factory Rest.fromKey(String key) => Rest(options: ClientOptions.fromKey(key));
+  factory Rest.fromKey(String key) => Rest(options: ClientOptions(key: key));
 
   @override
   Future<int?> createPlatformInstance() async {

--- a/test/ably_flutter_plugin_test.dart
+++ b/test/ably_flutter_plugin_test.dart
@@ -51,9 +51,10 @@ void main() {
   });
 
   test(PlatformMethod.createRest, () async {
-    final o = ClientOptions();
     const host = 'http://rest.ably.io/';
-    o.restHost = host;
+    final o = ClientOptions(
+      restHost: host,
+    );
     final rest = Rest(options: o);
     expect(await rest.handle, counter);
     expect(rest.options.restHost, host);

--- a/test/realtime/channel_test.dart
+++ b/test/realtime/channel_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock_method_call_manager.dart';
@@ -48,9 +47,10 @@ void main() {
       // setup
       final authCallback = expectAsync1((token) async => 'token', max: 2);
 
-      final options = ClientOptions()
-        ..authCallback = authCallback
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: authCallback,
+        authUrl: 'hasAuthCallback',
+      );
       final realtime = Realtime(options: options, key: 'TEST-KEY');
 
       final channel = realtime.channels.get('test');
@@ -74,9 +74,10 @@ void main() {
 
     test('publish realtime message with authCallback', () async {
       // setup
-      final options = ClientOptions()
-        ..authCallback = ((tokenParams) async => 'token')
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: (tokenParams) async => 'token',
+        authUrl: 'hasAuthCallback',
+      );
       final realtime = Realtime(options: options, key: 'TEST-KEY');
       final channel = realtime.channels.get('test');
 
@@ -111,9 +112,10 @@ void main() {
       // setup
       final authCallback = expectAsync1((token) async => 'token');
 
-      final options = ClientOptions()
-        ..authCallback = authCallback
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: authCallback,
+        authUrl: 'hasAuthCallback',
+      );
       final realtime = Realtime(options: options, key: 'TEST-KEY');
       final channel = realtime.channels.get('test');
 

--- a/test/rest/channel_test.dart
+++ b/test/rest/channel_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
-import 'package:fake_async/fake_async.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../mock_method_call_manager.dart';
@@ -46,9 +45,10 @@ void main() {
       // setup
       final authCallback = expectAsync1((token) async => 'token', max: 2);
 
-      final options = ClientOptions()
-        ..authCallback = authCallback
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: authCallback,
+        authUrl: 'hasAuthCallback',
+      );
       final rest = Rest(options: options);
 
       final channel = rest.channels.get('test');
@@ -71,9 +71,10 @@ void main() {
 
     test('publishes message with authCallback', () async {
       // setup
-      final options = ClientOptions()
-        ..authCallback = ((tokenParams) => Future.value('token'))
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: (tokenParams) => Future.value('token'),
+        authUrl: 'hasAuthCallback',
+      );
       final rest = Rest(options: options);
       final channel = rest.channels.get('test');
 
@@ -109,9 +110,10 @@ void main() {
       // setup
       final authCallback = expectAsync1((token) async => 'token');
 
-      final options = ClientOptions()
-        ..authCallback = authCallback
-        ..authUrl = 'hasAuthCallback';
+      final options = ClientOptions(
+        authCallback: authCallback,
+        authUrl: 'hasAuthCallback',
+      );
       final rest = Rest(options: options);
       final channel = rest.channels.get('test');
 

--- a/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
@@ -18,9 +18,11 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublish({
   final channelOptions = RealtimeChannelOptions(cipherParams: cipherParams);
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId',
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+    ),
   );
 
   final channel = realtime.channels.get('test');
@@ -46,10 +48,12 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
 
   // Realtime instance where client id is specified in the instance itself
   final realtimeWithClientId = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = clientId
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: clientId,
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   // Create encrypted channel with client ID

--- a/test_integration/lib/test/realtime/realtime_events_test.dart
+++ b/test_integration/lib/test/realtime/realtime_events_test.dart
@@ -19,10 +19,12 @@ Future<Map<String, dynamic>> testRealtimeEvents({
   final filteredChannelStateChanges = <Map<String, dynamic>>[];
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..autoConnect = false,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      autoConnect: false,
+    ),
   );
 
   void recordConnectionState() =>

--- a/test_integration/lib/test/realtime/realtime_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_history_test.dart
@@ -13,10 +13,12 @@ Future<Map<String, dynamic>> testRealtimeHistory({
   final appKey = await AppProvisioning().provisionApp();
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   final channel = realtime.channels.get('test');
   await publishMessages(channel);

--- a/test_integration/lib/test/realtime/realtime_presence_enter_update_leave.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_enter_update_leave.dart
@@ -10,10 +10,12 @@ ClientOptions getClientOptions(
   String appKey, [
   String? clientId = 'someClientId',
 ]) =>
-    ClientOptions.fromKey(appKey)
-      ..environment = 'sandbox'
-      ..clientId = clientId
-      ..logLevel = LogLevel.verbose;
+    ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: clientId,
+      logLevel: LogLevel.verbose,
+    );
 
 Future<Map<String, dynamic>> testRealtimePresenceEnterUpdateLeave({
   required Reporter reporter,

--- a/test_integration/lib/test/realtime/realtime_presence_get.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_get.dart
@@ -11,10 +11,12 @@ ClientOptions getClientOptions(
   String appKey, [
   String clientId = 'someClientId',
 ]) =>
-    ClientOptions.fromKey(appKey)
-      ..environment = 'sandbox'
-      ..clientId = clientId
-      ..logLevel = LogLevel.verbose;
+    ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: clientId,
+      logLevel: LogLevel.verbose,
+    );
 
 Future<Map<String, dynamic>> testRealtimePresenceGet({
   required Reporter reporter,

--- a/test_integration/lib/test/realtime/realtime_presence_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_history_test.dart
@@ -13,10 +13,12 @@ Future<Map<String, dynamic>> testRealtimePresenceHistory({
   final appKey = await AppProvisioning().provisionApp();
   final logMessages = <List<String?>>[];
 
-  final options = ClientOptions.fromKey(appKey.toString())
-    ..environment = 'sandbox'
-    ..clientId = 'someClientId'
-    ..logLevel = LogLevel.verbose;
+  final options = ClientOptions(
+    key: appKey,
+    environment: 'sandbox',
+    clientId: 'someClientId',
+    logLevel: LogLevel.verbose,
+  );
 
   final realtime = Realtime(options: options);
   final channel = realtime.channels.get('test');

--- a/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
@@ -19,10 +19,12 @@ Future<Map<String, dynamic>> testRealtimePresenceSubscribe({
   reporter.reportLog('init start');
   final appKey = await AppProvisioning().provisionApp();
   final presence = Realtime(
-    options: ClientOptions.fromKey(appKey)
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   ).channels.get('test').presence;
 
   final allMessages = <PresenceMessage>[];

--- a/test_integration/lib/test/realtime/realtime_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_publish_test.dart
@@ -14,10 +14,12 @@ Future<Map<String, dynamic>> testRealtimePublish({
   final logMessages = <List<String?>>[];
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   await publishMessages(realtime.channels.get('test'));
   await realtime.close();
@@ -34,10 +36,12 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
   final appKey = await AppProvisioning().provisionApp();
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   final channel = realtime.channels.get('test');
   await channel.publish();
@@ -78,7 +82,10 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
 
   // client options - no client id, message has client id
   final realtime2 = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+    ),
   );
 
   final channel2 = realtime2.channels.get('test2');

--- a/test_integration/lib/test/realtime/realtime_publish_with_auth_callback_test.dart
+++ b/test_integration/lib/test/realtime/realtime_publish_with_auth_callback_test.dart
@@ -9,14 +9,16 @@ Future<Map<String, dynamic>> testRealtimePublishWithAuthCallback({
 }) async {
   var authCallbackInvoked = false;
   final realtime = Realtime(
-      options: ClientOptions()
-        ..logLevel = LogLevel.verbose
-        ..authCallback = ((params) async {
-          authCallbackInvoked = true;
-          return TokenRequest.fromMap(
-            await AppProvisioning().getTokenRequest(),
-          );
-        }));
+    options: ClientOptions(
+      logLevel: LogLevel.verbose,
+      authCallback: (params) async {
+        authCallbackInvoked = true;
+        return TokenRequest.fromMap(
+          await AppProvisioning().getTokenRequest(),
+        );
+      },
+    ),
+  );
   await publishMessages(realtime.channels.get('test'));
   await realtime.close();
 

--- a/test_integration/lib/test/realtime/realtime_subscribe.dart
+++ b/test_integration/lib/test/realtime/realtime_subscribe.dart
@@ -7,10 +7,12 @@ import 'package:ably_flutter_integration_test/utils/realtime.dart';
 
 Future<Realtime> _createRealtime(String apiKey) async {
   final realtime = Realtime(
-    options: ClientOptions.fromKey(apiKey)
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..autoConnect = false,
+    options: ClientOptions(
+      key: apiKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      autoConnect: false,
+    ),
   );
   await realtime.connect();
   return realtime;

--- a/test_integration/lib/test/realtime/realtime_time_test.dart
+++ b/test_integration/lib/test/realtime/realtime_time_test.dart
@@ -11,10 +11,12 @@ Future<Map<String, dynamic>> testRealtimeTime({
   final logMessages = <List<String?>>[];
 
   final realtime = Realtime(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   final realtimeTime = await realtime.time();

--- a/test_integration/lib/test/rest/rest_capability_test.dart
+++ b/test_integration/lib/test/rest/rest_capability_test.dart
@@ -20,10 +20,12 @@ Future<Map<String, dynamic>> testRestCapabilities({
       await AppProvisioning(keyCapabilities: capabilitySpec).provisionApp();
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   final matrix = <Map>[];

--- a/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
@@ -18,10 +18,12 @@ Future<Map<String, dynamic>> testRestEncryptedPublish({
   final channelOptions = RestChannelOptions(cipherParams: cipherParams);
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   final channel = rest.channels.get('test');
@@ -47,10 +49,12 @@ Future<Map<String, dynamic>> testRestEncryptedPublishSpec({
 
   // Rest instance where client id is specified in the instance itself
   final restWithClientId = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = clientId
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: clientId,
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   // Create encrypted channel with client ID

--- a/test_integration/lib/test/rest/rest_history_test.dart
+++ b/test_integration/lib/test/rest/rest_history_test.dart
@@ -13,10 +13,12 @@ Future<Map<String, dynamic>> testRestHistory({
   final appKey = await AppProvisioning().provisionApp();
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   final channel = rest.channels.get('test');
   await publishMessages(channel);

--- a/test_integration/lib/test/rest/rest_presence_get_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_get_test.dart
@@ -11,10 +11,12 @@ ClientOptions getClientOptions(
   String appKey, [
   String clientId = 'someClientId',
 ]) =>
-    ClientOptions.fromKey(appKey)
-      ..environment = 'sandbox'
-      ..clientId = clientId
-      ..logLevel = LogLevel.verbose;
+    ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: clientId,
+      logLevel: LogLevel.verbose,
+    );
 
 Future<Map<String, dynamic>> testRestPresenceGet({
   required Reporter reporter,

--- a/test_integration/lib/test/rest/rest_presence_history_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_history_test.dart
@@ -13,10 +13,12 @@ Future<Map<String, dynamic>> testRestPresenceHistory({
   final appKey = await AppProvisioning().provisionApp();
   final logMessages = <List<String?>>[];
 
-  final options = ClientOptions.fromKey(appKey.toString())
-    ..environment = 'sandbox'
-    ..clientId = 'someClientId'
-    ..logLevel = LogLevel.verbose;
+  final options = ClientOptions(
+    key: appKey,
+    environment: 'sandbox',
+    clientId: 'someClientId',
+    logLevel: LogLevel.verbose,
+  );
 
   final rest = Rest(options: options);
   final channel = rest.channels.get('test');

--- a/test_integration/lib/test/rest/rest_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_publish_test.dart
@@ -15,10 +15,12 @@ Future<Map<String, dynamic>> testRestPublish({
   final logMessages = <List<String?>>[];
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey.toString(),
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   await publishMessages(rest.channels.get('test'));
   return {
@@ -34,10 +36,12 @@ Future<Map<String, dynamic>> testRestPublishSpec({
   final appKey = await AppProvisioning().provisionApp();
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
   final channel = rest.channels.get('test');
   await channel.publish();
@@ -78,7 +82,10 @@ Future<Map<String, dynamic>> testRestPublishSpec({
 
   // client options - no client id, message has client id
   final rest2 = Rest(
-    options: ClientOptions.fromKey(appKey.toString())..environment = 'sandbox',
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+    ),
   );
 
   final channel2 = rest2.channels.get('test2');

--- a/test_integration/lib/test/rest/rest_publish_with_auth_callback_test.dart
+++ b/test_integration/lib/test/rest/rest_publish_with_auth_callback_test.dart
@@ -10,15 +10,17 @@ Future<Map<String, dynamic>> testRestPublishWithAuthCallback({
   reporter.reportLog('init start');
   var authCallbackInvoked = false;
   final rest = Rest(
-      options: ClientOptions()
-        ..clientId = 'someClientId'
-        ..logLevel = LogLevel.verbose
-        ..authCallback = ((params) async {
-          authCallbackInvoked = true;
-          return TokenRequest.fromMap(
-            await AppProvisioning().getTokenRequest(),
-          );
-        }));
+    options: ClientOptions(
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+      authCallback: (params) async {
+        authCallbackInvoked = true;
+        return TokenRequest.fromMap(
+          await AppProvisioning().getTokenRequest(),
+        );
+      },
+    ),
+  );
   await publishMessages(rest.channels.get('test'));
   return {
     'handle': await rest.handle,

--- a/test_integration/lib/test/rest/rest_time_test.dart
+++ b/test_integration/lib/test/rest/rest_time_test.dart
@@ -11,10 +11,12 @@ Future<Map<String, dynamic>> testRestTime({
   final logMessages = <List<String?>>[];
 
   final rest = Rest(
-    options: ClientOptions.fromKey(appKey.toString())
-      ..environment = 'sandbox'
-      ..clientId = 'someClientId'
-      ..logLevel = LogLevel.verbose,
+    options: ClientOptions(
+      key: appKey,
+      environment: 'sandbox',
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+    ),
   );
 
   final restTime = await rest.time();


### PR DESCRIPTION
This is a part of #61, including changes only for `ClientOptions` and `AuthOptions`, without moving the fields as private. Main changes:
* Updated constructor of `AuthOptions` and `ClientOptions` to use named parameters
* Deprecated `fromKey` methods, since the object can be now created with constructor invocation
* Refactored all places where `ClientOptions` was created with public parameter setters 

Although this PR is fairly large, most of the changes were done in integration testing, and none of the changes are breaking in any way - users should be able to migrate without any issues. Moving the variables as private is a breaking change, so I decided to implement this later, in a separate PR, to give users some more time to adopt these changes before we deprecate the public fields 