### PR TITLE
Sorted parameters for named constructors

### DIFF
--- a/example/lib/push_notifications/push_notification_handlers.dart
+++ b/example/lib/push_notifications/push_notification_handlers.dart
@@ -1,5 +1,4 @@
 import 'package:ably_flutter/ably_flutter.dart' as ably;
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:rxdart/rxdart.dart';
 

--- a/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
@@ -6,7 +6,6 @@ import 'package:ably_flutter_example/ui/bool_stream_button.dart';
 import 'package:device_info_plus/device_info_plus.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 

--- a/example/lib/ui/push_notifications/push_notifications_device_information.dart
+++ b/example/lib/ui/push_notifications/push_notifications_device_information.dart
@@ -1,7 +1,6 @@
 import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/push_notifications/push_notification_service.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class PushNotificationsDeviceInformation extends StatelessWidget {

--- a/example/lib/ui/push_notifications/push_notifications_ios_permissions_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_ios_permissions_sliver.dart
@@ -4,7 +4,6 @@ import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/push_notifications/push_notification_service.dart';
 import 'package:ably_flutter_example/ui/bool_stream_button.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
 

--- a/example/lib/ui/rest_sliver.dart
+++ b/example/lib/ui/rest_sliver.dart
@@ -3,7 +3,6 @@ import 'package:ably_flutter_example/constants.dart';
 import 'package:ably_flutter_example/ui/paginated_result_viewer.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
 import 'package:ably_flutter_example/ui/utilities.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -2,7 +2,6 @@ import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/constants.dart';
 import 'package:ably_flutter_example/ui/api_key_service.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';

--- a/lib/src/authentication/src/auth.dart
+++ b/lib/src/authentication/src/auth.dart
@@ -18,8 +18,8 @@ abstract class Auth {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RSA10
   Future<TokenDetails> authorize({
-    TokenParams? tokenParams,
     AuthOptions? authOptions,
+    TokenParams? tokenParams,
   });
 
   /// Returns a signed TokenRequest object that can be used to obtain
@@ -27,8 +27,8 @@ abstract class Auth {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RSA9
   Future<TokenRequest> createTokenRequest({
-    TokenParams? tokenParams,
     AuthOptions? authOptions,
+    TokenParams? tokenParams,
   });
 
   /// Implicitly creates a TokenRequest if required and requests a token
@@ -36,7 +36,7 @@ abstract class Auth {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RSA8
   Future<TokenDetails> requestToken({
-    TokenParams? tokenParams,
     AuthOptions? authOptions,
+    TokenParams? tokenParams,
   });
 }

--- a/lib/src/authentication/src/auth_options.dart
+++ b/lib/src/authentication/src/auth_options.dart
@@ -73,13 +73,13 @@ abstract class AuthOptions {
   /// Initializes an instance without any defaults
   AuthOptions({
     this.authCallback,
-    this.authUrl,
-    this.authMethod,
-    this.key,
-    this.tokenDetails,
     this.authHeaders,
+    this.authMethod,
     this.authParams,
+    this.authUrl,
+    this.key,
     this.queryTime,
+    this.tokenDetails,
     this.useTokenAuth,
   }) {
     if (key != null && !key!.contains(':')) {

--- a/lib/src/authentication/src/client_options.dart
+++ b/lib/src/authentication/src/client_options.dart
@@ -190,41 +190,41 @@ class ClientOptions extends AuthOptions {
   /// Initializes an instance with defaults
   ClientOptions({
     AuthCallback? authCallback,
-    String? authUrl,
-    String? authMethod,
-    String? key,
-    TokenDetails? tokenDetails,
     Map<String, String>? authHeaders,
+    String? authMethod,
     Map<String, String>? authParams,
-    bool? queryTime,
-    bool? useTokenAuth,
-    this.clientId,
-    this.logHandler,
-    LogLevel? logLevel,
-    this.restHost,
-    this.realtimeHost,
-    this.port,
-    bool? tls,
-    this.tlsPort,
+    String? authUrl,
     bool? autoConnect,
-    bool? useBinaryProtocol,
-    bool? queueMessages,
-    bool? echoMessages,
-    this.recover,
-    this.environment,
-    this.fallbackHosts,
-    this.fallbackHostsUseDefault,
+    int? channelRetryTimeout,
+    this.clientId,
     this.defaultTokenParams,
     int? disconnectedRetryTimeout,
-    int? suspendedRetryTimeout,
-    this.idempotentRestPublishing,
-    this.transportParams,
+    bool? echoMessages,
+    this.environment,
+    this.fallbackHosts,
+    int? fallbackRetryTimeout,
+    this.fallbackHostsUseDefault,
+    int? httpMaxRetryCount,
     int? httpOpenTimeout,
     int? httpRequestTimeout,
-    int? httpMaxRetryCount,
+    this.idempotentRestPublishing,
+    String? key,
+    this.logHandler,
+    LogLevel? logLevel,
+    this.port,
+    bool? queryTime,
+    bool? queueMessages,
+    this.realtimeHost,
     this.realtimeRequestTimeout,
-    int? fallbackRetryTimeout,
-    int? channelRetryTimeout,
+    this.recover,
+    this.restHost,
+    int? suspendedRetryTimeout,
+    bool? tls,
+    this.tlsPort,
+    this.transportParams,
+    TokenDetails? tokenDetails,
+    bool? useBinaryProtocol,
+    bool? useTokenAuth,
   }) : super(
           authCallback: authCallback,
           authUrl: authUrl,
@@ -239,22 +239,22 @@ class ClientOptions extends AuthOptions {
     /// These default value assignments are only required until
     /// [ClientOptions.fromKey] is removed, because then defaults can be set
     /// directly in the constructor invocation
-    this.logLevel = logLevel ?? this.logLevel;
-    this.tls = tls ?? this.tls;
     this.autoConnect = autoConnect ?? this.autoConnect;
-    this.useBinaryProtocol = useBinaryProtocol ?? this.useBinaryProtocol;
-    this.queueMessages = queueMessages ?? this.queueMessages;
-    this.echoMessages = echoMessages ?? this.echoMessages;
+    this.channelRetryTimeout = channelRetryTimeout ?? this.channelRetryTimeout;
     this.disconnectedRetryTimeout =
         disconnectedRetryTimeout ?? this.disconnectedRetryTimeout;
-    this.suspendedRetryTimeout =
-        suspendedRetryTimeout ?? this.suspendedRetryTimeout;
-    this.httpOpenTimeout = httpOpenTimeout ?? this.httpOpenTimeout;
-    this.httpRequestTimeout = httpRequestTimeout ?? this.httpRequestTimeout;
-    this.httpMaxRetryCount = httpMaxRetryCount ?? this.httpMaxRetryCount;
+    this.echoMessages = echoMessages ?? this.echoMessages;
     this.fallbackRetryTimeout =
         fallbackRetryTimeout ?? this.fallbackRetryTimeout;
-    this.channelRetryTimeout = channelRetryTimeout ?? this.channelRetryTimeout;
+    this.httpMaxRetryCount = httpMaxRetryCount ?? this.httpMaxRetryCount;
+    this.httpOpenTimeout = httpOpenTimeout ?? this.httpOpenTimeout;
+    this.httpRequestTimeout = httpRequestTimeout ?? this.httpRequestTimeout;
+    this.logLevel = logLevel ?? this.logLevel;
+    this.queueMessages = queueMessages ?? this.queueMessages;
+    this.suspendedRetryTimeout =
+        suspendedRetryTimeout ?? this.suspendedRetryTimeout;
+    this.tls = tls ?? this.tls;
+    this.useBinaryProtocol = useBinaryProtocol ?? this.useBinaryProtocol;
   }
 
   /// initializes [ClientOptions] with a key and log level set to info

--- a/lib/src/authentication/src/token_details.dart
+++ b/lib/src/authentication/src/token_details.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:meta/meta.dart';
 
 /// Response to a `requestToken` request
 ///

--- a/lib/src/authentication/src/token_details.dart
+++ b/lib/src/authentication/src/token_details.dart
@@ -37,19 +37,19 @@ class TokenDetails {
   /// instantiates a [TokenDetails] with provided values
   const TokenDetails(
     this.token, {
-    this.expires,
-    this.issued,
     this.capability,
     this.clientId,
+    this.expires,
+    this.issued,
   });
 
   /// Creates an instance from the map
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TD7
   TokenDetails.fromMap(Map<String, dynamic> map)
-      : token = map['token'] as String?,
+      : capability = map['capability'] as String?,
+        clientId = map['clientId'] as String?,
         expires = map['expires'] as int?,
         issued = map['issued'] as int?,
-        capability = map['capability'] as String?,
-        clientId = map['clientId'] as String?;
+        token = map['token'] as String?;
 }

--- a/lib/src/authentication/src/token_params.dart
+++ b/lib/src/authentication/src/token_params.dart
@@ -1,5 +1,5 @@
 import 'package:ably_flutter/ably_flutter.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 
 /// A class providing parameters of a token request.
 ///

--- a/lib/src/authentication/src/token_request.dart
+++ b/lib/src/authentication/src/token_request.dart
@@ -52,23 +52,23 @@ class TokenRequest {
 
   /// instantiates a [TokenRequest] with provided values
   const TokenRequest({
-    this.keyName,
-    this.nonce,
-    this.clientId,
-    this.mac,
     this.capability,
+    this.clientId,
+    this.keyName,
+    this.mac,
+    this.nonce,
     this.timestamp,
     this.ttl,
   });
 
   /// spec: https://docs.ably.com/client-lib-development-guide/features/#TE7
   TokenRequest.fromMap(Map<String, dynamic> map)
-      : keyName = map['keyName'] as String?,
-        nonce = map['nonce'] as String?,
-        mac = map['mac'] as String?,
-        capability = map['capability'] as String?,
+      : capability = map['capability'] as String?,
         clientId = map['clientId'] as String?,
+        mac = map['mac'] as String?,
+        nonce = map['nonce'] as String?,
         timestamp =
             DateTime.fromMillisecondsSinceEpoch(map['timestamp'] as int),
-        ttl = map['ttl'] as int?;
+        ttl = map['ttl'] as int?,
+        keyName = map['keyName'] as String?;
 }

--- a/lib/src/error/src/ably_exception.dart
+++ b/lib/src/error/src/ably_exception.dart
@@ -19,15 +19,15 @@ class AblyException implements Exception {
   /// initializes with no defaults
   AblyException({
     this.code,
-    this.message,
     this.errorInfo,
+    this.message,
   });
 
   /// create AblyException from [PlatformException]
   AblyException.fromPlatformException(PlatformException exception)
       : code = exception.code,
-        message = exception.message,
-        errorInfo = exception.details as ErrorInfo?;
+        errorInfo = exception.details as ErrorInfo?,
+        message = exception.message;
 
   @override
   String toString() {

--- a/lib/src/error/src/error_info.dart
+++ b/lib/src/error/src/error_info.dart
@@ -28,12 +28,12 @@ class ErrorInfo {
 
   /// instantiates a [ErrorInfo] with provided values
   ErrorInfo({
+    this.cause,
     this.code,
     this.href,
     this.message,
-    this.cause,
-    this.statusCode,
     this.requestId,
+    this.statusCode,
   });
 
   @override

--- a/lib/src/message/src/delta_extras.dart
+++ b/lib/src/message/src/delta_extras.dart
@@ -14,8 +14,8 @@ class DeltaExtras {
   /// create instance from a map
   @protected
   DeltaExtras.fromMap(Map value)
-      : from = value[TxDeltaExtras.from] as String?,
-        format = value[TxDeltaExtras.format] as String?;
+      : format = value[TxDeltaExtras.format] as String?,
+        from = value[TxDeltaExtras.from] as String?;
 
   @override
   bool operator ==(Object other) =>

--- a/lib/src/message/src/message.dart
+++ b/lib/src/message/src/message.dart
@@ -49,27 +49,27 @@ class Message {
 
   /// Creates a message instance with [name], [data] and [clientId]
   Message({
-    this.id,
-    this.name,
-    Object? data,
     this.clientId,
     this.connectionId,
-    this.timestamp,
+    Object? data,
     this.encoding,
     this.extras,
+    this.id,
+    this.name,
+    this.timestamp,
   }) : _data = MessageData.fromValue(data);
 
   @override
   bool operator ==(Object other) =>
       other is Message &&
+      other.clientId == clientId &&
+      other.connectionId == connectionId &&
+      other.data == data &&
+      other.encoding == encoding &&
+      other.extras == extras &&
       other.id == id &&
       other.name == name &&
-      other.data == data &&
-      other.extras == extras &&
-      other.encoding == encoding &&
-      other.clientId == clientId &&
-      other.timestamp == timestamp &&
-      other.connectionId == connectionId;
+      other.timestamp == timestamp;
 
   @override
   int get hashCode => '$id:'
@@ -89,9 +89,7 @@ class Message {
   Message.fromEncoded(
     Map<String, dynamic> jsonObject, [
     RestChannelOptions? channelOptions,
-  ])  : id = jsonObject['id'] as String?,
-        name = jsonObject['name'] as String?,
-        clientId = jsonObject['clientId'] as String?,
+  ])  : clientId = jsonObject['clientId'] as String?,
         connectionId = jsonObject['connectionId'] as String?,
         _data = MessageData.fromValue(jsonObject['data']),
         encoding = jsonObject['encoding'] as String?,
@@ -100,6 +98,8 @@ class Message {
             jsonObject['extras'] as Map,
           ),
         ),
+        id = jsonObject['id'] as String?,
+        name = jsonObject['name'] as String?,
         timestamp = jsonObject['timestamp'] != null
             ? DateTime.fromMillisecondsSinceEpoch(
                 jsonObject['timestamp'] as int,

--- a/lib/src/message/src/presence_message.dart
+++ b/lib/src/message/src/presence_message.dart
@@ -49,26 +49,26 @@ class PresenceMessage {
 
   /// instantiates presence message with
   PresenceMessage({
-    this.id,
     this.action,
     this.clientId,
     this.connectionId,
     Object? data,
     this.encoding,
     this.extras,
+    this.id,
     this.timestamp,
   }) : _data = MessageData.fromValue(data);
 
   @override
   bool operator ==(Object other) =>
       other is PresenceMessage &&
-      other.id == id &&
       other.action == action &&
       other.clientId == clientId &&
       other.connectionId == connectionId &&
       other.data == data &&
       other.encoding == encoding &&
       other.extras == extras &&
+      other.id == id &&
       other.timestamp == timestamp;
 
   @override

--- a/lib/src/platform/src/paginated_result.dart
+++ b/lib/src/platform/src/paginated_result.dart
@@ -40,8 +40,8 @@ class PaginatedResult<T> extends PlatformObject {
   /// Sets appropriate [_pageHandle] for identifying platform side of this
   /// result object so that [next] and [first] can be executed
   PaginatedResult.fromAblyMessage(AblyMessage<PaginatedResult> message)
-      : _items = message.message.items.map<T>((e) => e as T).toList(),
-        _hasNext = message.message.hasNext(),
+      : _hasNext = message.message.hasNext(),
+        _items = message.message.items.map<T>((e) => e as T).toList(),
         _pageHandle = message.handle,
         super(fetchHandle: false);
 

--- a/lib/src/push_notifications/src/device_details.dart
+++ b/lib/src/push_notifications/src/device_details.dart
@@ -41,11 +41,11 @@ class DeviceDetails {
 
   /// Initializes an instance without any defaults
   const DeviceDetails({
-    required this.platform,
     required this.formFactor,
     required this.metadata,
+    required this.platform,
     required this.push,
-    this.id,
     this.clientId,
+    this.id,
   });
 }

--- a/lib/src/push_notifications/src/device_push_details.dart
+++ b/lib/src/push_notifications/src/device_push_details.dart
@@ -24,8 +24,8 @@ class DevicePushDetails {
 
   /// Initializes an instance without any defaults
   const DevicePushDetails({
+    this.errorReason,
     this.recipient,
     this.state,
-    this.errorReason,
   });
 }

--- a/lib/src/push_notifications/src/ios_notification_settings.dart
+++ b/lib/src/push_notifications/src/ios_notification_settings.dart
@@ -16,55 +16,68 @@ enum UNAuthorizationStatus {
   denied,
   authorized,
   provisional,
-  ephemeral
+  ephemeral,
 }
 
 /// Constants indicating the presentation styles for alerts.
 ///
 /// [Apple docs](https://developer.apple.com/documentation/usernotifications/unalertstyle)
-enum UNAlertStyle { none, banner, alert }
+enum UNAlertStyle {
+  none,
+  banner,
+  alert,
+}
 
 /// Constants that indicate the current status of a notification setting.
 ///
 /// [Apple docs](https://developer.apple.com/documentation/usernotifications/unnotificationsetting)
-enum UNNotificationSetting { notSupported, disabled, enabled }
+enum UNNotificationSetting {
+  notSupported,
+  disabled,
+  enabled,
+}
 
 /// Constants indicating the style previewing a notification's content.
 ///
 /// [Apple docs](https://developer.apple.com/documentation/usernotifications/unshowpreviewssetting)
-enum UNShowPreviewsSetting { always, whenAuthenticated, never }
+enum UNShowPreviewsSetting {
+  always,
+  whenAuthenticated,
+  never,
+}
 
 /// The object for managing notification-related settings and the authorization
 /// status of your app.
 ///
 /// [Apple docs](https://developer.apple.com/documentation/usernotifications/unnotificationsettings)
 class UNNotificationSettings {
-  UNAuthorizationStatus authorizationStatus;
-  UNNotificationSetting soundSetting;
-  UNNotificationSetting badgeSetting;
   UNNotificationSetting alertSetting;
-  UNNotificationSetting notificationCenterSetting;
-  UNNotificationSetting lockScreenSetting;
-  UNNotificationSetting carPlaySetting;
   UNAlertStyle alertStyle;
-  UNShowPreviewsSetting showPreviewsSetting;
-  UNNotificationSetting criticalAlertSetting;
-  bool providesAppNotificationSettings;
   UNNotificationSetting announcementSetting;
+  UNAuthorizationStatus authorizationStatus;
+  UNNotificationSetting badgeSetting;
+  UNNotificationSetting carPlaySetting;
+  UNNotificationSetting criticalAlertSetting;
+  UNNotificationSetting lockScreenSetting;
+  UNNotificationSetting notificationCenterSetting;
+  bool providesAppNotificationSettings;
+  UNNotificationSetting soundSetting;
+  UNShowPreviewsSetting showPreviewsSetting;
 
   /// Users do not create this class. Call [Push.getNotificationSettings]
   /// instead.
-  UNNotificationSettings(
-      {required this.authorizationStatus,
-      required this.soundSetting,
-      required this.badgeSetting,
-      required this.alertSetting,
-      required this.notificationCenterSetting,
-      required this.lockScreenSetting,
-      required this.carPlaySetting,
-      required this.alertStyle,
-      required this.showPreviewsSetting,
-      required this.criticalAlertSetting,
-      required this.providesAppNotificationSettings,
-      required this.announcementSetting});
+  UNNotificationSettings({
+    required this.alertSetting,
+    required this.alertStyle,
+    required this.announcementSetting,
+    required this.authorizationStatus,
+    required this.badgeSetting,
+    required this.carPlaySetting,
+    required this.criticalAlertSetting,
+    required this.lockScreenSetting,
+    required this.notificationCenterSetting,
+    required this.providesAppNotificationSettings,
+    required this.showPreviewsSetting,
+    required this.soundSetting,
+  });
 }

--- a/lib/src/push_notifications/src/local_device.dart
+++ b/lib/src/push_notifications/src/local_device.dart
@@ -20,14 +20,14 @@ class LocalDevice extends DeviceDetails {
   /// Initializes an instance without any defaults
   LocalDevice({
     required DeviceDetails deviceDetails,
-    this.deviceSecret,
     this.deviceIdentityToken,
+    this.deviceSecret,
   }) : super(
-          id: deviceDetails.id,
           clientId: deviceDetails.clientId,
-          platform: deviceDetails.platform,
           formFactor: deviceDetails.formFactor,
+          id: deviceDetails.id,
           metadata: deviceDetails.metadata,
+          platform: deviceDetails.platform,
           push: deviceDetails.push,
         );
 }

--- a/lib/src/push_notifications/src/notification.dart
+++ b/lib/src/push_notifications/src/notification.dart
@@ -22,7 +22,7 @@ class Notification {
   });
 
   factory Notification.fromMap(Map<String, dynamic> map) => Notification(
-        title: map[TxNotification.title] as String,
         body: map[TxNotification.body] as String?,
+        title: map[TxNotification.title] as String,
       );
 }

--- a/lib/src/push_notifications/src/push.dart
+++ b/lib/src/push_notifications/src/push.dart
@@ -22,7 +22,10 @@ class Push extends PlatformObject {
   final Realtime? realtime;
 
   /// Pass an Ably realtime or rest client.
-  Push({this.rest, this.realtime}) : super() {
+  Push({
+    this.realtime,
+    this.rest,
+  }) : super() {
     final ablyClientNotPresent = rest == null && realtime == null;
     final moreThanOneAblyClientPresent = rest != null && realtime != null;
     if (ablyClientNotPresent || moreThanOneAblyClientPresent) {
@@ -72,26 +75,27 @@ class Push extends PlatformObject {
   /// @returns bool Permission was granted.
   ///
   /// [Apple docs](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorization)
-  Future<bool> requestPermission(
-      {bool badge = true,
-      bool sound = true,
-      bool alert = true,
-      bool carPlay = true,
-      bool criticalAlert = false,
-      bool provisional = false,
-      bool providesAppNotificationSettings = false,
-      bool announcement = true}) async {
+  Future<bool> requestPermission({
+    bool alert = true,
+    bool announcement = true,
+    bool badge = true,
+    bool carPlay = true,
+    bool criticalAlert = false,
+    bool providesAppNotificationSettings = false,
+    bool provisional = false,
+    bool sound = true,
+  }) async {
     if (io.Platform.isIOS) {
       return invokeRequest<bool>(PlatformMethod.pushRequestPermission, {
-        TxPushRequestPermission.badge: badge,
-        TxPushRequestPermission.sound: sound,
         TxPushRequestPermission.alert: alert,
+        TxPushRequestPermission.announcement: announcement,
+        TxPushRequestPermission.badge: badge,
         TxPushRequestPermission.carPlay: carPlay,
         TxPushRequestPermission.criticalAlert: criticalAlert,
-        TxPushRequestPermission.provisional: provisional,
         TxPushRequestPermission.providesAppNotificationSettings:
             providesAppNotificationSettings,
-        TxPushRequestPermission.announcement: announcement,
+        TxPushRequestPermission.provisional: provisional,
+        TxPushRequestPermission.sound: sound,
       });
     } else {
       return true;

--- a/lib/src/push_notifications/src/push_channel_subscription.dart
+++ b/lib/src/push_notifications/src/push_channel_subscription.dart
@@ -24,7 +24,7 @@ class PushChannelSubscription {
   /// Initializes an instance without any defaults
   const PushChannelSubscription({
     required this.channel,
-    this.deviceId,
     this.clientId,
+    this.deviceId,
   });
 }

--- a/lib/src/realtime/src/channel_state_event.dart
+++ b/lib/src/realtime/src/channel_state_event.dart
@@ -37,8 +37,8 @@ class ChannelStateChange {
   /// initializes with [resumed] set to false
   const ChannelStateChange({
     required this.current,
-    required this.previous,
     required this.event,
+    required this.previous,
     this.reason,
     this.resumed = false,
   });

--- a/lib/src/realtime/src/connection_state_change.dart
+++ b/lib/src/realtime/src/connection_state_change.dart
@@ -39,8 +39,8 @@ class ConnectionStateChange {
   /// initializes without any defaults
   const ConnectionStateChange({
     required this.current,
-    required this.previous,
     required this.event,
+    required this.previous,
     this.reason,
     this.retryIn,
   });

--- a/lib/src/realtime/src/realtime_channel_options.dart
+++ b/lib/src/realtime/src/realtime_channel_options.dart
@@ -30,8 +30,8 @@ class RealtimeChannelOptions {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TB2
   const RealtimeChannelOptions({
-    this.params,
-    this.modes,
     this.cipherParams,
+    this.modes,
+    this.params,
   });
 }

--- a/lib/src/realtime/src/realtime_channel_options.dart
+++ b/lib/src/realtime/src/realtime_channel_options.dart
@@ -1,5 +1,5 @@
 import 'package:ably_flutter/ably_flutter.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 
 /// Configuration options for a [RealtimeChannel]
 ///

--- a/lib/src/realtime/src/realtime_history_params.dart
+++ b/lib/src/realtime/src/realtime_history_params.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 
 /// Params for realtime history
 ///

--- a/lib/src/realtime/src/realtime_history_params.dart
+++ b/lib/src/realtime/src/realtime_history_params.dart
@@ -49,14 +49,14 @@ class RealtimeHistoryParams {
   ///
   /// Raises [AssertionError] if [direction] is not "backwards" or "forwards"
   RealtimeHistoryParams({
-    DateTime? start,
-    DateTime? end,
     this.direction = 'backwards',
+    DateTime? end,
     this.limit = 100,
+    DateTime? start,
     this.untilAttach,
   })  : assert(direction == 'backwards' || direction == 'forwards'),
-        start = start ?? DateTime.fromMillisecondsSinceEpoch(0),
-        end = end ?? DateTime.now();
+        end = end ?? DateTime.now(),
+        start = start ?? DateTime.fromMillisecondsSinceEpoch(0);
 
   @override
   String toString() => 'RealtimeHistoryParams:'

--- a/lib/src/realtime/src/realtime_presence_params.dart
+++ b/lib/src/realtime/src/realtime_presence_params.dart
@@ -24,8 +24,8 @@ class RealtimePresenceParams {
 
   /// initializes with [waitForSync] set to true by default
   const RealtimePresenceParams({
-    this.waitForSync = true,
     this.clientId,
     this.connectionId,
+    this.waitForSync = true,
   });
 }

--- a/lib/src/realtime/src/realtime_presence_params.dart
+++ b/lib/src/realtime/src/realtime_presence_params.dart
@@ -1,5 +1,5 @@
 import 'package:ably_flutter/ably_flutter.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:meta/meta.dart';
 
 /// Params used as a filter for querying presence on a channel
 ///

--- a/lib/src/rest/src/rest_history_params.dart
+++ b/lib/src/rest/src/rest_history_params.dart
@@ -38,13 +38,13 @@ class RestHistoryParams {
   ///
   /// Raises [AssertionError] if [direction] is not "backwards" or "forwards"
   RestHistoryParams({
-    DateTime? start,
-    DateTime? end,
     this.direction = 'backwards',
+    DateTime? end,
     this.limit = 100,
+    DateTime? start,
   })  : assert(direction == 'backwards' || direction == 'forwards'),
-        start = start ?? DateTime.fromMillisecondsSinceEpoch(0),
-        end = end ?? DateTime.now();
+        end = end ?? DateTime.now(),
+        start = start ?? DateTime.fromMillisecondsSinceEpoch(0);
 
   @override
   String toString() => 'RestHistoryParams:'

--- a/lib/src/rest/src/rest_presence_params.dart
+++ b/lib/src/rest/src/rest_presence_params.dart
@@ -19,8 +19,8 @@ class RestPresenceParams {
 
   /// initializes with default [limit] set to 100
   RestPresenceParams({
-    this.limit = 100,
     this.clientId,
     this.connectionId,
+    this.limit = 100,
   });
 }

--- a/test_integration/lib/test_dispatcher.dart
+++ b/test_integration/lib/test_dispatcher.dart
@@ -6,7 +6,6 @@ import 'package:ably_flutter_integration_test/driver_data_handler.dart';
 import 'package:ably_flutter_integration_test/factory/error_handler.dart';
 import 'package:ably_flutter_integration_test/factory/reporter.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 enum _TestStatus { success, error, progress }
 


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/351. Parameters in named constructors are now sorted alphabetically. I've also done a quick cleanup of imports, mostly by removing `cupertino` and `material` imports, and replacing them with `meta` which is a non-UI package.