### PR TITLE
Updated Android message codec to use long values for TokenDetails

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -351,8 +351,8 @@ public class AblyMessageCodec extends StandardMessageCodec {
     if (jsonMap == null) return null;
     final TokenDetails o = new TokenDetails();
     readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.token, v -> o.token = (String) v);
-    readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.expires, v -> o.expires = (int) v);
-    readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.issued, v -> o.issued = (int) v);
+    readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.expires, v -> o.expires = (long) v);
+    readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.issued, v -> o.issued = (long) v);
     readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.capability, v -> o.capability = (String) v);
     readValueFromJson(jsonMap, PlatformConstants.TxTokenDetails.clientId, v -> o.clientId = (String) v);
 


### PR DESCRIPTION
This should resolved #356. I'm not sure why those values were cast to `int` in the first place, since `TokenDetails` in `ably-java` uses `long` internally for storing them, but I think this should resolve the issue