### PR TITLE
Unified platform method invocations

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -184,8 +184,8 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void createRest(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final AblyFlutterMessage<PlatformClientOptions> ablyMessage = (AblyFlutterMessage<PlatformClientOptions>) call.arguments;
-    final PlatformClientOptions clientOptions = (PlatformClientOptions) ablyMessage.message;
+    final AblyFlutterMessage<Map<String,Object>> ablyMessage = (AblyFlutterMessage<Map<String,Object>>) call.arguments;
+    final PlatformClientOptions clientOptions = (PlatformClientOptions) ablyMessage.message.get(PlatformConstants.TxTransportKeys.options);
     try {
       final AblyInstanceStore.ClientHandle clientHandle = instanceStore.reserveClientHandle();
       if (clientOptions.hasAuthCallback) {
@@ -427,12 +427,12 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void createRealtime(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final AblyFlutterMessage<PlatformClientOptions> ablyMessage = (AblyFlutterMessage<PlatformClientOptions>) call.arguments;
-    final PlatformClientOptions message = ablyMessage.message;
+    final AblyFlutterMessage<Map<String,Object>> ablyMessage = (AblyFlutterMessage<Map<String,Object>>) call.arguments;
+    final PlatformClientOptions clientOptions = (PlatformClientOptions) ablyMessage.message.get(PlatformConstants.TxTransportKeys.options);
     try {
       final AblyInstanceStore.ClientHandle clientHandle = instanceStore.reserveClientHandle();
-      if (message.hasAuthCallback) {
-        message.options.authCallback = (Auth.TokenParams params) -> {
+      if (clientOptions.hasAuthCallback) {
+        clientOptions.options.authCallback = (Auth.TokenParams params) -> {
           final Object[] token = {null};
           final CountDownLatch latch = new CountDownLatch(1);
           new Handler(Looper.getMainLooper()).post(() -> {
@@ -469,7 +469,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
           return token[0];
         };
       }
-      result.success(clientHandle.createRealtime(message.options, applicationContext));
+      result.success(clientHandle.createRealtime(clientOptions.options, applicationContext));
     } catch (final AblyException e) {
       handleAblyException(result, e);
     }

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -749,9 +749,9 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void cryptoGetParams(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final Map<String, Object> message = (Map<String, Object>) call.arguments;
-    final String algorithm = (String) message.get(PlatformConstants.TxCryptoGetParams.algorithm);
-    final byte[] keyData = getKeyData(message.get(PlatformConstants.TxCryptoGetParams.key));
+    final AblyFlutterMessage<Map<String, Object>> ablyMessage = (AblyFlutterMessage<Map<String, Object>>) call.arguments;
+    final String algorithm = (String) ablyMessage.message.get(PlatformConstants.TxCryptoGetParams.algorithm);
+    final byte[] keyData = getKeyData(ablyMessage.message.get(PlatformConstants.TxCryptoGetParams.key));
     if (keyData == null) {
       result.error("40000", "A key must be set for encryption, being either a base64 encoded key, or a byte array.", null);
       return;
@@ -778,8 +778,8 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void cryptoGenerateRandomKey(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final Map<String, Object> message = (Map<String, Object>) call.arguments;
-    final Integer keyLength = (Integer) message.get(PlatformConstants.TxCryptoGenerateRandomKey.keyLength);
+    final AblyFlutterMessage<Map<String, Object>> ablyMessage = (AblyFlutterMessage<Map<String, Object>>) call.arguments;
+    final Integer keyLength = (Integer) ablyMessage.message.get(PlatformConstants.TxCryptoGenerateRandomKey.keyLength);
     result.success(Crypto.generateRandomKey(keyLength));
   }
 

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -264,8 +264,8 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void releaseRestChannel(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) call.arguments;
-    final String channelName = (String) ablyMessage.message;
+    final AblyFlutterMessage<Map<String, Object>> ablyMessage = (AblyFlutterMessage<Map<String, Object>>) call.arguments;
+    final String channelName = (String) ablyMessage.message.get(PlatformConstants.TxTransportKeys.channelName);
     instanceStore.getRest(ablyMessage.handle).channels.release(channelName);
     result.success(null);
   }
@@ -561,8 +561,8 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void releaseRealtimeChannel(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) call.arguments;
-    final String channelName = (String) ablyMessage.message;
+    final AblyFlutterMessage<Map<String, Object>> ablyMessage = (AblyFlutterMessage<Map<String, Object>>) call.arguments;
+    final String channelName = (String) ablyMessage.message.get(PlatformConstants.TxTransportKeys.channelName);
 
     instanceStore.getRealtime(ablyMessage.handle).channels.release(channelName);
     result.success(null);

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -778,7 +778,8 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
   }
 
   private void cryptoGenerateRandomKey(@NonNull MethodCall call, @NonNull MethodChannel.Result result) {
-    final Integer keyLength = (Integer) call.arguments;
+    final Map<String, Object> message = (Map<String, Object>) call.arguments;
+    final Integer keyLength = (Integer) message.get(PlatformConstants.TxCryptoGenerateRandomKey.keyLength);
     result.success(Crypto.generateRandomKey(keyLength));
   }
 

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -217,7 +217,8 @@ static const FlutterHandler _getRestPresenceHistory = ^void(AblyFlutter *const a
 
 static const FlutterHandler _releaseRestChannel = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
-    NSString *const channelName = (NSString*) ablyMessage.message;
+    NSDictionary *const message = ablyMessage.message;
+    NSString *const channelName = (NSString*) message[TxTransportKeys_channelName];
     
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRest *const rest = [instanceStore restFrom:ablyMessage.handle];
@@ -558,7 +559,8 @@ static const FlutterHandler _leaveRealtimePresence = ^void(AblyFlutter *const ab
 
 static const FlutterHandler _releaseRealtimeChannel = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
-    NSString *const channelName = (NSString*) ablyMessage.message;
+    NSDictionary *const message = ablyMessage.message;
+    NSString *const channelName = (NSString*) message[TxTransportKeys_channelName];
     
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -43,17 +43,18 @@ static const FlutterHandler _resetAblyClients = ^void(AblyFlutter *const ably, F
 
 static const FlutterHandler _createRest = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
-    AblyFlutterClientOptions *const message = ablyMessage.message;
+    NSMutableDictionary<NSString *, NSObject *> *const message = ablyMessage.message;
+    AblyFlutterClientOptions *const options = (AblyFlutterClientOptions*) message[TxTransportKeys_options];
     
-    message.clientOptions.pushRegistererDelegate = [PushActivationEventHandlers getInstanceWithMethodChannel: ably.channel];
+    options.clientOptions.pushRegistererDelegate = [PushActivationEventHandlers getInstanceWithMethodChannel: ably.channel];
     ARTLog *const logger = [[ARTLog alloc] init];
-    logger.logLevel = message.clientOptions.logLevel;
+    logger.logLevel = options.clientOptions.logLevel;
 
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     NSNumber *const handle = [instanceStore getNextHandle];
     
-    if(message.hasAuthCallback){
-        message.clientOptions.authCallback =
+    if(options.hasAuthCallback){
+        options.clientOptions.authCallback =
         ^(ARTTokenParams *tokenParams, void(^callback)(id<ARTTokenDetailsCompatible>, NSError *)){
             AblyFlutterMessage *const message = [[AblyFlutterMessage alloc] initWithMessage:tokenParams handle: handle];
             [ably.channel invokeMethod:AblyPlatformMethod_authCallback
@@ -72,7 +73,7 @@ static const FlutterHandler _createRest = ^void(AblyFlutter *const ably, Flutter
             }];
         };
     }
-    ARTRest *const rest = [[ARTRest alloc] initWithOptions:message.clientOptions];
+    ARTRest *const rest = [[ARTRest alloc] initWithOptions:options.clientOptions];
     [instanceStore setRest:rest with: handle];
 
     NSData *const apnsDeviceToken = ably.instanceStore.didRegisterForRemoteNotificationsWithDeviceToken_deviceToken;
@@ -227,17 +228,18 @@ static const FlutterHandler _releaseRestChannel = ^void(AblyFlutter *const ably,
 
 static const FlutterHandler _createRealtime = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
-    AblyFlutterClientOptions *const message = ablyMessage.message;
+    NSMutableDictionary<NSString *, NSObject *> *const message = ablyMessage.message;
+    AblyFlutterClientOptions *const options = (AblyFlutterClientOptions*) message[TxTransportKeys_options];
     
-    message.clientOptions.pushRegistererDelegate = [PushActivationEventHandlers getInstanceWithMethodChannel: ably.channel];
+    options.clientOptions.pushRegistererDelegate = [PushActivationEventHandlers getInstanceWithMethodChannel: ably.channel];
     ARTLog *const logger = [[ARTLog alloc] init];
-    logger.logLevel = message.clientOptions.logLevel;
+    logger.logLevel = options.clientOptions.logLevel;
 
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     NSNumber *const handle = [instanceStore getNextHandle];
     
-    if(message.hasAuthCallback){
-        message.clientOptions.authCallback =
+    if(options.hasAuthCallback){
+        options.clientOptions.authCallback =
         ^(ARTTokenParams *tokenParams, void(^callback)(id<ARTTokenDetailsCompatible>, NSError *)){
             AblyFlutterMessage *const message
             = [[AblyFlutterMessage alloc] initWithMessage:tokenParams handle: handle];
@@ -257,7 +259,7 @@ static const FlutterHandler _createRealtime = ^void(AblyFlutter *const ably, Flu
             }];
         };
     }
-    ARTRealtime *const realtime = [[ARTRealtime alloc] initWithOptions:message.clientOptions];
+    ARTRealtime *const realtime = [[ARTRealtime alloc] initWithOptions:options.clientOptions];
     [instanceStore setRealtime:realtime with:handle];
 
     // Giving Ably client the deviceToken registered at device launch (didRegisterForRemoteNotificationsWithDeviceToken).

--- a/ios/Classes/handlers/CryptoHandlers.swift
+++ b/ios/Classes/handlers/CryptoHandlers.swift
@@ -4,9 +4,10 @@ import Ably
 public class CryptoHandlers: NSObject {
     @objc
     public static let getParams: FlutterHandler = { plugin, call, result in
-        let dictionary = call.arguments as! Dictionary<String, Any>
-        let algorithm = dictionary[TxCryptoGetParams_algorithm] as! String
-        let key = dictionary[TxCryptoGetParams_key]
+        let ablyMessage = call.arguments as! AblyFlutterMessage
+        let message = ablyMessage.message as! Dictionary<String, Any>
+        let algorithm = message[TxCryptoGetParams_algorithm] as! String
+        let key = message[TxCryptoGetParams_key]
 
         if let key = key as? NSString {
             result(ARTCipherParams(algorithm: algorithm, key: key))

--- a/ios/Classes/handlers/CryptoHandlers.swift
+++ b/ios/Classes/handlers/CryptoHandlers.swift
@@ -23,7 +23,8 @@ public class CryptoHandlers: NSObject {
     
     @objc
     public static let generateRandomKey: FlutterHandler = { plugin, call, result in
-        let keyLength = call.arguments as! Int;
+        let dictionary = call.arguments as! Dictionary<String, Any>
+        let keyLength = dictionary[TxCryptoGenerateRandomKey_keyLength] as! Int;
         result(ARTCrypto.generateRandomKey(UInt(keyLength)));
     }
 }

--- a/lib/src/crypto/src/crypto.dart
+++ b/lib/src/crypto/src/crypto.dart
@@ -35,10 +35,12 @@ class Crypto {
     }
 
     return Platform().invokePlatformMethodNonNull<CipherParams>(
-        PlatformMethod.cryptoGetParams, {
-      TxCryptoGetParams.algorithm: defaultAlgorithm,
-      TxCryptoGetParams.key: key,
-    });
+      PlatformMethod.cryptoGetParams,
+      AblyMessage(message: {
+        TxCryptoGetParams.algorithm: defaultAlgorithm,
+        TxCryptoGetParams.key: key,
+      }),
+    );
   }
 
   static void ensureSupportedKeyLength(Uint8List key) {
@@ -60,7 +62,9 @@ class Crypto {
   static Future<Uint8List> generateRandomKey(
           {keyLength = defaultKeyLengthInBits}) =>
       Platform().invokePlatformMethodNonNull<Uint8List>(
-          PlatformMethod.cryptoGenerateRandomKey, {
-        TxCryptoGenerateRandomKey.keyLength: keyLength,
-      });
+        PlatformMethod.cryptoGenerateRandomKey,
+        AblyMessage(message: {
+          TxCryptoGenerateRandomKey.keyLength: keyLength,
+        }),
+      );
 }

--- a/lib/src/crypto/src/crypto.dart
+++ b/lib/src/crypto/src/crypto.dart
@@ -60,5 +60,7 @@ class Crypto {
   static Future<Uint8List> generateRandomKey(
           {keyLength = defaultKeyLengthInBits}) =>
       Platform().invokePlatformMethodNonNull<Uint8List>(
-          PlatformMethod.cryptoGenerateRandomKey, keyLength);
+          PlatformMethod.cryptoGenerateRandomKey, {
+        TxCryptoGenerateRandomKey.keyLength: keyLength,
+      });
 }

--- a/lib/src/platform/src/platform.dart
+++ b/lib/src/platform/src/platform.dart
@@ -51,7 +51,7 @@ class Platform {
 
   /// Call a platform method which always provides a result.
   Future<T> invokePlatformMethodNonNull<T>(String method,
-      [Object? arguments]) async {
+      [Map<String, dynamic>? arguments]) async {
     final result = await invokePlatformMethod<T>(method, arguments);
     if (result == null) {
       throw AblyException(

--- a/lib/src/platform/src/platform.dart
+++ b/lib/src/platform/src/platform.dart
@@ -33,7 +33,8 @@ class Platform {
   /// instance of method channel to listen to android/ios events
   late final StreamsChannel? _streamsChannel;
 
-  Future<T?> invokePlatformMethod<T>(String method, [Object? arguments]) async {
+  Future<T?> invokePlatformMethod<T>(String method,
+      [AblyMessage? arguments]) async {
     try {
       // If argument is null, pass an empty [AblyMessage], because codec fails
       // if argument value is null
@@ -51,7 +52,7 @@ class Platform {
 
   /// Call a platform method which always provides a result.
   Future<T> invokePlatformMethodNonNull<T>(String method,
-      [Map<String, dynamic>? arguments]) async {
+      [AblyMessage? arguments]) async {
     final result = await invokePlatformMethod<T>(method, arguments);
     if (result == null) {
       throw AblyException(

--- a/lib/src/platform/src/platform_object.dart
+++ b/lib/src/platform/src/platform_object.dart
@@ -50,9 +50,10 @@ abstract class PlatformObject {
   /// invoke platform method channel with provided handle, or
   /// current handle if [externalHandle] is not provided
   Future<T?> invoke<T>(final String method,
-      [final Object? argument, final int? externalHandle]) async {
+      [final Map<String, dynamic>? arguments,
+      final int? externalHandle]) async {
     final message = AblyMessage(
-      message: argument ?? {},
+      message: arguments ?? {},
       handle: externalHandle ?? await handle,
     );
     return _platform.invokePlatformMethod<T>(method, message);
@@ -62,8 +63,8 @@ abstract class PlatformObject {
   ///
   /// this is similar to [invoke], but ensures the response is not null
   Future<T> invokeRequest<T>(final String method,
-      [final Object? argument]) async {
-    final response = await invoke<T>(method, argument);
+      [final Map<String, dynamic>? arguments]) async {
+    final response = await invoke<T>(method, arguments);
     if (response == null) {
       throw AblyException(
         message:

--- a/lib/src/platform/src/platform_object.dart
+++ b/lib/src/platform/src/platform_object.dart
@@ -39,7 +39,7 @@ abstract class PlatformObject {
   /// case for creating rest and realtime instances
   @protected
   Future<T?> invokeWithoutHandle<T>(final String method,
-      [final Object? argument]) async {
+      [final Map<String, dynamic>? argument]) async {
     final message = AblyMessage(
       message: argument ?? {},
       handle: null,

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -33,10 +33,10 @@ class Realtime extends PlatformObject {
 
   @override
   Future<int?> createPlatformInstance() async {
-    final handle = await invokeWithoutHandle<int>(
-      PlatformMethod.createRealtime,
-      options,
-    );
+    final handle =
+        await invokeWithoutHandle<int>(PlatformMethod.createRealtime, {
+      TxTransportKeys.options: options,
+    });
     _realtimeInstances[handle] = this;
 
     if (io.Platform.isAndroid && options.autoConnect) {

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -33,9 +33,9 @@ class Realtime extends PlatformObject {
 
   @override
   Future<int?> createPlatformInstance() async {
-    final handle = await invokeRaw<int>(
+    final handle = await invokeWithoutHandle<int>(
       PlatformMethod.createRealtime,
-      AblyMessage(message: options),
+      options,
     );
     _realtimeInstances[handle] = this;
 
@@ -45,11 +45,12 @@ class Realtime extends PlatformObject {
       // If this happens, we won't be able to identify which realtime client
       // the authCallback belongs to. Instead, on Android, we set autoConnect
       // to false, and call connect immediately once we get the handle.
-      // This is also a specific case where it's required to use [invokeRaw]
-      // because we need to pass message with handle outside of [PlatformObject]
-      await invokeRaw(
+      // This is also a specific case where it's required to pass the handle
+      // value from external source
+      await invoke(
         PlatformMethod.connectRealtime,
-        AblyMessage.empty(handle: handle),
+        null,
+        handle,
       );
     }
     return handle;

--- a/lib/src/platform/src/realtime/realtime_channels.dart
+++ b/lib/src/platform/src/realtime/realtime_channels.dart
@@ -20,7 +20,9 @@ class RealtimeChannels extends Channels<RealtimeChannel> {
   /// so it can be garbage collected.
   @override
   void release(String name) {
-    realtime.invoke(PlatformMethod.releaseRealtimeChannel, name);
+    realtime.invoke(PlatformMethod.releaseRealtimeChannel, {
+      TxTransportKeys.channelName: name,
+    });
     super.release(name);
   }
 }

--- a/lib/src/platform/src/rest/rest.dart
+++ b/lib/src/platform/src/rest/rest.dart
@@ -24,9 +24,9 @@ class Rest extends PlatformObject {
 
   @override
   Future<int?> createPlatformInstance() async {
-    final handle = await invokeRaw<int>(
+    final handle = await invokeWithoutHandle<int>(
       PlatformMethod.createRest,
-      AblyMessage(message: options),
+      options,
     );
     _restInstances[handle] = this;
     return handle;

--- a/lib/src/platform/src/rest/rest.dart
+++ b/lib/src/platform/src/rest/rest.dart
@@ -24,10 +24,9 @@ class Rest extends PlatformObject {
 
   @override
   Future<int?> createPlatformInstance() async {
-    final handle = await invokeWithoutHandle<int>(
-      PlatformMethod.createRest,
-      options,
-    );
+    final handle = await invokeWithoutHandle<int>(PlatformMethod.createRest, {
+      TxTransportKeys.options: options,
+    });
     _restInstances[handle] = this;
     return handle;
   }

--- a/lib/src/platform/src/rest/rest_channels.dart
+++ b/lib/src/platform/src/rest/rest_channels.dart
@@ -18,7 +18,9 @@ class RestChannels extends Channels<RestChannel> {
 
   @override
   void release(String name) {
-    _rest.invoke(PlatformMethod.releaseRestChannel, name);
+    _rest.invoke(PlatformMethod.releaseRestChannel, {
+      TxTransportKeys.channelName: name,
+    });
     super.release(name);
   }
 }


### PR DESCRIPTION
This should resolve https://github.com/ably/ably-flutter/issues/359. In scope of this pull request:
* All parameters passed to platform instances are now wrapped in AblyMessage. This makes it easier to handle them on native side, and the communication from Dart to platform SDKs is more consistent
* Parameters of platform methods are now always a Map of values. Previously, these methods accepted `Object` which led to inconsistent behavior (for example, `Crypto.generateRandomKey` did not use a map with the generated `TxCryptoGenerateRandomKey.keyLength` value, but rather passed a raw `int` value)
* `invoke` method was altered to allow passing `handle` value besides the parameters, and `invokeRaw` was removed, since it became unnecessary. 