### PR TITLE
Named parameters and immutable fields for realtime classes

### DIFF
--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -1034,8 +1034,13 @@ class Codec extends StandardMessageCodec {
     final errorInfo =
         toJsonMap(_readFromJson<Map>(jsonMap, TxChannelStateChange.reason));
     final reason = (errorInfo == null) ? null : _decodeErrorInfo(errorInfo);
-    return ChannelStateChange(current, previous, event,
-        resumed: resumed, reason: reason);
+    return ChannelStateChange(
+      current: current,
+      previous: previous,
+      event: event,
+      resumed: resumed,
+      reason: reason,
+    );
   }
 
   /// Decodes value [jsonMap] to [MessageData]

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -1013,9 +1013,9 @@ class Codec extends StandardMessageCodec {
         toJsonMap(_readFromJson<Map>(jsonMap, TxConnectionStateChange.reason));
     final reason = (errorInfo == null) ? null : _decodeErrorInfo(errorInfo);
     return ConnectionStateChange(
-      current,
-      previous,
-      event,
+      current: current,
+      previous: previous,
+      event: event,
       retryIn: retryIn,
       reason: reason,
     );

--- a/lib/src/realtime/src/channel_state_event.dart
+++ b/lib/src/realtime/src/channel_state_event.dart
@@ -1,9 +1,11 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:meta/meta.dart';
 
 /// Whenever the channel state changes, a ChannelStateChange object
 /// is emitted on the Channel object
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TH1
+@immutable
 class ChannelStateChange {
   /// the event that generated the channel state change
   ///
@@ -27,16 +29,16 @@ class ChannelStateChange {
   /// object describing the reason for the error
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TH3
-  ErrorInfo? reason;
+  final ErrorInfo? reason;
 
   /// https://docs.ably.com/client-lib-development-guide/features/#TH4
   final bool resumed;
 
   /// initializes with [resumed] set to false
-  ChannelStateChange(
-    this.current,
-    this.previous,
-    this.event, {
+  const ChannelStateChange({
+    required this.current,
+    required this.previous,
+    required this.event,
     this.reason,
     this.resumed = false,
   });

--- a/lib/src/realtime/src/connection_state_change.dart
+++ b/lib/src/realtime/src/connection_state_change.dart
@@ -1,9 +1,11 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:meta/meta.dart';
 
 /// Whenever the connection state changes,
 /// a ConnectionStateChange object is emitted on the [Connection] object
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TA1
+@immutable
 class ConnectionStateChange {
   /// https://docs.ably.com/client-lib-development-guide/features/#TA2
   final ConnectionEvent event;
@@ -25,20 +27,20 @@ class ConnectionStateChange {
   /// object describing the reason for the error
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TA3
-  ErrorInfo? reason;
+  final ErrorInfo? reason;
 
   /// when the client is not connected, a connection attempt will be made
   /// automatically by the library after the number of milliseconds
   /// specified by [retryIn]
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TA2
-  int? retryIn;
+  final int? retryIn;
 
   /// initializes without any defaults
-  ConnectionStateChange(
-    this.current,
-    this.previous,
-    this.event, {
+  const ConnectionStateChange({
+    required this.current,
+    required this.previous,
+    required this.event,
     this.reason,
     this.retryIn,
   });

--- a/lib/src/realtime/src/realtime_channel_options.dart
+++ b/lib/src/realtime/src/realtime_channel_options.dart
@@ -1,8 +1,10 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:flutter/cupertino.dart';
 
 /// Configuration options for a [RealtimeChannel]
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#TB1
+@immutable
 class RealtimeChannelOptions {
   /// https://docs.ably.com/client-lib-development-guide/features/#TB2b
   final CipherParams? cipherParams;
@@ -27,5 +29,9 @@ class RealtimeChannelOptions {
   /// If a [cipherParams] is set, messages will be encrypted with the cipher.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TB2
-  RealtimeChannelOptions({this.params, this.modes, this.cipherParams});
+  const RealtimeChannelOptions({
+    this.params,
+    this.modes,
+    this.cipherParams,
+  });
 }

--- a/lib/src/realtime/src/realtime_history_params.dart
+++ b/lib/src/realtime/src/realtime_history_params.dart
@@ -1,6 +1,9 @@
+import 'package:flutter/cupertino.dart';
+
 /// Params for realtime history
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#RTL10
+@immutable
 class RealtimeHistoryParams {
   /// [start] must be equal to or less than end and is unaffected
   /// by the request direction
@@ -39,7 +42,7 @@ class RealtimeHistoryParams {
   /// was attached or emitted an UPDATE indicating loss of continuity.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RTL10b
-  bool? untilAttach;
+  final bool? untilAttach;
 
   /// instantiates with [direction] set to "backwards", [limit] to 100
   /// [start] to epoch and end to current time

--- a/lib/src/realtime/src/realtime_presence_params.dart
+++ b/lib/src/realtime/src/realtime_presence_params.dart
@@ -1,8 +1,10 @@
 import 'package:ably_flutter/ably_flutter.dart';
+import 'package:flutter/cupertino.dart';
 
 /// Params used as a filter for querying presence on a channel
 ///
 /// https://docs.ably.com/client-lib-development-guide/features/#RTP11c
+@immutable
 class RealtimePresenceParams {
   /// When true, [RealtimePresence.get] will wait until SYNC is complete
   /// before returning a list of members
@@ -21,7 +23,7 @@ class RealtimePresenceParams {
   final String? connectionId;
 
   /// initializes with [waitForSync] set to true by default
-  RealtimePresenceParams({
+  const RealtimePresenceParams({
     this.waitForSync = true,
     this.clientId,
     this.connectionId,


### PR DESCRIPTION
I'm continuing my journey trough #61, this time for all `realtime` components. This time changes include:

* Making realtime classes `@immutable` for all classes that do not require mutability
* Making fields in realtime classes `final` and `const` where possible
* Unifying realtime constructors with the rest of SDK, by making them use named parameters with `required` annotations

These changes are non-breaking, since all components with altered with breaking changes are only used internally, so no user action is needed to migrate