### PR TITLE
Named parameters and immutable fields for token classes

### DIFF
--- a/UPDATING.md
+++ b/UPDATING.md
@@ -2,6 +2,10 @@
 
 This guide lists the changes needed to upgrade from one version of Ably to a newer one when there are breaking changes.
 
+## [Upgrading from v1.2.12]
+
+- `TokenDetails`, `TokenParams` and `TokenRequest` classes are now immutable, parameters have to be passed through constructor
+
 ## [Upgrading from v1.2.8]
 
 Changes made at v1.2.9:

--- a/lib/src/authentication/src/token_details.dart
+++ b/lib/src/authentication/src/token_details.dart
@@ -1,24 +1,27 @@
+import 'package:flutter/material.dart';
+
 /// Response to a `requestToken` request
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TD1
+@immutable
 class TokenDetails {
   /// https://docs.ably.com/client-lib-development-guide/features/#TD2
-  String? token;
+  final String? token;
 
   /// Token expiry time in milliseconds
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD3
-  int? expires;
+  final int? expires;
 
   /// the time the token was issued in milliseconds
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD4
-  int? issued;
+  final int? issued;
 
   /// stringified capabilities JSON
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD5
-  String? capability;
+  final String? capability;
 
   /// Client ID assigned to the token.
   ///
@@ -29,10 +32,10 @@ class TokenDetails {
   /// clientId is both enforced and assumed for all operations for this token
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD6
-  String? clientId;
+  final String? clientId;
 
   /// instantiates a [TokenDetails] with provided values
-  TokenDetails(
+  const TokenDetails(
     this.token, {
     this.expires,
     this.issued,
@@ -43,11 +46,10 @@ class TokenDetails {
   /// Creates an instance from the map
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD7
-  TokenDetails.fromMap(Map<String, dynamic> map) {
-    token = map['token'] as String?;
-    expires = map['expires'] as int?;
-    issued = map['issued'] as int?;
-    capability = map['capability'] as String?;
-    clientId = map['clientId'] as String?;
-  }
+  TokenDetails.fromMap(Map<String, dynamic> map)
+      : token = map['token'] as String?,
+        expires = map['expires'] as int?,
+        issued = map['issued'] as int?,
+        capability = map['capability'] as String?,
+        clientId = map['clientId'] as String?;
 }

--- a/lib/src/authentication/src/token_params.dart
+++ b/lib/src/authentication/src/token_params.dart
@@ -1,4 +1,5 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:flutter/cupertino.dart';
 
 /// A class providing parameters of a token request.
 ///
@@ -8,6 +9,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 /// accept an instance of TokenParams as a parameter
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TK1
+@immutable
 class TokenParams {
   /// Capability of the token.
   ///
@@ -16,14 +18,14 @@ class TokenParams {
   /// with the capability of the issuing key.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TK2b
-  String? capability;
+  final String? capability;
 
   /// A clientId to associate with this token.
   ///
   /// The generated token may be used to authenticate as this clientId.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TK2c
-  String? clientId;
+  final String? clientId;
 
   /// An opaque nonce string of at least 16 characters to ensure uniqueness.
   ///
@@ -31,7 +33,7 @@ class TokenParams {
   /// are used to prevent requests from being replayed
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TK2d
-  String? nonce;
+  final String? nonce;
 
   /// The timestamp (in millis since the epoch) of this request.
   ///
@@ -39,7 +41,7 @@ class TokenParams {
   ///	token requests from being replayed.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TK2d
-  DateTime? timestamp;
+  final DateTime? timestamp;
 
   /// Requested time to live for the token.
   ///
@@ -50,10 +52,10 @@ class TokenParams {
   /// 0 means Ably will set it to the default value
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TK2a
-  int? ttl;
+  final int? ttl;
 
   /// instantiates a [TokenParams] with provided values
-  TokenParams({
+  const TokenParams({
     this.capability,
     this.clientId,
     this.nonce,

--- a/lib/src/authentication/src/token_request.dart
+++ b/lib/src/authentication/src/token_request.dart
@@ -1,4 +1,7 @@
+import 'package:flutter/foundation.dart';
+
 /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE1
+@immutable
 class TokenRequest {
   /// [keyName] is the first part of Ably API Key.
   ///
@@ -7,7 +10,7 @@ class TokenRequest {
   ///
   /// More details about Ably API Key:
   /// https://docs.ably.com/client-lib-development-guide/features/#RSA11
-  String? keyName;
+  final String? keyName;
 
   /// An opaque nonce string of at least 16 characters to ensure
   ///	uniqueness of this request. Any subsequent request using the
@@ -16,39 +19,39 @@ class TokenRequest {
   /// spec:
   /// https://docs.ably.com/client-lib-development-guide/features/#TE2
   /// https://docs.ably.com/client-lib-development-guide/features/#TE5
-  String? nonce;
+  final String? nonce;
 
   /// The "Message Authentication Code" for this request.
   ///
   /// See the Ably Authentication documentation for more details.
   /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE2
-  String? mac;
+  final String? mac;
 
   /// stringified capabilities JSON
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TE3
-  String? capability;
+  final String? capability;
 
   ///  Client ID assigned to the tokenRequest.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TE2
-  String? clientId;
+  final String? clientId;
 
   /// timestamp long – The timestamp (in milliseconds since the epoch)
   /// of this request. Timestamps, in conjunction with the nonce,
   /// are used to prevent requests from being replayed
   ///
   /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE5
-  DateTime? timestamp;
+  final DateTime? timestamp;
 
   /// ttl attribute represents time to live (expiry)
   /// of this token in milliseconds
   ///
   /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE4
-  int? ttl;
+  final int? ttl;
 
   /// instantiates a [TokenRequest] with provided values
-  TokenRequest({
+  const TokenRequest({
     this.keyName,
     this.nonce,
     this.clientId,
@@ -59,14 +62,13 @@ class TokenRequest {
   });
 
   /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE7
-  TokenRequest.fromMap(Map<String, dynamic> map) {
-    keyName = map['keyName'] as String?;
-    nonce = map['nonce'] as String?;
-    mac = map['mac'] as String?;
-    capability = map['capability'] as String?;
-    clientId = map['clientId'] as String?;
-    timestamp = DateTime.fromMillisecondsSinceEpoch(map['timestamp'] as int);
-    final ttl = map['ttl'] as int?;
-    if (ttl != null) this.ttl = ttl;
-  }
+  TokenRequest.fromMap(Map<String, dynamic> map)
+      : keyName = map['keyName'] as String?,
+        nonce = map['nonce'] as String?,
+        mac = map['mac'] as String?,
+        capability = map['capability'] as String?,
+        clientId = map['clientId'] as String?,
+        timestamp =
+            DateTime.fromMillisecondsSinceEpoch(map['timestamp'] as int),
+        ttl = map['ttl'] as int?;
 }

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -637,24 +637,27 @@ class Codec extends StandardMessageCodec {
   /// Decodes value [jsonMap] to [TokenDetails]
   /// returns null if [jsonMap] is null
   TokenDetails _decodeTokenDetails(Map<String, dynamic> jsonMap) =>
-      TokenDetails(_readFromJson<String>(jsonMap, TxTokenDetails.token))
-        ..expires = _readFromJson<int>(jsonMap, TxTokenDetails.expires)
-        ..issued = _readFromJson<int>(jsonMap, TxTokenDetails.issued)
-        ..capability = _readFromJson<String>(jsonMap, TxTokenDetails.capability)
-        ..clientId = _readFromJson<String>(jsonMap, TxTokenDetails.clientId);
+      TokenDetails(
+        _readFromJson<String>(jsonMap, TxTokenDetails.token),
+        expires: _readFromJson<int>(jsonMap, TxTokenDetails.expires),
+        issued: _readFromJson<int>(jsonMap, TxTokenDetails.issued),
+        capability: _readFromJson<String>(jsonMap, TxTokenDetails.capability),
+        clientId: _readFromJson<String>(jsonMap, TxTokenDetails.clientId),
+      );
 
   /// Decodes value [jsonMap] to [TokenParams]
   /// returns null if [jsonMap] is null
   TokenParams _decodeTokenParams(Map<String, dynamic> jsonMap) {
     final timestamp = _readFromJson<int>(jsonMap, TxTokenParams.timestamp);
-    final params = TokenParams()
-      ..capability = _readFromJson<String>(jsonMap, TxTokenParams.capability)
-      ..clientId = _readFromJson<String>(jsonMap, TxTokenParams.clientId)
-      ..nonce = _readFromJson<String>(jsonMap, TxTokenParams.nonce)
-      ..timestamp = (timestamp != null)
+    final params = TokenParams(
+      capability: _readFromJson<String>(jsonMap, TxTokenParams.capability),
+      clientId: _readFromJson<String>(jsonMap, TxTokenParams.clientId),
+      nonce: _readFromJson<String>(jsonMap, TxTokenParams.nonce),
+      timestamp: (timestamp != null)
           ? DateTime.fromMillisecondsSinceEpoch(timestamp)
-          : null
-      ..ttl = _readFromJson<int>(jsonMap, TxTokenParams.ttl);
+          : null,
+      ttl: _readFromJson<int>(jsonMap, TxTokenParams.ttl),
+    );
     return params;
   }
 


### PR DESCRIPTION
This is another part of https://github.com/ably/ably-flutter/issues/61, continuing work from #348, but this time in scope of token-related classes instead of client options. Main changes include:

* `Codec` class was updated to use constructors instead of public fields for `TokenDetails` and `TokenParams`
* `TokenDetails`, `TokenParams` and `TokenRequest` classes were made `@immutable`, and their public fields `final`. This pattern is already present in some files in the codebase and I think for classes like this it may be the best approach - after the object is created, it can't be changed by reassigning the public fields.
* The changes to public fields are breaking changes, but I don't think they will have a large impact, because constructors for these classes were added quite a while ago and they aren't used too often, so I don't think migration may be a problem here. I've included the information in UPDATING file