### PR TITLE
Experimental method to reset push device on Android

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -682,7 +682,6 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
       Integer handle = (Integer) message.message;
       instanceStore.getPush(handle)
               .getActivationContext()
-              .getActivationStateMachine()
               .reset();
     } catch (AblyException e) {
       handleAblyException(result, e);

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -94,6 +94,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     // Push Notifications
     _map.put(PlatformConstants.PlatformMethod.pushActivate, this::pushActivate);
     _map.put(PlatformConstants.PlatformMethod.pushDeactivate, this::pushDeactivate);
+    _map.put(PlatformConstants.PlatformMethod.pushReset, this::pushReset);
     _map.put(PlatformConstants.PlatformMethod.pushSubscribeDevice, this::pushSubscribeDevice);
     _map.put(PlatformConstants.PlatformMethod.pushUnsubscribeDevice, this::pushUnsubscribeDevice);
     _map.put(PlatformConstants.PlatformMethod.pushSubscribeClient, this::pushSubscribeClient);
@@ -670,6 +671,19 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
       Integer handle = (Integer) message.message;
       PushActivationEventHandlers.getInstance().setResultForDeactivate(result);
       instanceStore.getPush(handle).deactivate();
+    } catch (AblyException e) {
+      handleAblyException(result, e);
+    }
+  }
+
+  private void pushReset(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
+    final AblyFlutterMessage message = (AblyFlutterMessage) call.arguments;
+    try {
+      Integer handle = (Integer) message.message;
+      instanceStore.getPush(handle)
+              .getActivationContext()
+              .getActivationStateMachine()
+              .reset();
     } catch (AblyException e) {
       handleAblyException(result, e);
     }

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -70,6 +70,7 @@ final public class PlatformConstants {
         public static final String restTime = "restTime";
         public static final String pushActivate = "pushActivate";
         public static final String pushDeactivate = "pushDeactivate";
+        public static final String pushReset = "pushReset";
         public static final String pushSubscribeDevice = "pushSubscribeDevice";
         public static final String pushUnsubscribeDevice = "pushUnsubscribeDevice";
         public static final String pushSubscribeClient = "pushSubscribeClient";

--- a/bin/codegen_context.dart
+++ b/bin/codegen_context.dart
@@ -100,6 +100,7 @@ const List<Map<String, dynamic>> _platformMethods = [
   // Push Notifications
   {'name': 'pushActivate', 'value': 'pushActivate'},
   {'name': 'pushDeactivate', 'value': 'pushDeactivate'},
+  {'name': 'pushReset', 'value': 'pushReset'},
   {'name': 'pushSubscribeDevice', 'value': 'pushSubscribeDevice'},
   {'name': 'pushUnsubscribeDevice', 'value': 'pushUnsubscribeDevice'},
   {'name': 'pushSubscribeClient', 'value': 'pushSubscribeClient'},

--- a/example/lib/push_notifications/push_notification_service.dart
+++ b/example/lib/push_notifications/push_notification_service.dart
@@ -104,6 +104,8 @@ class PushNotificationService {
 
   Future<void> deactivateDevice() => getPushFromAblyClient().deactivate();
 
+  Future<void> resetActivation() => getPushFromAblyClient().reset();
+
   Future<void> getDevice() async {
     if (useRealtimeClient) {
       final localDevice = await _realtime.device();

--- a/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
@@ -51,6 +51,15 @@ class PushNotificationsActivationSliver extends HookWidget {
     await _pushNotificationService.getDevice();
   }
 
+  Future<void> handleResetDeviceButton(BuildContext context) async {
+    try {
+      await _pushNotificationService.resetActivation();
+    } on ably.AblyException catch (error) {
+      await showErrorDialog(context, error);
+    }
+    await _pushNotificationService.getDevice();
+  }
+
   Widget buildiOSSimulatorWarningText(bool isIOSSimulator) {
     if (isIOSSimulator) {
       return Padding(
@@ -107,6 +116,12 @@ class PushNotificationsActivationSliver extends HookWidget {
                     onPressed: () => handleDeactivateDeviceButton(context),
                     child: const Text('Deactivate device')),
               ),
+              Expanded(
+                child: BoolStreamButton(
+                    stream: _pushNotificationService.hasPushChannelStream,
+                    onPressed: () => handleResetDeviceButton(context),
+                    child: const Text('Reset activation')),
+              )
             ],
           ),
           const Text('Once devices are activated, a Push Admin can '

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -68,6 +68,7 @@ extern NSString *const AblyPlatformMethod_realtimeTime;
 extern NSString *const AblyPlatformMethod_restTime;
 extern NSString *const AblyPlatformMethod_pushActivate;
 extern NSString *const AblyPlatformMethod_pushDeactivate;
+extern NSString *const AblyPlatformMethod_pushReset;
 extern NSString *const AblyPlatformMethod_pushSubscribeDevice;
 extern NSString *const AblyPlatformMethod_pushUnsubscribeDevice;
 extern NSString *const AblyPlatformMethod_pushSubscribeClient;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -38,6 +38,7 @@ NSString *const AblyPlatformMethod_realtimeTime= @"realtimeTime";
 NSString *const AblyPlatformMethod_restTime= @"restTime";
 NSString *const AblyPlatformMethod_pushActivate= @"pushActivate";
 NSString *const AblyPlatformMethod_pushDeactivate= @"pushDeactivate";
+NSString *const AblyPlatformMethod_pushReset= @"pushReset";
 NSString *const AblyPlatformMethod_pushSubscribeDevice= @"pushSubscribeDevice";
 NSString *const AblyPlatformMethod_pushUnsubscribeDevice= @"pushUnsubscribeDevice";
 NSString *const AblyPlatformMethod_pushSubscribeClient= @"pushSubscribeClient";

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -384,7 +384,8 @@ class TxPushRequestPermission {
   static const String alert = 'alert';
   static const String carPlay = 'carPlay';
   static const String criticalAlert = 'criticalAlert';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String provisional = 'provisional';
   static const String announcement = 'announcement';
 }
@@ -400,7 +401,8 @@ class TxUNNotificationSettings {
   static const String alertStyle = 'alertStyle';
   static const String showPreviewsSetting = 'showPreviewsSetting';
   static const String criticalAlertSetting = 'criticalAlertSetting';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String announcementSetting = 'announcementSetting';
   static const String scheduledDeliverySetting = 'scheduledDeliverySetting';
   static const String timeSensitiveSetting = 'timeSensitiveSetting';

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -68,6 +68,7 @@ class PlatformMethod {
   static const String restTime = 'restTime';
   static const String pushActivate = 'pushActivate';
   static const String pushDeactivate = 'pushDeactivate';
+  static const String pushReset = 'pushReset';
   static const String pushSubscribeDevice = 'pushSubscribeDevice';
   static const String pushUnsubscribeDevice = 'pushUnsubscribeDevice';
   static const String pushSubscribeClient = 'pushSubscribeClient';
@@ -383,8 +384,7 @@ class TxPushRequestPermission {
   static const String alert = 'alert';
   static const String carPlay = 'carPlay';
   static const String criticalAlert = 'criticalAlert';
-  static const String providesAppNotificationSettings =
-      'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
   static const String provisional = 'provisional';
   static const String announcement = 'announcement';
 }
@@ -400,8 +400,7 @@ class TxUNNotificationSettings {
   static const String alertStyle = 'alertStyle';
   static const String showPreviewsSetting = 'showPreviewsSetting';
   static const String criticalAlertSetting = 'criticalAlertSetting';
-  static const String providesAppNotificationSettings =
-      'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
   static const String announcementSetting = 'announcementSetting';
   static const String scheduledDeliverySetting = 'scheduledDeliverySetting';
   static const String timeSensitiveSetting = 'timeSensitiveSetting';

--- a/lib/src/push_notifications/src/push.dart
+++ b/lib/src/push_notifications/src/push.dart
@@ -1,5 +1,4 @@
 import 'dart:io' as io show Platform;
-
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
 import 'package:meta/meta.dart';
@@ -125,13 +124,21 @@ class Push extends PlatformObject {
   /// https://docs.ably.com/client-lib-development-guide/features/#RSH2b
   Future<void> deactivate() => invoke(PlatformMethod.pushDeactivate);
 
-  /// Resets activation state of push device by removing device data from
-  /// Android / iOS native storage solutions
+  /// Resets activation state of Android push device by removing
+  /// device data from Android SharedPreferences. After this operation, device
+  /// is recognized as a completely new push device and all device data
+  /// has to be regenerated with [Push.activate] call
   ///
   /// Warning: This is an experimental method and it's use can lead to
-  /// unexpected behavior in Push
+  /// unexpected behavior in Push module
   @experimental
-  Future<void> reset() => invoke(PlatformMethod.pushReset);
+  Future<void> reset() {
+    if (io.Platform.isAndroid) {
+      return invoke(PlatformMethod.pushReset);
+    } else {
+      return Future.value(null);
+    }
+  }
 
   @override
   Future<int?> createPlatformInstance() => (realtime != null)

--- a/lib/src/push_notifications/src/push.dart
+++ b/lib/src/push_notifications/src/push.dart
@@ -2,6 +2,7 @@ import 'dart:io' as io show Platform;
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
+import 'package:meta/meta.dart';
 
 /// Class providing push notification functionality
 ///
@@ -123,6 +124,14 @@ class Push extends PlatformObject {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RSH2b
   Future<void> deactivate() => invoke(PlatformMethod.pushDeactivate);
+
+  /// Resets activation state of push device by removing device data from
+  /// Android / iOS native storage solutions
+  ///
+  /// Warning: This is an experimental method and it's use can lead to
+  /// unexpected behavior in Push
+  @experimental
+  Future<void> reset() => invoke(PlatformMethod.pushReset);
 
   @override
   Future<int?> createPlatformInstance() => (realtime != null)


### PR DESCRIPTION
This PR adds an experimental method `Push.reset()` that clears the state of `ActivationStateMachine` for Push Notifications. This method can be used to solve some issues with activating push devices in Ably service, but since it's an experimental solution it shouldn't be used without a good reason.

Internally, the `reset()` method call clears `SharedPreference` storage and restores `ActivationStateMachine` to its initial state, removing all local device data and making it possible to perform a clean activation of device.