### PR TITLE
Updated documentation URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,7 +324,7 @@ This is a preview release of v1.2.2, which adds support for push notifications, 
 
 With this release we are conforming our version numbering to match that used in our other client libraries.
 This reflects the fact that this plugin is heading towards compliance with version 1.2 of our
-[Features Specification](https://docs.ably.io/client-lib-development-guide/features/), also aligning with the
+[Features Specification](https://ably.com/docs/client-lib-development-guide/features), also aligning with the
 underlying implementations of
 [ably-cocoa](https://github.com/ably/ably-cocoa)
 and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,7 +324,7 @@ This is a preview release of v1.2.2, which adds support for push notifications, 
 
 With this release we are conforming our version numbering to match that used in our other client libraries.
 This reflects the fact that this plugin is heading towards compliance with version 1.2 of our
-[Features Specification](https://ably.com/docs/client-lib-development-guide/features), also aligning with the
+[Features Specification](https://docs.ably.com/client-lib-development-guide/features), also aligning with the
 underlying implementations of
 [ably-cocoa](https://github.com/ably/ably-cocoa)
 and

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![.github/workflows/docs.yml](https://github.com/ably/ably-flutter/actions/workflows/docs.yml/badge.svg)](https://github.com/ably/ably-flutter/actions/workflows/docs.yml)
 [![.github/workflows/flutter_integration.yaml](https://github.com/ably/ably-flutter/actions/workflows/flutter_integration.yaml/badge.svg)](https://github.com/ably/ably-flutter/actions/workflows/flutter_integration.yaml)
 
-_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/documentation)._
+_[Ably](https://ably.com) is the platform that powers synchronized digital experiences in realtime. Whether attending an event in a virtual venue, receiving realtime financial information, or monitoring live car performance data – consumers simply expect realtime digital experiences as standard. Ably provides a suite of APIs to build, extend, and deliver powerful digital experiences in realtime for more than 250 million devices across 80 countries each month. Organizations like Bloomberg, HubSpot, Verizon, and Hopin depend on Ably’s platform to offload the growing complexity of business-critical realtime data synchronization at global scale. For more information, see the [Ably documentation](https://ably.com/docs)._
 
 ## Overview
 
@@ -13,7 +13,7 @@ built on top of Ably's [iOS](https://github.com/ably/ably-cocoa) and [Android](h
 
 ## Resources
 
-- [Quickstart Guide](https://www.ably.com/documentation/quick-start-guide?lang=flutter)
+- [Quickstart Guide](https://www.ably.com/docs/quick-start-guide?lang=flutter)
 - [Introducing the Ably Flutter plugin](https://www.ably.com/blog/ably-flutter-plugin) by [Srushtika](https://github.com/Srushtika) (Developer Advocate)
 - [Building a Realtime Cryptocurrency App with Flutter](https://www.ably.com/tutorials/realtime-cryptocurrency-app-flutter) by [pr-Mais](https://github.com/pr-Mais) and [escamoteur](https://github.com/escamoteur)
 - [Building realtime apps with Flutter and WebSockets: client-side considerations](https://www.ably.com/topic/websockets-flutter)
@@ -124,9 +124,9 @@ import 'package:ably_flutter/ably_flutter.dart' as ably;
 
 ### Configure a Client Options object
 
-For guidance on selecting an authentication method (basic authentication vs. token authentication), read [Selecting an authentication mechanism](https://ably.com/documentation/core-features/authentication/#selecting-auth).
+For guidance on selecting an authentication method (basic authentication vs. token authentication), read [Selecting an authentication mechanism](https://ably.com/docs/core-features/authentication/#selecting-auth).
 
-Authenticating using [basic authentication/ API key](https://ably.com/documentation/core-features/authentication/#basic-authentication) (for running example app/ test apps and not for production)
+Authenticating using [basic authentication/ API key](https://ably.com/docs/core-features/authentication/#basic-authentication) (for running example app/ test apps and not for production)
 
 ```dart
 // Specify your apiKey with `flutter run --dart-define=ABLY_API_KEY=replace_your_api_key`
@@ -135,7 +135,7 @@ final clientOptions = ably.ClientOptions(key: ablyApiKey);
 clientOptions.logLevel = ably.LogLevel.verbose;  // optional
 ```
 
-Authenticating using [token authentication](https://ably.com/documentation/core-features/authentication/#token-authentication)
+Authenticating using [token authentication](https://ably.com/docs/core-features/authentication/#token-authentication)
 
 ```dart
 // Used to create a clientId when a client first doesn't have one. 
@@ -555,7 +555,7 @@ channel
 
 ### Symmetric Encryption
 
-When a key is provided to the library, the `data` attribute of all messages is encrypted and decrypted automatically using that key. The secret key is never transmitted to Ably. See https://www.ably.com/documentation/realtime/encryption.
+When a key is provided to the library, the `data` attribute of all messages is encrypted and decrypted automatically using that key. The secret key is never transmitted to Ably. See https://www.ably.com/docs/realtime/encryption.
 
 1. Create a key by calling `ably.Crypto.generateRandomKey()` (or retrieve one from your server using your own secure API). The same key needs to be used to encrypt and decrypt the messages.
 2. Create a `CipherParams` instance by passing a key to `final cipherParams = await ably.Crypto.getDefaultParams(key: key);` - the key can be a Base64-encoded `String`, or a `Uint8List`

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -123,7 +123,7 @@ class Realtime extends PlatformObject {
   /// represents the current state of the device in respect of it being a
   /// target for push notifications.
   ///
-  /// https://docs.ably.io/client-lib-development-guide/features/#RSH8
+  /// https://ably.com/docs/client-lib-development-guide/features/#RSH8
   Future<LocalDevice> device() async =>
       invokeRequest<LocalDevice>(PlatformMethod.pushDevice);
 }

--- a/lib/src/platform/src/realtime/realtime.dart
+++ b/lib/src/platform/src/realtime/realtime.dart
@@ -123,7 +123,7 @@ class Realtime extends PlatformObject {
   /// represents the current state of the device in respect of it being a
   /// target for push notifications.
   ///
-  /// https://ably.com/docs/client-lib-development-guide/features/#RSH8
+  /// https://docs.ably.com/client-lib-development-guide/features/#RSH8
   Future<LocalDevice> device() async =>
       invokeRequest<LocalDevice>(PlatformMethod.pushDevice);
 }

--- a/lib/src/platform/src/rest/rest.dart
+++ b/lib/src/platform/src/rest/rest.dart
@@ -76,13 +76,13 @@ class Rest extends PlatformObject {
 
   /// collection of [RestChannel] instances
   ///
-  /// https://docs.ably.com/client-lib-development-guide/features/#RSN1
+  /// https://ably.com/docs/client-lib-development-guide/features/#RSN1
   late RestChannels channels;
 
   /// represents the current state of the device in respect of it being a
   /// target for push notifications.
   ///
-  /// https://docs.ably.io/client-lib-development-guide/features/#RSH8
+  /// https://ably.com/docs/client-lib-development-guide/features/#RSH8
   Future<LocalDevice> device() async =>
       invokeRequest<LocalDevice>(PlatformMethod.pushDevice);
 }

--- a/lib/src/platform/src/rest/rest.dart
+++ b/lib/src/platform/src/rest/rest.dart
@@ -76,13 +76,13 @@ class Rest extends PlatformObject {
 
   /// collection of [RestChannel] instances
   ///
-  /// https://ably.com/docs/client-lib-development-guide/features/#RSN1
+  /// https://docs.ably.com/client-lib-development-guide/features/#RSN1
   late RestChannels channels;
 
   /// represents the current state of the device in respect of it being a
   /// target for push notifications.
   ///
-  /// https://ably.com/docs/client-lib-development-guide/features/#RSH8
+  /// https://docs.ably.com/client-lib-development-guide/features/#RSH8
   Future<LocalDevice> device() async =>
       invokeRequest<LocalDevice>(PlatformMethod.pushDevice);
 }

--- a/lib/src/platform/src/rest/rest_channels.dart
+++ b/lib/src/platform/src/rest/rest_channels.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 
 /// A collection of rest channel objects
 ///
-/// https://docs.ably.io/client-lib-development-guide/features/#RSN1
+/// https://ably.com/docs/client-lib-development-guide/features/#RSN1
 class RestChannels extends Channels<RestChannel> {
   final Rest _rest;
 

--- a/lib/src/platform/src/rest/rest_channels.dart
+++ b/lib/src/platform/src/rest/rest_channels.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 
 /// A collection of rest channel objects
 ///
-/// https://ably.com/docs/client-lib-development-guide/features/#RSN1
+/// https://docs.ably.com/client-lib-development-guide/features/#RSN1
 class RestChannels extends Channels<RestChannel> {
   final Rest _rest;
 

--- a/lib/src/push_notifications/src/local_device.dart
+++ b/lib/src/push_notifications/src/local_device.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 /// Current state of the device in respect of it being a target for
 /// push notifications.
 ///
-/// https://docs.ably.io/client-lib-development-guide/features/#RSH8
+/// https://ably.com/docs/client-lib-development-guide/features/#RSH8
 @immutable
 class LocalDevice extends DeviceDetails {
   /// Device token. Generated locally, if not available.

--- a/lib/src/push_notifications/src/local_device.dart
+++ b/lib/src/push_notifications/src/local_device.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta.dart';
 /// Current state of the device in respect of it being a target for
 /// push notifications.
 ///
-/// https://ably.com/docs/client-lib-development-guide/features/#RSH8
+/// https://docs.ably.com/client-lib-development-guide/features/#RSH8
 @immutable
 class LocalDevice extends DeviceDetails {
   /// Device token. Generated locally, if not available.

--- a/lib/src/push_notifications/src/push_channel.dart
+++ b/lib/src/push_notifications/src/push_channel.dart
@@ -58,7 +58,7 @@ class PushChannel extends PlatformObject {
   ///
   /// as [PushChannelSubscription] objects encapsulated in a paginated result.
   /// Optional filters can be passed as a [params] map. These filters include
-  /// [channel, deviceId, clientId and limit](https://docs.ably.io/rest-api/#list-channel-subscriptions).
+  /// [channel, deviceId, clientId and limit](https://ably.com/docs/rest-api/#list-channel-subscriptions).
   ///
   /// Requires Push Admin capability
   ///


### PR DESCRIPTION
This should resolve #368. Following information I got, I've updated all URLs in the documentation to use `ably.com/docs` instead of `ably.io/documentation`. I've also updated all `client-lib-development-guide` URLs from `docs.ably.io` to `docs.ably.com`