### PR TITLE
Fixed iOS push module compilation issue on some versions of XCode

### DIFF
--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -180,6 +180,9 @@ public class PushHandlers: NSObject {
     /// This function will callback the with the push channel for the channelName and client handle you provide.
     private static func getPushChannel(ably: AblyFlutter, call: FlutterMethodCall, result: @escaping FlutterResult) -> ARTPushChannel? {
         let ablyMessage = call.arguments as! AblyFlutterMessage
+
+        /// Using `guard let handle` in that case caused compilation errors for some users
+        /// See https://github.com/ably/ably-flutter/issues/347 for more information and
         let optionalHandle: NSNumber? = ablyMessage.handle
         var optionalChannelName: String?
         

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UserNotifications
 
 public class PushHandlers: NSObject {
     @objc
@@ -26,7 +27,7 @@ public class PushHandlers: NSObject {
 
     @objc
     public static let getNotificationSettings: (_ ably: AblyFlutter, _ call: FlutterMethodCall, _ result: @escaping (_ result: Any?) -> Void) -> Void = { ably, call, result in
-        UNUserNotificationCenter.current().getNotificationSettings { [result] settings in
+        UNUserNotificationCenter.current().getNotificationSettings { settings in
             result(settings)
         }
     }

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -180,26 +180,27 @@ public class PushHandlers: NSObject {
     private static func getPushChannel(ably: AblyFlutter, call: FlutterMethodCall, result: @escaping FlutterResult) -> ARTPushChannel? {
         let ablyMessage = call.arguments as! AblyFlutterMessage
         let handle: NSNumber? = ablyMessage.handle
-        var channelName: String? = nil
+        var channelName: String?
+        
         if let dataMap = ablyMessage.message as? Dictionary<String, Any> {
             channelName = dataMap[TxTransportKeys_channelName] as? String
         }
 
-        guard let handle = handle else {
+        guard let handleUnwrapped: NSNumber = handle else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "clientHandle was null", details: nil))
             return nil
         }
-        guard let channelName = channelName else {
+        guard let channelNameUnwrapped: String = channelName else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "channelName was null", details: nil))
             return nil
         }
 
         let instanceStore = ably.instanceStore
-        let realtime = instanceStore.realtime(from: handle)
+        let realtime = instanceStore.realtime(from: handleUnwrapped)
         if let realtime = realtime {
-            return realtime.channels.get(channelName).push
-        } else if let rest = instanceStore.rest(from: handle) {
-            return rest.channels.get(channelName).push
+            return realtime.channels.get(channelNameUnwrapped).push
+        } else if let rest = instanceStore.rest(from: handleUnwrapped) {
+            return rest.channels.get(channelNameUnwrapped).push
         } else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "No ably client (rest or realtime) exists for that handle.", details: nil))
             return nil

--- a/ios/Classes/handlers/PushHandlers.swift
+++ b/ios/Classes/handlers/PushHandlers.swift
@@ -180,28 +180,28 @@ public class PushHandlers: NSObject {
     /// This function will callback the with the push channel for the channelName and client handle you provide.
     private static func getPushChannel(ably: AblyFlutter, call: FlutterMethodCall, result: @escaping FlutterResult) -> ARTPushChannel? {
         let ablyMessage = call.arguments as! AblyFlutterMessage
-        let handle: NSNumber? = ablyMessage.handle
-        var channelName: String?
+        let optionalHandle: NSNumber? = ablyMessage.handle
+        var optionalChannelName: String?
         
         if let dataMap = ablyMessage.message as? Dictionary<String, Any> {
-            channelName = dataMap[TxTransportKeys_channelName] as? String
+            optionalChannelName = dataMap[TxTransportKeys_channelName] as? String
         }
 
-        guard let handleUnwrapped: NSNumber = handle else {
+        guard let handle: NSNumber = optionalHandle else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "clientHandle was null", details: nil))
             return nil
         }
-        guard let channelNameUnwrapped: String = channelName else {
+        guard let channelName: String = optionalChannelName else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "channelName was null", details: nil))
             return nil
         }
 
         let instanceStore = ably.instanceStore
-        let realtime = instanceStore.realtime(from: handleUnwrapped)
+        let realtime = instanceStore.realtime(from: handle)
         if let realtime = realtime {
-            return realtime.channels.get(channelNameUnwrapped).push
-        } else if let rest = instanceStore.rest(from: handleUnwrapped) {
-            return rest.channels.get(channelNameUnwrapped).push
+            return realtime.channels.get(channelName).push
+        } else if let rest = instanceStore.rest(from: handle) {
+            return rest.channels.get(channelName).push
         } else {
             result(FlutterError(code: "getAblyPushChannel_error", message: "No ably client (rest or realtime) exists for that handle.", details: nil))
             return nil


### PR DESCRIPTION
This should solve https://github.com/ably/ably-flutter/issues/347. Apparently, for some combinations of Swift/XCode versions the compiler doesn't correctly recognize the `let guard` statements, which leads to `handle` and `channelName` being identified as nullable types, although they are guarded by specific checks before they are used. I've made a non-nullable, unwrapped versions of those variables to avoid those compilation errors.