### PR TITLE
Dart runtime version as agent header

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -323,9 +323,11 @@ public class AblyMessageCodec extends StandardMessageCodec {
     readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.channelRetryTimeout, v -> o.channelRetryTimeout = (Integer) v);
     readValueFromJson(jsonMap, PlatformConstants.TxClientOptions.transportParams, v -> o.transportParams = (Param[]) v);
 
-    o.agents = new HashMap<>();
-    o.agents.put("ably-flutter", BuildConfig.FLUTTER_PACKAGE_PLUGIN_VERSION);
-    o.agents.put("dart", (String) jsonMap.get(PlatformConstants.TxClientOptions.dartVersion));
+    o.agents = new HashMap<String, String>() {{
+        put("ably-flutter", BuildConfig.FLUTTER_PACKAGE_PLUGIN_VERSION);
+        put("dart", (String) jsonMap.get(PlatformConstants.TxClientOptions.dartVersion));
+    }};
+
 
     return new PlatformClientOptions(o, jsonMap.containsKey(PlatformConstants.TxClientOptions.hasAuthCallback) ? ((boolean) jsonMap.get(PlatformConstants.TxClientOptions.hasAuthCallback)) : false);
   }

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -325,6 +325,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
 
     o.agents = new HashMap<>();
     o.agents.put("ably-flutter", BuildConfig.FLUTTER_PACKAGE_PLUGIN_VERSION);
+    o.agents.put("dart", (String) jsonMap.get(PlatformConstants.TxClientOptions.dartVersion));
 
     return new PlatformClientOptions(o, jsonMap.containsKey(PlatformConstants.TxClientOptions.hasAuthCallback) ? ((boolean) jsonMap.get(PlatformConstants.TxClientOptions.hasAuthCallback)) : false);
   }

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -177,6 +177,7 @@ final public class PlatformConstants {
         public static final String defaultTokenParams = "defaultTokenParams";
         public static final String channelRetryTimeout = "channelRetryTimeout";
         public static final String transportParams = "transportParams";
+        public static final String dartVersion = "dartVersion";
     }
 
     static final public class TxRestChannelOptions {

--- a/bin/codegen_context.dart
+++ b/bin/codegen_context.dart
@@ -242,6 +242,7 @@ const List<Map<String, dynamic>> _objects = [
       'defaultTokenParams',
       'channelRetryTimeout',
       'transportParams',
+      'dartVersion',
     ]
   },
   {

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -145,6 +145,9 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
     // track @ https://github.com/ably/ably-flutter/issues/14
 
     [clientOptions addAgent:@"ably-flutter" version:FLUTTER_PACKAGE_PLUGIN_VERSION];
+    ON_VALUE(^(const id value) {
+        [clientOptions addAgent:@"dart" version:value];
+    }, dictionary, TxClientOptions_dartVersion);
 
     return  [[AblyFlutterClientOptions alloc]
              initWithClientOptions:clientOptions

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -167,6 +167,7 @@ extern NSString *const TxClientOptions_fallbackRetryTimeout;
 extern NSString *const TxClientOptions_defaultTokenParams;
 extern NSString *const TxClientOptions_channelRetryTimeout;
 extern NSString *const TxClientOptions_transportParams;
+extern NSString *const TxClientOptions_dartVersion;
 
 // key constants for RestChannelOptions
 extern NSString *const TxRestChannelOptions_cipherParams;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -137,6 +137,7 @@ NSString *const TxClientOptions_fallbackRetryTimeout = @"fallbackRetryTimeout";
 NSString *const TxClientOptions_defaultTokenParams = @"defaultTokenParams";
 NSString *const TxClientOptions_channelRetryTimeout = @"channelRetryTimeout";
 NSString *const TxClientOptions_transportParams = @"transportParams";
+NSString *const TxClientOptions_dartVersion = @"dartVersion";
 
 // key constants for RestChannelOptions
 NSString *const TxRestChannelOptions_cipherParams = @"cipherParams";

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -385,7 +385,8 @@ class TxPushRequestPermission {
   static const String alert = 'alert';
   static const String carPlay = 'carPlay';
   static const String criticalAlert = 'criticalAlert';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String provisional = 'provisional';
   static const String announcement = 'announcement';
 }
@@ -401,7 +402,8 @@ class TxUNNotificationSettings {
   static const String alertStyle = 'alertStyle';
   static const String showPreviewsSetting = 'showPreviewsSetting';
   static const String criticalAlertSetting = 'criticalAlertSetting';
-  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings =
+      'providesAppNotificationSettings';
   static const String announcementSetting = 'announcementSetting';
   static const String scheduledDeliverySetting = 'scheduledDeliverySetting';
   static const String timeSensitiveSetting = 'timeSensitiveSetting';

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -181,6 +181,7 @@ class TxClientOptions {
   static const String defaultTokenParams = 'defaultTokenParams';
   static const String channelRetryTimeout = 'channelRetryTimeout';
   static const String transportParams = 'transportParams';
+  static const String dartVersion = 'dartVersion';
 }
 
 class TxRestChannelOptions {
@@ -384,8 +385,7 @@ class TxPushRequestPermission {
   static const String alert = 'alert';
   static const String carPlay = 'carPlay';
   static const String criticalAlert = 'criticalAlert';
-  static const String providesAppNotificationSettings =
-      'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
   static const String provisional = 'provisional';
   static const String announcement = 'announcement';
 }
@@ -401,8 +401,7 @@ class TxUNNotificationSettings {
   static const String alertStyle = 'alertStyle';
   static const String showPreviewsSetting = 'showPreviewsSetting';
   static const String criticalAlertSetting = 'criticalAlertSetting';
-  static const String providesAppNotificationSettings =
-      'providesAppNotificationSettings';
+  static const String providesAppNotificationSettings = 'providesAppNotificationSettings';
   static const String announcementSetting = 'announcementSetting';
   static const String scheduledDeliverySetting = 'scheduledDeliverySetting';
   static const String timeSensitiveSetting = 'timeSensitiveSetting';

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -276,6 +276,7 @@ class Codec extends StandardMessageCodec {
     _writeToJson(
         jsonMap, TxClientOptions.channelRetryTimeout, v.channelRetryTimeout);
     _writeToJson(jsonMap, TxClientOptions.transportParams, v.transportParams);
+    _writeToJson(jsonMap, TxClientOptions.dartVersion, dartVersion());
     return jsonMap;
   }
 

--- a/lib/src/platform/src/info.dart
+++ b/lib/src/platform/src/info.dart
@@ -12,4 +12,9 @@ Future<String> version() async =>
     Platform().invokePlatformMethodNonNull<String>(PlatformMethod.getVersion);
 
 /// Get version of Dart runtime
-String dartVersion() => io.Platform.version.split(' ').first;
+String dartVersion() => readSemverFromPlatformVersion(io.Platform.version);
+
+/// Extracts semver value from platform version
+/// value is split by space and first element is selected as semver value
+String readSemverFromPlatformVersion(String platformVersion) =>
+    platformVersion.split(' ').first;

--- a/lib/src/platform/src/info.dart
+++ b/lib/src/platform/src/info.dart
@@ -1,3 +1,5 @@
+import 'dart:io' as io show Platform;
+
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
 
@@ -8,3 +10,6 @@ Future<String> platformVersion() async => Platform()
 /// Get ably library version
 Future<String> version() async =>
     Platform().invokePlatformMethodNonNull<String>(PlatformMethod.getVersion);
+
+/// Get version of Dart runtime
+String dartVersion() => io.Platform.version.split(' ').first;

--- a/test/platform/info_test.dart
+++ b/test/platform/info_test.dart
@@ -1,0 +1,60 @@
+import 'dart:io' as io show Platform;
+
+import 'package:ably_flutter/ably_flutter.dart' as ably;
+import 'package:test/test.dart';
+
+import '../test_constants.dart';
+
+void main() {
+  final semverRegexp = RegExp(TestConstants.semverRegexp);
+
+  group('dartVersion', () {
+    // Raw value of runtime version returned from [Platform]
+    late String platformVersion;
+    // Semver value read from platform version
+    late String dartVersion;
+
+    setUpAll(() {
+      platformVersion = io.Platform.version;
+      dartVersion = ably.dartVersion();
+    });
+
+    test('platform version is not empty', () {
+      expect(platformVersion, isNotEmpty);
+    });
+
+    test('dart version is not empty', () {
+      expect(dartVersion, isNotEmpty);
+    });
+
+    test('platform version starts with dart version', () {
+      expect(platformVersion, startsWith(dartVersion));
+    });
+
+    test('dart version is a valid semver string', () {
+      final hasMatch = semverRegexp.hasMatch(dartVersion);
+      expect(hasMatch, equals(true));
+    });
+  });
+
+  group('readSemverFromPlatformVersion', () {
+    test('returns valid semver from platform version', () {
+      const platformVersion =
+          '2.16.2 (stable) (Tue Mar 22 13:15:13 2022 +0100) on "macos_x64"';
+      final result = ably.readSemverFromPlatformVersion(platformVersion);
+      expect(result, equals('2.16.2'));
+    });
+
+    test('returns valid semver from semver only string', () {
+      const platformVersion = '2.16.2';
+      final result = ably.readSemverFromPlatformVersion(platformVersion);
+      expect(result, equals('2.16.2'));
+    });
+
+    test('returns empty semver from empty string', () {
+      const platformVersion = '';
+      final result = ably.readSemverFromPlatformVersion(platformVersion);
+      expect(result, isEmpty);
+    });
+  });
+}

--- a/test/test_constants.dart
+++ b/test/test_constants.dart
@@ -1,0 +1,6 @@
+class TestConstants {
+  /// Regular expression that matches all valid semantic versioning
+  /// Source: https://semver.org/
+  static const semverRegexp =
+      r'^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$';
+}


### PR DESCRIPTION
This should resolve https://github.com/ably/ably-flutter/issues/286, but will only work after https://github.com/ably/ably-common/pull/143 is landed. It's a simple change, that passes Dart runtime along with `ClientOptions` and encodes it as an `agent` header in platform implementations. The entire header looks like this:

```
Ably-Agent: ably-java/1.2.11 dart/2.16.2 ably-flutter/1.2.13 android/31
```