### PR TITLE
TransportParams support in ClientOptions

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -375,12 +375,12 @@ public class AblyMessageCodec extends StandardMessageCodec {
     if (jsonMap == null) return null;
     // It's not possible to initialize the array here, because that way,
     // Params will have a (null, null) entry, so we need to initialize it later with `Params.set`
-    Param[] o = null;
+    Param[] transportParams = null;
     for (String key: jsonMap.keySet()) {
       // Params.set() creates new parms instance if o is null
-      o = Param.set(o, key, jsonMap.get(key));
+      transportParams = Param.set(transportParams, key, jsonMap.get(key));
     }
-    return o;
+    return transportParams;
   }
 
   private Auth.TokenRequest decodeTokenRequest(Map<String, Object> jsonMap) {

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -321,7 +321,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
     readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.fallbackRetryTimeout, v -> o.fallbackRetryTimeout = readValueAsLong(v));
     readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.defaultTokenParams, v -> o.defaultTokenParams = decodeTokenParams((Map<String, Object>) v));
     readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.channelRetryTimeout, v -> o.channelRetryTimeout = (Integer) v);
-    readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.transportParams, v -> o.transportParams = (Param[]) v);
+    readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.transportParams, v -> o.transportParams = decodeTransportParams((Map<String, String>) v));
 
     o.agents = new HashMap<>();
     o.agents.put("ably-flutter", BuildConfig.FLUTTER_PACKAGE_PLUGIN_VERSION);
@@ -368,6 +368,18 @@ public class AblyMessageCodec extends StandardMessageCodec {
     readValueFromJson(jsonMap, PlatformConstants.TxTokenParams.ttl, v -> o.ttl = readValueAsLong(v));
     // nonce is not supported in ably-java
     // Track @ https://github.com/ably/ably-flutter/issues/14
+    return o;
+  }
+
+  private Param[] decodeTransportParams(Map<String, String> jsonMap) {
+    if (jsonMap == null) return null;
+    // It's not possible to initialize the array here, because that way,
+    // Params will have a (null, null) entry, so we need to initialize it later with `Params.set`
+    Param[] o = null;
+    for (String key: jsonMap.keySet()) {
+      // Params.set() creates new parms instance if o is null
+      o = Param.set(o, key, jsonMap.get(key));
+    }
     return o;
   }
 

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -135,13 +135,14 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
     READ_VALUE(clientOptions, idempotentRestPublishing, dictionary, TxClientOptions_idempotentRestPublishing);
     READ_VALUE(clientOptions, fallbackHosts, dictionary, TxClientOptions_fallbackHosts);
     READ_VALUE(clientOptions, fallbackHostsUseDefault, dictionary, TxClientOptions_fallbackHostsUseDefault);
+    READ_VALUE(clientOptions, transportParams, dictionary, TxClientOptions_transportParams);
     ON_VALUE(^(const id value) {
         clientOptions.defaultTokenParams = [AblyFlutterReader tokenParamsFromDictionary: value];
     }, dictionary, TxClientOptions_defaultTokenParams);
     // Following properties not supported by Objective C library
     // useAuthToken, port, tlsPort, httpOpenTimeout, httpRequestTimeout,
     // httpMaxRetryCount, realtimeRequestTimeout, fallbackRetryTimeout,
-    // channelRetryTimeout, transportParams, asyncHttpThreadpoolSize, pushFullWait
+    // channelRetryTimeout, asyncHttpThreadpoolSize, pushFullWait
     // track @ https://github.com/ably/ably-flutter/issues/14
 
     [clientOptions addAgent:@"ably-flutter" version:FLUTTER_PACKAGE_PLUGIN_VERSION];


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/108. I've found out that this feature was implemented on Dart side, but it wasn't implemented in iOS and Android bridges, probably because of differences in implementation of these methods for each platform (iOS requires `NSDictionary` and Android requires `Param[]` array).  I've implemented bridges on each platform and now it seems to work fine 🙂 