### PR TITLE
Lint rule to disable implicit dynamic values

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ However, using a neat little workaround will fix this...
 Instead of `await subscriptionToBeCancelled.cancel();`, use
 
 ```dart
-Future.delayed(Duration.zero, () {
+Future<void>.delayed(Duration.zero, () {
     subscriptionToBeCancelled.cancel();
 });
 ```

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,15 +1,14 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
-
-  strong-mode:
-    implicit-casts: false
-# TODO(zoechi) conflicts with some other rules and is subject to be reworked
-# https://github.com/dart-lang/sdk/issues/33749
-# but in general a useful setting to be enabled eventually
-#    implicit-dynamic: false
-
+  # Templates for code generation can be excluded from analysis
+  exclude:
+    - bin/templates/**
   language:
+    # Replacements for deprecated implicit-casts: false
+    # Following https://dart.dev/guides/language/analysis-options#enabling-additional-type-checks
+    strict-casts: true
+    strict-inference: true
     strict-raw-types: true
 
 linter:
@@ -38,7 +37,6 @@ linter:
     - always_declare_return_types
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
-    - avoid_annotating_with_dynamic
     - avoid_bool_literals_in_conditional_expressions
     - avoid_catches_without_on_clauses
     - avoid_catching_errors
@@ -61,7 +59,6 @@ linter:
     - avoid_setters_without_getters
     - avoid_shadowing_type_parameters
     - avoid_single_cascade_in_expression_statements
-    - avoid_types_on_closure_parameters
     - avoid_void_async
     - await_only_futures
     - cascade_invocations

--- a/example/lib/nested_realtime_events.dart
+++ b/example/lib/nested_realtime_events.dart
@@ -21,7 +21,7 @@ void listenRealtimeConnection(ably.Realtime realtime) {
 
   //DISPOSE ON CONNECTED
   final stream = realtime.connection.on();
-  late StreamSubscription omegaSubscription;
+  late StreamSubscription<ably.ConnectionStateChange> omegaSubscription;
   omegaSubscription = stream.listen((stateChange) async {
     print('DISPOSABLE LISTENER ω :: Change event arrived!:'
         ' ${stateChange.event}');
@@ -44,8 +44,8 @@ void listenRealtimeConnection(ably.Realtime realtime) {
     });
   });
 
-  StreamSubscription preZetaSubscription;
-  late StreamSubscription postZetaSubscription;
+  StreamSubscription<ably.ConnectionStateChange> preZetaSubscription;
+  late StreamSubscription<ably.ConnectionStateChange> postZetaSubscription;
   preZetaSubscription = realtime.connection.on().listen((stateChange) {
     //This listener "pre ζ" will be cancelled from γ
     print('NESTED LISTENER "pre ζ": ${stateChange.event}');

--- a/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
+++ b/example/lib/ui/push_notifications/push_notifications_activation_sliver.dart
@@ -18,7 +18,7 @@ class PushNotificationsActivationSliver extends HookWidget {
 
   Future<void> showErrorDialog(
       BuildContext context, ably.AblyException error) async {
-    await showDialog(
+    await showDialog<void>(
       context: context,
       builder: (context) => AlertDialog(
         title: const Text('Push notification error'),

--- a/example/lib/ui/realtime_presence_sliver.dart
+++ b/example/lib/ui/realtime_presence_sliver.dart
@@ -1,9 +1,8 @@
 import 'dart:async';
 
-import 'package:ably_flutter/src/platform/src/realtime/realtime.dart';
+import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/constants.dart';
 import 'package:ably_flutter_example/ui/paginated_result_viewer.dart';
-import 'package:ably_flutter/ably_flutter.dart' as ably;
 import 'package:ably_flutter_example/ui/text_row.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
@@ -12,14 +11,16 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 class RealtimePresenceSliver extends HookWidget {
   final ably.Realtime realtime;
   final ably.RealtimeChannel channel;
-  final List<StreamSubscription> _subscriptions = [];
+  final List<StreamSubscription<ably.PresenceMessage?>> _subscriptions = [];
 
   RealtimePresenceSliver(this.realtime, this.channel);
 
   Widget createChannelPresenceSubscribeButton(
-          ValueNotifier<ably.PresenceMessage?> latestMessage,
-          ably.ChannelState? channelState,
-          ValueNotifier<StreamSubscription?> presenceSubscription) =>
+    ValueNotifier<ably.PresenceMessage?> latestMessage,
+    ably.ChannelState? channelState,
+    ValueNotifier<StreamSubscription<ably.PresenceMessage?>?>
+        presenceSubscription,
+  ) =>
       TextButton(
         onPressed: (channelState == ably.ChannelState.attached &&
                 presenceSubscription.value == null)
@@ -37,7 +38,9 @@ class RealtimePresenceSliver extends HookWidget {
       );
 
   Widget createChannelPresenceUnsubscribeButton(
-          ValueNotifier<StreamSubscription?> presenceSubscription) =>
+    ValueNotifier<StreamSubscription<ably.PresenceMessage?>?>
+        presenceSubscription,
+  ) =>
       TextButton(
         onPressed: (presenceSubscription.value != null)
             ? () async {
@@ -58,7 +61,7 @@ class RealtimePresenceSliver extends HookWidget {
         child: const Text('Get Realtime presence members'),
       );
 
-  final List _presenceData = [
+  final List<dynamic> _presenceData = [
     null,
     1,
     'hello',

--- a/example/lib/ui/realtime_sliver.dart
+++ b/example/lib/ui/realtime_sliver.dart
@@ -15,7 +15,7 @@ class RealtimeSliver extends HookWidget {
   final AblyService ablyService;
   final ably.Realtime realtime;
   late ably.RealtimeChannel channel;
-  List<StreamSubscription> _subscriptions = [];
+  List<StreamSubscription<dynamic>> _subscriptions = [];
 
   RealtimeSliver(this.ablyService, {Key? key})
       : realtime = ablyService.realtime,
@@ -84,7 +84,7 @@ class RealtimeSliver extends HookWidget {
       );
 
   Widget buildChannelUnsubscribeButton(
-          ValueNotifier<StreamSubscription?> channelSubscription) =>
+          ValueNotifier<StreamSubscription<dynamic>?> channelSubscription) =>
       TextButton(
         onPressed: (channelSubscription.value != null)
             ? () async {

--- a/lib/src/common/src/http_paginated_response.dart
+++ b/lib/src/common/src/http_paginated_response.dart
@@ -12,8 +12,9 @@ abstract class HttpPaginatedResponse<T> extends PaginatedResult<T> {
   ///
   /// Sets appropriate [_pageHandle] for identifying platform side of this
   /// result object so that [next] and [first] can be executed
-  HttpPaginatedResponse.fromAblyMessage(AblyMessage<PaginatedResult> message)
-      : super.fromAblyMessage(message);
+  HttpPaginatedResponse.fromAblyMessage(
+    AblyMessage<PaginatedResult<dynamic>> message,
+  ) : super.fromAblyMessage(message);
 
   /// HTTP status code for the response
   ///

--- a/lib/src/crypto/src/crypto.dart
+++ b/lib/src/crypto/src/crypto.dart
@@ -23,7 +23,7 @@ class Crypto {
   ///  If you have a password, do not use it directly, instead you should
   ///  derive a key from this password, for example by using a key derivation
   ///  function (KDF) such as PBKDF2.
-  static Future<CipherParams> getDefaultParams({required key}) async {
+  static Future<CipherParams> getDefaultParams({required dynamic key}) async {
     if (key is String) {
       ensureSupportedKeyLength(base64Decode(key));
     } else if (key is Uint8List) {
@@ -59,8 +59,9 @@ class Crypto {
   ///
   /// Warning: If you create a random key and encrypt messages without sharing
   /// this key with other clients, there is no way to decrypt the messages.
-  static Future<Uint8List> generateRandomKey(
-          {keyLength = defaultKeyLengthInBits}) =>
+  static Future<Uint8List> generateRandomKey({
+    int keyLength = defaultKeyLengthInBits,
+  }) =>
       Platform().invokePlatformMethodNonNull<Uint8List>(
         PlatformMethod.cryptoGenerateRandomKey,
         AblyMessage(message: {

--- a/lib/src/message/src/delta_extras.dart
+++ b/lib/src/message/src/delta_extras.dart
@@ -14,7 +14,7 @@ class DeltaExtras with ObjectHash {
 
   /// create instance from a map
   @protected
-  DeltaExtras.fromMap(Map value)
+  DeltaExtras.fromMap(Map<String, dynamic> value)
       : format = value[TxDeltaExtras.format] as String?,
         from = value[TxDeltaExtras.from] as String?;
 

--- a/lib/src/message/src/message.dart
+++ b/lib/src/message/src/message.dart
@@ -30,7 +30,7 @@ class Message with ObjectHash {
   /// Any transformation applied to the data for this message
   final String? encoding;
 
-  final MessageData? _data;
+  final MessageData<dynamic>? _data;
 
   /// Message payload
   ///

--- a/lib/src/message/src/message_data.dart
+++ b/lib/src/message/src/message_data.dart
@@ -12,7 +12,7 @@ class MessageData<T> {
   T get data => _data;
 
   /// initializes [MessageData] with given value and asserts from input type
-  static MessageData? fromValue(Object? value) {
+  static MessageData<dynamic>? fromValue(Object? value) {
     if (value == null) {
       return null;
     }
@@ -28,11 +28,11 @@ class MessageData<T> {
     if (value is MessageData) {
       return value;
     } else if (value is Map) {
-      return MessageData<Map>(value);
+      return MessageData<Map<dynamic, dynamic>>(value);
     } else if (value is Uint8List) {
       return MessageData<Uint8List>(value);
     } else if (value is List) {
-      return MessageData<List>(value);
+      return MessageData<List<dynamic>>(value);
     } else if (value is String) {
       return MessageData<String>(value);
     } else {

--- a/lib/src/message/src/message_extras.dart
+++ b/lib/src/message/src/message_extras.dart
@@ -45,7 +45,7 @@ class MessageExtras with ObjectHash {
   @override
   bool operator ==(Object other) =>
       other is MessageExtras &&
-      const MapEquality().equals(other.map, map) &&
+      const MapEquality<String, dynamic>().equals(other.map, map) &&
       other.delta == delta;
 
   @override

--- a/lib/src/message/src/message_extras.dart
+++ b/lib/src/message/src/message_extras.dart
@@ -31,7 +31,8 @@ class MessageExtras with ObjectHash {
     extrasMap = Map.castFrom<dynamic, dynamic, String, dynamic>(
       json.decode(json.encode(extrasMap)) as Map,
     );
-    final deltaMap = extrasMap.remove(TxMessageExtras.delta) as Map?;
+    final deltaMap =
+        extrasMap.remove(TxMessageExtras.delta) as Map<String, dynamic>?;
     return MessageExtras._withDelta(
       extrasMap,
       (deltaMap == null) ? null : DeltaExtras.fromMap(deltaMap),

--- a/lib/src/message/src/presence_message.dart
+++ b/lib/src/message/src/presence_message.dart
@@ -26,7 +26,7 @@ class PresenceMessage with ObjectHash {
   /// https://docs.ably.com/client-lib-development-guide/features/#TP3d
   final String? connectionId;
 
-  final MessageData? _data;
+  final MessageData<dynamic>? _data;
 
   /// Message payload
   ///

--- a/lib/src/platform/src/background_android_isolate_platform.dart
+++ b/lib/src/platform/src/background_android_isolate_platform.dart
@@ -45,6 +45,6 @@ class BackgroundIsolateAndroidPlatform {
     _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
   }
 
-  Future<T?> invokeMethod<T>(String method, [arguments]) async =>
+  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async =>
       _methodChannel.invokeMethod<T>(method, arguments);
 }

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -39,7 +39,7 @@ class AblyMethodCallHandler {
   }
 
   /// handles auth callback for rest instances
-  Future<Object> onAuthCallback(AblyMessage message) async {
+  Future<Object> onAuthCallback(AblyMessage<dynamic> message) async {
     final tokenParams = message.message as TokenParams;
     final rest = restInstances[message.handle];
     if (rest == null) {
@@ -52,7 +52,7 @@ class AblyMethodCallHandler {
   }
 
   /// handles auth callback for realtime instances
-  Future<Object?> onRealtimeAuthCallback(AblyMessage? message) async {
+  Future<Object?> onRealtimeAuthCallback(AblyMessage<dynamic>? message) async {
     final tokenParams = message!.message as TokenParams;
     final realtime = realtimeInstances[message.handle];
     if (realtime == null) {

--- a/lib/src/platform/src/paginated_result.dart
+++ b/lib/src/platform/src/paginated_result.dart
@@ -39,7 +39,7 @@ class PaginatedResult<T> extends PlatformObject {
   ///
   /// Sets appropriate [_pageHandle] for identifying platform side of this
   /// result object so that [next] and [first] can be executed
-  PaginatedResult.fromAblyMessage(AblyMessage<PaginatedResult> message)
+  PaginatedResult.fromAblyMessage(AblyMessage<PaginatedResult<dynamic>> message)
       : _hasNext = message.message.hasNext(),
         _items = message.message.items.map<T>((e) => e as T).toList(),
         _pageHandle = message.handle,
@@ -53,9 +53,10 @@ class PaginatedResult<T> extends PlatformObject {
   /// If there are no further pages, then null is returned.
   /// https://docs.ably.com/client-lib-development-guide/features/#TG4
   Future<PaginatedResult<T>> next() async {
-    final message = await invokeRequest<AblyMessage>(PlatformMethod.nextPage);
+    final message =
+        await invokeRequest<AblyMessage<dynamic>>(PlatformMethod.nextPage);
     return PaginatedResult<T>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 
@@ -64,9 +65,10 @@ class PaginatedResult<T> extends PlatformObject {
   /// If there are no further pages, then null is returned.
   /// https://docs.ably.com/client-lib-development-guide/features/#TG5
   Future<PaginatedResult<T>> first() async {
-    final message = await invokeRequest<AblyMessage>(PlatformMethod.firstPage);
+    final message =
+        await invokeRequest<AblyMessage<dynamic>>(PlatformMethod.firstPage);
     return PaginatedResult<T>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 

--- a/lib/src/platform/src/push_notification_events_internal.dart
+++ b/lib/src/platform/src/push_notification_events_internal.dart
@@ -58,8 +58,9 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
     if (io.Platform.isAndroid) {
       // Inform Android side that the Flutter application
       // is ready to receive push messages.
-      await BackgroundIsolateAndroidPlatform().invokeMethod(
-          PlatformMethod.pushBackgroundFlutterApplicationReadyOnAndroid);
+      await BackgroundIsolateAndroidPlatform().invokeMethod<void>(
+        PlatformMethod.pushBackgroundFlutterApplicationReadyOnAndroid,
+      );
     }
   }
 

--- a/lib/src/platform/src/realtime/presence.dart
+++ b/lib/src/platform/src/realtime/presence.dart
@@ -22,7 +22,7 @@ class RealtimePresence extends PlatformObject {
   Future<List<PresenceMessage>> get([
     RealtimePresenceParams? params,
   ]) async {
-    final presenceMessages = await invokeRequest<List>(
+    final presenceMessages = await invokeRequest<List<dynamic>>(
       PlatformMethod.realtimePresenceGet,
       {
         TxTransportKeys.channelName: _channel.name,
@@ -42,7 +42,7 @@ class RealtimePresence extends PlatformObject {
   Future<PaginatedResult<PresenceMessage>> history([
     RealtimeHistoryParams? params,
   ]) async {
-    final message = await invokeRequest<AblyMessage>(
+    final message = await invokeRequest<AblyMessage<dynamic>>(
       PlatformMethod.realtimePresenceHistory,
       {
         TxTransportKeys.channelName: _channel.name,
@@ -50,7 +50,7 @@ class RealtimePresence extends PlatformObject {
       },
     );
     return PaginatedResult<PresenceMessage>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 

--- a/lib/src/platform/src/realtime/presence.dart
+++ b/lib/src/platform/src/realtime/presence.dart
@@ -75,7 +75,7 @@ class RealtimePresence extends PlatformObject {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RTP15
   Future<void> enterClient(String clientId, [Object? data]) async {
-    await invoke(PlatformMethod.realtimePresenceEnter, {
+    await invoke<void>(PlatformMethod.realtimePresenceEnter, {
       TxTransportKeys.channelName: _channel.name,
       TxTransportKeys.clientId: clientId,
       if (data != null) TxTransportKeys.data: MessageData.fromValue(data),
@@ -94,7 +94,7 @@ class RealtimePresence extends PlatformObject {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RTP15
   Future<void> updateClient(String clientId, [Object? data]) async {
-    await invoke(PlatformMethod.realtimePresenceUpdate, {
+    await invoke<void>(PlatformMethod.realtimePresenceUpdate, {
       TxTransportKeys.channelName: _channel.name,
       TxTransportKeys.clientId: clientId,
       if (data != null) TxTransportKeys.data: MessageData.fromValue(data),
@@ -113,7 +113,7 @@ class RealtimePresence extends PlatformObject {
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#RTP15
   Future<void> leaveClient(String clientId, [Object? data]) async {
-    await invoke(PlatformMethod.realtimePresenceLeave, {
+    await invoke<void>(PlatformMethod.realtimePresenceLeave, {
       TxTransportKeys.channelName: _channel.name,
       TxTransportKeys.clientId: clientId,
       if (data != null) TxTransportKeys.data: MessageData.fromValue(data),

--- a/lib/src/platform/src/realtime/realtime_channel.dart
+++ b/lib/src/platform/src/realtime/realtime_channel.dart
@@ -66,7 +66,7 @@ class RealtimeChannel extends PlatformObject {
     messages ??= [
       if (message == null) Message(name: name, data: data) else message
     ];
-    await invoke(PlatformMethod.publishRealtimeChannelMessage, {
+    await invoke<void>(PlatformMethod.publishRealtimeChannelMessage, {
       TxTransportKeys.channelName: this.name,
       TxTransportKeys.messages: messages,
     });

--- a/lib/src/platform/src/realtime/realtime_channel.dart
+++ b/lib/src/platform/src/realtime/realtime_channel.dart
@@ -43,13 +43,13 @@ class RealtimeChannel extends PlatformObject {
   Future<PaginatedResult<Message>> history([
     RealtimeHistoryParams? params,
   ]) async {
-    final message =
-        await invokeRequest<AblyMessage>(PlatformMethod.realtimeHistory, {
+    final message = await invokeRequest<AblyMessage<dynamic>>(
+        PlatformMethod.realtimeHistory, {
       TxTransportKeys.channelName: name,
-      if (params != null) TxTransportKeys.params: params
+      if (params != null) TxTransportKeys.params: params,
     });
     return PaginatedResult<Message>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 

--- a/lib/src/platform/src/realtime/realtime_channels.dart
+++ b/lib/src/platform/src/realtime/realtime_channels.dart
@@ -20,7 +20,7 @@ class RealtimeChannels extends Channels<RealtimeChannel> {
   /// so it can be garbage collected.
   @override
   void release(String name) {
-    realtime.invoke(PlatformMethod.releaseRealtimeChannel, {
+    realtime.invoke<void>(PlatformMethod.releaseRealtimeChannel, {
       TxTransportKeys.channelName: name,
     });
     super.release(name);

--- a/lib/src/platform/src/rest/rest_channel.dart
+++ b/lib/src/platform/src/rest/rest_channel.dart
@@ -1,9 +1,7 @@
 import 'dart:async';
-import 'dart:collection';
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
-import 'package:flutter/services.dart';
 
 /// A named channel through with rest client can interact with ably service.
 ///
@@ -45,7 +43,7 @@ class RestChannel extends PlatformObject {
   Future<PaginatedResult<Message>> history([
     RestHistoryParams? params,
   ]) async {
-    final message = await invokeRequest<AblyMessage>(
+    final message = await invokeRequest<AblyMessage<dynamic>>(
       PlatformMethod.restHistory,
       {
         TxTransportKeys.channelName: name,
@@ -53,7 +51,7 @@ class RestChannel extends PlatformObject {
       },
     );
     return PaginatedResult<Message>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 

--- a/lib/src/platform/src/rest/rest_channel.dart
+++ b/lib/src/platform/src/rest/rest_channel.dart
@@ -67,7 +67,7 @@ class RestChannel extends PlatformObject {
     messages ??= [
       if (message == null) Message(name: name, data: data) else message
     ];
-    await invoke(PlatformMethod.publish, {
+    await invoke<void>(PlatformMethod.publish, {
       TxTransportKeys.channelName: this.name,
       TxTransportKeys.messages: messages,
     });

--- a/lib/src/platform/src/rest/rest_channels.dart
+++ b/lib/src/platform/src/rest/rest_channels.dart
@@ -18,7 +18,7 @@ class RestChannels extends Channels<RestChannel> {
 
   @override
   void release(String name) {
-    _rest.invoke(PlatformMethod.releaseRestChannel, {
+    _rest.invoke<void>(PlatformMethod.releaseRestChannel, {
       TxTransportKeys.channelName: name,
     });
     super.release(name);

--- a/lib/src/platform/src/rest/rest_presence.dart
+++ b/lib/src/platform/src/rest/rest_presence.dart
@@ -20,7 +20,7 @@ class RestPresence extends PlatformObject {
   Future<PaginatedResult<PresenceMessage>> get([
     RestPresenceParams? params,
   ]) async {
-    final message = await invokeRequest<AblyMessage>(
+    final message = await invokeRequest<AblyMessage<dynamic>>(
       PlatformMethod.restPresenceGet,
       {
         TxTransportKeys.channelName: _restChannel.name,
@@ -28,7 +28,7 @@ class RestPresence extends PlatformObject {
       },
     );
     return PaginatedResult<PresenceMessage>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 
@@ -38,7 +38,7 @@ class RestPresence extends PlatformObject {
   Future<PaginatedResult<PresenceMessage>> history([
     RestHistoryParams? params,
   ]) async {
-    final message = await invokeRequest<AblyMessage>(
+    final message = await invokeRequest<AblyMessage<dynamic>>(
       PlatformMethod.restPresenceHistory,
       {
         TxTransportKeys.channelName: _restChannel.name,
@@ -46,7 +46,7 @@ class RestPresence extends PlatformObject {
       },
     );
     return PaginatedResult<PresenceMessage>.fromAblyMessage(
-      AblyMessage.castFrom<dynamic, PaginatedResult>(message),
+      AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message),
     );
   }
 }

--- a/lib/src/push_notifications/src/admin/push_admin.dart
+++ b/lib/src/push_notifications/src/admin/push_admin.dart
@@ -16,5 +16,8 @@ abstract class PushAdmin {
   PushChannelSubscriptions? channelSubscriptions;
 
   /// https://docs.ably.com/client-lib-development-guide/features/#RSH1a
-  Future<void> publish(Map<String, dynamic> recipient, Map payload);
+  Future<void> publish(
+    Map<String, dynamic> recipient,
+    Map<String, dynamic> payload,
+  );
 }

--- a/lib/src/push_notifications/src/push_channel.dart
+++ b/lib/src/push_notifications/src/push_channel.dart
@@ -79,12 +79,12 @@ class PushChannel extends PlatformObject {
       );
     }
 
-    final message = await invokeRequest<AblyMessage>(
+    final message = await invokeRequest<AblyMessage<dynamic>>(
       PlatformMethod.pushListSubscriptions,
       {TxTransportKeys.params: params, TxTransportKeys.channelName: _name},
     );
 
     return PaginatedResult<PushChannelSubscription>.fromAblyMessage(
-        AblyMessage.castFrom<dynamic, PaginatedResult>(message));
+        AblyMessage.castFrom<dynamic, PaginatedResult<dynamic>>(message));
   }
 }

--- a/lib/src/realtime/src/realtime_channel_options.dart
+++ b/lib/src/realtime/src/realtime_channel_options.dart
@@ -20,7 +20,7 @@ class RealtimeChannelOptions {
   /// other parameters of [RealtimeChannelOptions].
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TB3
-  static Future<RealtimeChannelOptions> withCipherKey(key) async {
+  static Future<RealtimeChannelOptions> withCipherKey(dynamic key) async {
     final cipherParams = await Crypto.getDefaultParams(key: key);
     return RealtimeChannelOptions(cipherParams: cipherParams);
   }

--- a/lib/src/rest/src/rest_channel_options.dart
+++ b/lib/src/rest/src/rest_channel_options.dart
@@ -11,7 +11,7 @@ class RestChannelOptions {
   /// equivalent to calling the constructor.
   ///
   /// https://docs.ably.com/client-lib-development-guide/features/#TB3
-  static Future<RestChannelOptions> withCipherKey(key) async {
+  static Future<RestChannelOptions> withCipherKey(dynamic key) async {
     final cipherParams = await Crypto.getDefaultParams(key: key);
     return RestChannelOptions(cipherParams: cipherParams);
   }

--- a/test/ably_event_listener_test.dart
+++ b/test/ably_event_listener_test.dart
@@ -49,8 +49,8 @@ void main() {
     final emitter = MockEmitter(3, [1, 2, 3, 4, 5]);
     final streams = emitter.streams;
 
-    StreamSubscription subscriptionPre;
-    late StreamSubscription subscriptionPost;
+    StreamSubscription<dynamic> subscriptionPre;
+    late StreamSubscription<dynamic> subscriptionPost;
 
     subscriptionPre = streams[1].listen(resultsNestedPre.add);
 

--- a/test/ably_event_listener_test.dart
+++ b/test/ably_event_listener_test.dart
@@ -67,7 +67,7 @@ void main() {
     subscriptionPost = streams[2].listen(resultsNestedPost.add);
 
     //Waiting for stream to end
-    await Future.delayed(Duration.zero);
+    await Future<void>.delayed(Duration.zero);
 
     //Checking if data received by stream is same as expected
     expect(

--- a/test/mock_method_call_manager.dart
+++ b/test/mock_method_call_manager.dart
@@ -9,7 +9,7 @@ class MockMethodCallManager {
   int handleCounter = 0;
   bool isAuthenticated = false;
   final channels = <int, ClientOptions?>{};
-  final publishedMessages = <AblyMessage>[];
+  final publishedMessages = <AblyMessage<dynamic>>[];
 
   MockMethodCallManager() {
     final channel =

--- a/test/realtime/channel_test.dart
+++ b/test/realtime/channel_test.dart
@@ -35,7 +35,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -63,7 +63,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -98,7 +98,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -125,7 +125,7 @@ void main() {
       final message0 = manager.publishedMessages[0];
       final messageData0 = message0.message as Map<dynamic, dynamic>;
       expect(messageData0[TxTransportKeys.channelName], 'test');
-      expect(messageData0[TxTransportKeys.messages], isA<List>());
+      expect(messageData0[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData0[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -134,7 +134,7 @@ void main() {
       final message1 = manager.publishedMessages[1];
       final messageData1 = message1.message as Map<dynamic, dynamic>;
       expect(messageData1[TxTransportKeys.channelName], 'test');
-      expect(messageData1[TxTransportKeys.messages], isA<List>());
+      expect(messageData1[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages1 =
           List<Message>.from(messageData1[TxTransportKeys.messages] as List);
       expect(messages1[0].name, 'name');

--- a/test/rest/channel_test.dart
+++ b/test/rest/channel_test.dart
@@ -33,7 +33,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -60,7 +60,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -96,7 +96,7 @@ void main() {
       final firstMessage = manager.publishedMessages.first;
       final messageData = firstMessage.message as Map<dynamic, dynamic>;
       expect(messageData[TxTransportKeys.channelName], 'test');
-      expect(messageData[TxTransportKeys.messages], isA<List>());
+      expect(messageData[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -123,7 +123,7 @@ void main() {
       final message0 = manager.publishedMessages[0];
       final messageData0 = message0.message as Map<dynamic, dynamic>;
       expect(messageData0[TxTransportKeys.channelName], 'test');
-      expect(messageData0[TxTransportKeys.messages], isA<List>());
+      expect(messageData0[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages =
           List<Message>.from(messageData0[TxTransportKeys.messages] as List);
       expect(messages[0].name, 'name');
@@ -132,7 +132,7 @@ void main() {
       final message1 = manager.publishedMessages[1];
       final messageData1 = message1.message as Map<dynamic, dynamic>;
       expect(messageData1[TxTransportKeys.channelName], 'test');
-      expect(messageData1[TxTransportKeys.messages], isA<List>());
+      expect(messageData1[TxTransportKeys.messages], isA<List<dynamic>>());
       final messages2 =
           List<Message>.from(messageData1[TxTransportKeys.messages] as List);
       expect(messages2[0].name, 'name');

--- a/test_integration/ios/Flutter/AppFrameworkInfo.plist
+++ b/test_integration/ios/Flutter/AppFrameworkInfo.plist
@@ -21,6 +21,6 @@
   <key>CFBundleVersion</key>
   <string>1.0</string>
   <key>MinimumOSVersion</key>
-  <string>8.0</string>
+  <string>9.0</string>
 </dict>
 </plist>

--- a/test_integration/ios/Runner.xcodeproj/project.pbxproj
+++ b/test_integration/ios/Runner.xcodeproj/project.pbxproj
@@ -155,7 +155,7 @@
 		97C146E61CF9000F007C117D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1020;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					97C146ED1CF9000F007C117D = {

--- a/test_integration/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/test_integration/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1020"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/test_integration/lib/driver_data_handler.dart
+++ b/test_integration/lib/driver_data_handler.dart
@@ -31,9 +31,10 @@ class TestControlMessage {
   final Map<String, dynamic>? payload;
 
   factory TestControlMessage.fromJsonEncoded(String encoded) =>
-      TestControlMessage.fromJson(json.decode(encoded) as Map);
+      TestControlMessage.fromJson(json.decode(encoded) as Map<String, dynamic>);
 
-  factory TestControlMessage.fromJson(Map jsonValue) => TestControlMessage(
+  factory TestControlMessage.fromJson(Map<String, dynamic> jsonValue) =>
+      TestControlMessage(
         jsonValue[testNameKey] as String,
         payload: jsonValue[payloadKey] as Map<String, dynamic>?,
       );
@@ -66,9 +67,11 @@ class TestControlResponseMessage {
   final List<dynamic> log;
 
   factory TestControlResponseMessage.fromJsonEncoded(String encoded) =>
-      TestControlResponseMessage.fromJson(json.decode(encoded) as Map);
+      TestControlResponseMessage.fromJson(
+        json.decode(encoded) as Map<String, dynamic>,
+      );
 
-  factory TestControlResponseMessage.fromJson(Map jsonValue) =>
+  factory TestControlResponseMessage.fromJson(Map<String, dynamic> jsonValue) =>
       TestControlResponseMessage(
         jsonValue[testNameKey] as String,
         payload: jsonValue[payloadKey] as Map<String, dynamic>,

--- a/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_encrypted_publish_test.dart
@@ -65,7 +65,7 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
   await encryptedChannel.publish(name: 'name');
   await encryptedChannel.publish(data: 'data');
   await encryptedChannel.publish(name: 'name', data: 'data');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send single message object
   await encryptedChannel.publish(
@@ -74,14 +74,14 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
       data: 'single-message-data',
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send multiple message objects at once
   await encryptedChannel.publish(messages: [
     Message(name: 'multi-message-name-1', data: 'multi-message-data-1'),
     Message(name: 'multi-message-name-2', data: 'multi-message-data-2'),
   ]);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send message with [clientId] defined
   await encryptedChannel.publish(
@@ -91,7 +91,7 @@ Future<Map<String, dynamic>> testRealtimeEncryptedPublishSpec({
       clientId: clientId,
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Retrieve history of channel where client id was specified
   final historyOfEncryptedChannel = await getHistory(

--- a/test_integration/lib/test/realtime/realtime_events_test.dart
+++ b/test_integration/lib/test/realtime/realtime_events_test.dart
@@ -71,9 +71,9 @@ Future<Map<String, dynamic>> testRealtimeEvents({
   recordConnectionState(); // connection: connected
   reporter.reportLog({'before connection.close': ''});
   await realtime.close();
-  await Future.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
   while (realtime.connection.state != ConnectionState.closed) {
-    await Future.delayed(TestConstants.publishToHistoryDelay);
+    await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   }
   recordChannelState(); // channel: detached
   recordConnectionState(); // connection: closed

--- a/test_integration/lib/test/realtime/realtime_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_history_test.dart
@@ -25,39 +25,39 @@ Future<Map<String, dynamic>> testRealtimeHistory({
 
   final paginatedResult = await channel.history();
   final historyDefault = await getHistory(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit4 = await getHistory(
     channel,
     RealtimeHistoryParams(limit: 4),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit2 = await getHistory(
     channel,
     RealtimeHistoryParams(limit: 2),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyForwardLimit4 = await getHistory(
     channel,
     RealtimeHistoryParams(direction: 'forwards', limit: 4),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time1 = DateTime.now();
   //TODO(tiholic) iOS fails without this delay
   // - timestamp on message retrieved from history
   // is earlier than expected when ran in CI
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(name: 'history', data: 'test');
   //TODO(tiholic) understand why tests fail without this delay
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time2 = DateTime.now();
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(name: 'history', data: 'test2');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyWithStart = await getHistory(
     channel,

--- a/test_integration/lib/test/realtime/realtime_presence_get.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_get.dart
@@ -36,16 +36,16 @@ Future<Map<String, dynamic>> testRealtimePresenceGet({
     ).channels.get('test').presence.enter(messagesToPublish[i][1]);
   }
 
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersDefault = await getPresenceMembers(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersClientId = await getPresenceMembers(
     channel,
     RealtimePresenceParams(clientId: 'client-1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // TODO(tiholic) extract connection ID from realtime instance
   //  after implementing `id` update on connection object from platform
@@ -54,7 +54,7 @@ Future<Map<String, dynamic>> testRealtimePresenceGet({
     channel,
     RealtimePresenceParams(connectionId: 'connection-1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   return {
     'handle': await realtime.handle,

--- a/test_integration/lib/test/realtime/realtime_presence_history_test.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_history_test.dart
@@ -37,39 +37,39 @@ Future<Map<String, dynamic>> testRealtimePresenceHistory({
   await realtimePresence.leave(messagesToPublish.last[1]);
 
   final historyDefault = await getPresenceHistory(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit4 = await getPresenceHistory(
     channel,
     RealtimeHistoryParams(limit: 4),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit2 = await getPresenceHistory(
     channel,
     RealtimeHistoryParams(limit: 2),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyForwards = await getPresenceHistory(
     channel,
     RealtimeHistoryParams(direction: 'forwards'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time1 = DateTime.now();
   //TODO(tiholic) iOS fails without this delay
   // - timestamp on message retrieved from history
   // is earlier than expected when ran in CI
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await realtimePresence.enter('enter-start-time');
   // TODO(tiholic) understand why tests fail without this delay
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time2 = DateTime.now();
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await realtimePresence.leave('leave-end-time');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyWithStart = await getPresenceHistory(
     channel,

--- a/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
+++ b/test_integration/lib/test/realtime/realtime_presence_subscribe.dart
@@ -55,14 +55,14 @@ Future<Map<String, dynamic>> testRealtimePresenceSubscribe({
   // Wait for the update event as it is asynchronously triggered.
   // Then cancelling partial subscription expecting it to not receive
   // further presence events.
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await partialMessagesSubscription.cancel();
 
   await presence.leave(messagesToPublish.last[1]);
 
   // Wait for the leave event to be received by listeners.
   // Assuming, they'd turn out in 2 seconds.
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await allMessagesSubscription.cancel();
   await enterMessagesSubscription.cancel();
   await enterUpdateMessagesSubscription.cancel();

--- a/test_integration/lib/test/realtime/realtime_publish_test.dart
+++ b/test_integration/lib/test/realtime/realtime_publish_test.dart
@@ -48,16 +48,16 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
   await channel.publish(name: 'name1');
   await channel.publish(data: 'data1');
   await channel.publish(name: 'name1', data: 'data1');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(
     message: Message(name: 'message-name1', data: 'message-data1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(messages: [
     Message(name: 'messages-name1', data: 'messages-data1'),
     Message(name: 'messages-name2', data: 'messages-data2'),
   ]);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(
     message: Message(
       name: 'message-name1',
@@ -65,7 +65,7 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
       clientId: 'someClientId',
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // publishing message with a different client id
   Map<String, dynamic>? exception;
@@ -92,7 +92,7 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
   await channel2.publish(
     message: Message(name: 'name-client-id', clientId: 'client-id'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   final history2 = await getHistory(
     channel2,
     RealtimeHistoryParams(direction: 'forwards'),
@@ -101,7 +101,7 @@ Future<Map<String, dynamic>> testRealtimePublishSpec({
   final channel3 = realtime2.channels.get('©Äblý');
   await channel3.publish(name: 'Ωπ', data: 'ΨΔ');
 
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   final history3 = await getHistory(channel3);
 
   final channelExtras = realtime.channels.get('pushenabled:test:extras');

--- a/test_integration/lib/test/realtime/realtime_subscribe.dart
+++ b/test_integration/lib/test/realtime/realtime_subscribe.dart
@@ -70,7 +70,7 @@ Future<Map<String, dynamic>> testRealtimeSubscribe({
       extras: const MessageExtras({...pushPayload}),
     ),
   );
-  await Future.delayed(const Duration(seconds: 2));
+  await Future<void>.delayed(const Duration(seconds: 2));
   await extrasSubscription.cancel();
 
   return {

--- a/test_integration/lib/test/rest/rest_capability_test.dart
+++ b/test_integration/lib/test/rest/rest_capability_test.dart
@@ -8,7 +8,7 @@ Future<Map<String, dynamic>> testRestCapabilities({
   required Reporter reporter,
   Map<String, dynamic>? payload,
 }) async {
-  final capabilitySpec = <String, List>{};
+  final capabilitySpec = <String, List<dynamic>>{};
   final combinations = getAllSubsets(['publish', 'history', 'subscribe'])
       .where((spec) => spec.isNotEmpty)
       .toList();
@@ -28,7 +28,7 @@ Future<Map<String, dynamic>> testRestCapabilities({
     ),
   );
 
-  final matrix = <Map>[];
+  final matrix = <Map<String, dynamic>>[];
   for (final entry in capabilitySpec.entries) {
     Map<String, dynamic>? publishException;
     Map<String, dynamic>? historyException;

--- a/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_encrypted_publish_test.dart
@@ -66,7 +66,7 @@ Future<Map<String, dynamic>> testRestEncryptedPublishSpec({
   await encryptedChannel.publish(name: 'name');
   await encryptedChannel.publish(data: 'data');
   await encryptedChannel.publish(name: 'name', data: 'data');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send single message object
   await encryptedChannel.publish(
@@ -75,14 +75,14 @@ Future<Map<String, dynamic>> testRestEncryptedPublishSpec({
       data: 'single-message-data',
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send multiple message objects at once
   await encryptedChannel.publish(messages: [
     Message(name: 'multi-message-name-1', data: 'multi-message-data-1'),
     Message(name: 'multi-message-name-2', data: 'multi-message-data-2'),
   ]);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Send message with [clientId] defined
   await encryptedChannel.publish(
@@ -92,7 +92,7 @@ Future<Map<String, dynamic>> testRestEncryptedPublishSpec({
       clientId: clientId,
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // Retrieve history of channel where client id was specified
   final historyOfEncryptedChannel = await getHistory(

--- a/test_integration/lib/test/rest/rest_history_test.dart
+++ b/test_integration/lib/test/rest/rest_history_test.dart
@@ -25,31 +25,31 @@ Future<Map<String, dynamic>> testRestHistory({
 
   final paginatedResult = await channel.history();
   final historyDefault = await getHistory(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit4 = await getHistory(channel, RestHistoryParams(limit: 4));
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit2 = await getHistory(channel, RestHistoryParams(limit: 2));
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyForwardLimit4 = await getHistory(
       channel, RestHistoryParams(direction: 'forwards', limit: 4));
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time1 = DateTime.now();
   //TODO(tiholic) iOS fails without this delay
   // - timestamp on message retrieved from history
   // is earlier than expected when ran in CI
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(name: 'history', data: 'test');
   //TODO(tiholic) understand why tests fail without this delay
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time2 = DateTime.now();
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(name: 'history', data: 'test2');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyWithStart =
       await getHistory(channel, RestHistoryParams(start: time1));

--- a/test_integration/lib/test/rest/rest_presence_get_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_get_test.dart
@@ -36,28 +36,28 @@ Future<Map<String, dynamic>> testRestPresenceGet({
     ).channels.get('test').presence.enter(messagesToPublish[i][1]);
   }
 
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersDefault = await getPresenceMembers(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersLimit4 = await getPresenceMembers(
     channel,
     RestPresenceParams(limit: 4),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersLimit2 = await getPresenceMembers(
     channel,
     RestPresenceParams(limit: 2),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final membersClientId = await getPresenceMembers(
     channel,
     RestPresenceParams(clientId: 'client-1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // TODO(tiholic) extract connection ID from realtime instance
   //  after implementing `id` update on connection object from platform
@@ -66,7 +66,7 @@ Future<Map<String, dynamic>> testRestPresenceGet({
     channel,
     RestPresenceParams(connectionId: 'connection-1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   return {
     'handle': await rest.handle,

--- a/test_integration/lib/test/rest/rest_presence_history_test.dart
+++ b/test_integration/lib/test/rest/rest_presence_history_test.dart
@@ -38,39 +38,39 @@ Future<Map<String, dynamic>> testRestPresenceHistory({
   await realtimePresence.leave(messagesToPublish.last[1]);
 
   final historyDefault = await getPresenceHistory(channel);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit4 = await getPresenceHistory(
     channel,
     RestHistoryParams(limit: 4),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyLimit2 = await getPresenceHistory(
     channel,
     RestHistoryParams(limit: 2),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyForwards = await getPresenceHistory(
     channel,
     RestHistoryParams(direction: 'forwards'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time1 = DateTime.now();
   //TODO(tiholic) iOS fails without this delay
   // - timestamp on message retrieved from history
   // is earlier than expected when ran in CI
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await realtimePresence.enter('enter-start-time');
   // TODO(tiholic) understand why tests fail without this delay
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final time2 = DateTime.now();
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await realtimePresence.leave('leave-end-time');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   final historyWithStart = await getPresenceHistory(
     channel,

--- a/test_integration/lib/test/rest/rest_publish_test.dart
+++ b/test_integration/lib/test/rest/rest_publish_test.dart
@@ -48,16 +48,16 @@ Future<Map<String, dynamic>> testRestPublishSpec({
   await channel.publish(name: 'name1');
   await channel.publish(data: 'data1');
   await channel.publish(name: 'name1', data: 'data1');
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(
     message: Message(name: 'message-name1', data: 'message-data1'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(messages: [
     Message(name: 'messages-name1', data: 'messages-data1'),
     Message(name: 'messages-name2', data: 'messages-data2'),
   ]);
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   await channel.publish(
     message: Message(
       name: 'message-name1',
@@ -65,7 +65,7 @@ Future<Map<String, dynamic>> testRestPublishSpec({
       clientId: 'someClientId',
     ),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
 
   // publishing message with a different client id
   Map<String, dynamic>? exception;
@@ -92,7 +92,7 @@ Future<Map<String, dynamic>> testRestPublishSpec({
   await channel2.publish(
     message: Message(name: 'name-client-id', clientId: 'client-id'),
   );
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   final history2 = await getHistory(
     channel2,
     RestHistoryParams(direction: 'forwards'),
@@ -117,7 +117,7 @@ Future<Map<String, dynamic>> testRestPublishSpec({
   final channel3 = rest2.channels.get('©Äblý');
   await channel3.publish(name: 'Ωπ', data: 'ΨΔ');
 
-  await Future.delayed(TestConstants.publishToHistoryDelay);
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
   final history3 = await getHistory(channel3);
 
   final channelExtras = rest.channels.get('pushenabled:test:extras');

--- a/test_integration/lib/test_dispatcher.dart
+++ b/test_integration/lib/test_dispatcher.dart
@@ -235,7 +235,9 @@ class DispatcherController {
 
   Future<String> driveHandler(String? encodedMessage) async {
     final response = await _dispatcher.handleDriverMessage(
-      TestControlMessage.fromJson(json.decode(encodedMessage!) as Map),
+      TestControlMessage.fromJson(
+        json.decode(encodedMessage!) as Map<String, dynamic>,
+      ),
     );
     return json.encode(response);
   }

--- a/test_integration/lib/test_dispatcher.dart
+++ b/test_integration/lib/test_dispatcher.dart
@@ -50,7 +50,7 @@ class _TestDispatcherState extends State<TestDispatcher> {
   ) {
     final reporter = Reporter(message, widget.controller);
 
-    Future.delayed(Duration.zero, () async {
+    Future<void>.delayed(Duration.zero, () async {
       // check if a test is running and throw error
       if (_reporters.containsKey(reporter.testName)) {
         reporter.reportTestError(
@@ -69,11 +69,10 @@ class _TestDispatcherState extends State<TestDispatcher> {
             reporter: reporter,
             payload: reporter.message.payload,
           ).then(reporter.reportTestCompletion).catchError(
-                (error, stack) => reporter.reportTestCompletion({
-                  TestControlMessage.errorKey: ErrorHandler.encodeException(
-                    error as Object,
-                    stack as StackTrace,
-                  ),
+                (Object error, StackTrace stack) =>
+                    reporter.reportTestCompletion({
+                  TestControlMessage.errorKey:
+                      ErrorHandler.encodeException(error, stack),
                 }),
               );
         }
@@ -163,7 +162,7 @@ class _TestDispatcherState extends State<TestDispatcher> {
           IconButton(
             icon: const Icon(Icons.remove_red_eye),
             onPressed: () {
-              showDialog(
+              showDialog<void>(
                 context: context,
                 builder: (context) => AlertDialog(
                   contentPadding: const EdgeInsets.all(4),

--- a/test_integration/lib/utils/data.dart
+++ b/test_integration/lib/utils/data.dart
@@ -42,7 +42,8 @@ String getRandomString(int length) => String.fromCharCodes(
     );
 
 /// returns subsets of all entries in a list
-List<List> getAllSubsets(List l) => l.fold<List<List>>(
+List<List<dynamic>> getAllSubsets(List<dynamic> l) =>
+    l.fold<List<List<dynamic>>>(
       [[]],
       (subLists, element) => subLists
           .map((subList) => [

--- a/test_integration/lib/utils/encoders.dart
+++ b/test_integration/lib/utils/encoders.dart
@@ -70,7 +70,7 @@ Map<String, dynamic> encodePaginatedResult<T>(
       'isLast': paginatedResult.isLast(),
     };
 
-Map<String, dynamic> encodeAblyException<T>(AblyException exception) => {
+Map<String, dynamic> encodeAblyException(AblyException exception) => {
       'code': exception.code,
       'message': exception.message,
       'errorInfo': {

--- a/test_integration/test_driver/test_implementation/basic_platform_tests.dart
+++ b/test_integration/test_driver/test_implementation/basic_platform_tests.dart
@@ -37,10 +37,10 @@ void testDemoDependencies(FlutterDriver Function() getDriver) {
   });
 
   group('token request has', () {
-    late Map tokenRequest;
+    late Map<String, dynamic> tokenRequest;
 
     setUp(() {
-      tokenRequest = response.payload['tokenRequest'] as Map;
+      tokenRequest = response.payload['tokenRequest'] as Map<String, dynamic>;
     });
 
     test('non-empty keyName', () {

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -41,19 +41,23 @@ void testRealtimeEncryptedPublish(FlutterDriver Function() getDriver) {
 void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimePublishSpec);
   late TestControlResponseMessage response;
-  late List messages;
-  late List messages2;
-  late List messages3;
-  late List messagesWithExtras;
+  late List<Map<String, dynamic>> messages;
+  late List<Map<String, dynamic>> messages2;
+  late List<Map<String, dynamic>> messages3;
+  late List<Map<String, dynamic>> messagesWithExtras;
   Map<String, dynamic>? exception;
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    messages = response.payload['publishedMessages'] as List;
-    messages2 = response.payload['publishedMessages2'] as List;
-    messages3 = response.payload['publishedMessages3'] as List;
-    messagesWithExtras = response.payload['publishedExtras'] as List;
+    messages =
+        response.payload['publishedMessages'] as List<Map<String, dynamic>>;
+    messages2 =
+        response.payload['publishedMessages2'] as List<Map<String, dynamic>>;
+    messages3 =
+        response.payload['publishedMessages3'] as List<Map<String, dynamic>>;
+    messagesWithExtras =
+        response.payload['publishedExtras'] as List<Map<String, dynamic>>;
     exception = response.payload['exception'] as Map<String, dynamic>?;
   });
 
@@ -119,7 +123,7 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
       ' from the clientId in the client options should result in a message'
       ' being rejected by the server.',
       () {
-        expect(response.payload['exception'], isA<Map>());
+        expect(response.payload['exception'], isA<Map<String, dynamic>>());
       },
     );
 
@@ -151,22 +155,24 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
 void testRealtimeEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeEncryptedPublishSpec);
   late TestControlResponseMessage response;
-  late List historyOfEncryptedChannel;
-  late List historyOfPlaintextChannel;
-  late List historyOfEncryptedPushEnabledChannel;
-  late List historyOfPlaintextPushEnabledChannel;
+  late List<Map<String, dynamic>> historyOfEncryptedChannel;
+  late List<Map<String, dynamic>> historyOfPlaintextChannel;
+  late List<Map<String, dynamic>> historyOfEncryptedPushEnabledChannel;
+  late List<Map<String, dynamic>> historyOfPlaintextPushEnabledChannel;
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    historyOfEncryptedChannel =
-        response.payload['historyOfEncryptedChannel'] as List;
-    historyOfPlaintextChannel =
-        response.payload['historyOfPlaintextChannel'] as List;
+    historyOfEncryptedChannel = response.payload['historyOfEncryptedChannel']
+        as List<Map<String, dynamic>>;
+    historyOfPlaintextChannel = response.payload['historyOfPlaintextChannel']
+        as List<Map<String, dynamic>>;
     historyOfEncryptedPushEnabledChannel =
-        response.payload['historyOfEncryptedPushEnabledChannel'] as List;
+        response.payload['historyOfEncryptedPushEnabledChannel']
+            as List<Map<String, dynamic>>;
     historyOfPlaintextPushEnabledChannel =
-        response.payload['historyOfPlaintextPushEnabledChannel'] as List;
+        response.payload['historyOfPlaintextPushEnabledChannel']
+            as List<Map<String, dynamic>>;
   });
 
   group('RSL5', () {
@@ -471,7 +477,7 @@ void testRealtimeHistory(FlutterDriver Function() getDriver) {
 
   group('paginated result', () {
     test('#items is a list', () {
-      expect(paginatedResult['items'], isA<List>());
+      expect(paginatedResult['items'], isA<List<Map<String, dynamic>>>());
     });
     test('#hasNext indicates whether there are more entries', () {
       expect(paginatedResult['hasNext'], false);
@@ -654,7 +660,7 @@ void testRealtimeEnterUpdateLeave(FlutterDriver Function() getDriver) {
   });
 
   void testMatrixEntry(
-    Map entry, {
+    Map<String, dynamic> entry, {
     bool enter = false,
     bool update = false,
     bool leave = false,

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -50,14 +50,11 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    messages =
-        response.payload['publishedMessages'] as List<Map<String, dynamic>>;
-    messages2 =
-        response.payload['publishedMessages2'] as List<Map<String, dynamic>>;
-    messages3 =
-        response.payload['publishedMessages3'] as List<Map<String, dynamic>>;
+    messages = transformListResponse(response.payload['publishedMessages']);
+    messages2 = transformListResponse(response.payload['publishedMessages2']);
+    messages3 = transformListResponse(response.payload['publishedMessages3']);
     messagesWithExtras =
-        response.payload['publishedExtras'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['publishedExtras']);
     exception = response.payload['exception'] as Map<String, dynamic>?;
   });
 
@@ -163,16 +160,14 @@ void testRealtimeEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    historyOfEncryptedChannel = response.payload['historyOfEncryptedChannel']
-        as List<Map<String, dynamic>>;
-    historyOfPlaintextChannel = response.payload['historyOfPlaintextChannel']
-        as List<Map<String, dynamic>>;
-    historyOfEncryptedPushEnabledChannel =
-        response.payload['historyOfEncryptedPushEnabledChannel']
-            as List<Map<String, dynamic>>;
-    historyOfPlaintextPushEnabledChannel =
-        response.payload['historyOfPlaintextPushEnabledChannel']
-            as List<Map<String, dynamic>>;
+    historyOfEncryptedChannel =
+        transformListResponse(response.payload['historyOfEncryptedChannel']);
+    historyOfPlaintextChannel =
+        transformListResponse(response.payload['historyOfPlaintextChannel']);
+    historyOfEncryptedPushEnabledChannel = transformListResponse(
+        response.payload['historyOfEncryptedPushEnabledChannel']);
+    historyOfPlaintextPushEnabledChannel = transformListResponse(
+        response.payload['historyOfPlaintextPushEnabledChannel']);
   });
 
   group('RSL5', () {
@@ -214,19 +209,25 @@ void testRealtimeEvents(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> channelStateChanges;
   late List<Map<String, dynamic>> filteredChannelStateChanges;
 
+  List<String> transformState(dynamic items) =>
+      List<dynamic>.from(items as List).map((t) => t as String).toList();
+
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    connectionStates = response.payload['connectionStates'] as List<String>;
-    connectionStateChanges = response.payload['connectionStateChanges']
-        as List<Map<String, dynamic>>;
-    filteredConnectionStateChanges =
-        response.payload['filteredConnectionStateChanges']
-            as List<Map<String, dynamic>>;
-    channelStates = response.payload['channelStates'] as List<String>;
-    channelStateChanges =
-        response.payload['channelStateChanges'] as List<Map<String, dynamic>>;
-    filteredChannelStateChanges = response
-        .payload['filteredChannelStateChanges'] as List<Map<String, dynamic>>;
+    connectionStates = transformState(response.payload['connectionStates']);
+    connectionStateChanges = transformListResponse(
+      response.payload['connectionStateChanges'],
+    );
+    filteredConnectionStateChanges = transformListResponse(
+      response.payload['filteredConnectionStateChanges'],
+    );
+    channelStates = transformState(response.payload['channelStates']);
+    channelStateChanges = transformListResponse(
+      response.payload['channelStateChanges'],
+    );
+    filteredChannelStateChanges = transformListResponse(
+      response.payload['filteredChannelStateChanges'],
+    );
   });
 
   group('realtime#channel#connection', () {
@@ -372,19 +373,15 @@ void testRealtimeSubscribe(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> filteredWithNames;
   late List<Map<String, dynamic>> extrasMessages;
 
-  List<Map<String, dynamic>> transformMessages(messages) =>
-      List.from(messages as List)
-          .map((t) => t as Map<String, dynamic>)
-          .toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    all = transformMessages(response.payload['all']);
-    filteredWithName = transformMessages(response.payload['filteredWithName']);
-    filteredWithNames = transformMessages(
+    all = transformListResponse(response.payload['all']);
+    filteredWithName =
+        transformListResponse(response.payload['filteredWithName']);
+    filteredWithNames = transformListResponse(
       response.payload['filteredWithNames'],
     );
-    extrasMessages = transformMessages(response.payload['extrasMessages']);
+    extrasMessages = transformListResponse(response.payload['extrasMessages']);
   });
 
   test(
@@ -453,23 +450,21 @@ void testRealtimeHistory(FlutterDriver Function() getDriver) {
     response = await requestDataForTest(getDriver(), message);
     paginatedResult =
         response.payload['paginatedResult'] as Map<String, dynamic>;
-    historyDefault =
-        response.payload['historyDefault'] as List<Map<String, dynamic>>;
-    historyLimit4 =
-        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
-    historyLimit2 =
-        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyDefault = transformListResponse(response.payload['historyDefault']);
+    historyLimit4 = transformListResponse(response.payload['historyLimit4']);
+    historyLimit2 = transformListResponse(response.payload['historyLimit2']);
     historyForwardLimit4 =
-        response.payload['historyForwardLimit4'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyForwardLimit4']);
     historyWithStart =
-        response.payload['historyWithStart'] as List<Map<String, dynamic>>;
-    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
-        as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyWithStart']);
+    historyWithStartAndEnd = transformListResponse(
+      response.payload['historyWithStartAndEnd'],
+    );
   });
 
   group('paginated result', () {
     test('#items is a list', () {
-      expect(paginatedResult['items'], isA<List<Map<String, dynamic>>>());
+      expect(paginatedResult['items'], isA<List<dynamic>>());
     });
     test('#hasNext indicates whether there are more entries', () {
       expect(paginatedResult['hasNext'], false);
@@ -538,14 +533,12 @@ void testRealtimePresenceGet(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    membersInitial =
-        response.payload['membersInitial'] as List<Map<String, dynamic>>;
-    membersDefault =
-        response.payload['membersDefault'] as List<Map<String, dynamic>>;
+    membersInitial = transformListResponse(response.payload['membersInitial']);
+    membersDefault = transformListResponse(response.payload['membersDefault']);
     membersClientId =
-        response.payload['membersClientId'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['membersClientId']);
     membersConnectionId =
-        response.payload['membersConnectionId'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['membersConnectionId']);
   });
 
   group('realtime#channels#channel#presence#get', () {
@@ -585,23 +578,19 @@ void testRealtimePresenceHistory(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    historyInitial =
-        response.payload['historyInitial'] as List<Map<String, dynamic>>;
-    historyDefault =
-        response.payload['historyDefault'] as List<Map<String, dynamic>>;
-    historyLimit4 =
-        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
-    historyLimit2 =
-        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyInitial = transformListResponse(response.payload['historyInitial']);
+    historyDefault = transformListResponse(response.payload['historyDefault']);
+    historyLimit4 = transformListResponse(response.payload['historyLimit4']);
+    historyLimit2 = transformListResponse(response.payload['historyLimit2']);
     historyForwards =
-        response.payload['historyForwards'] as List<Map<String, dynamic>>;
-    historyWithStart =
-        (response.payload['historyWithStart'] as List<Map<String, dynamic>>)
-            .reversed
-            .toList();
-    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
-        as List<Map<String, dynamic>>;
-    historyAll = response.payload['historyAll'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyForwards']);
+    historyWithStart = transformListResponse(
+      response.payload['historyWithStart'],
+    ).reversed.toList();
+    historyWithStartAndEnd = transformListResponse(
+      response.payload['historyWithStartAndEnd'],
+    );
+    historyAll = transformListResponse(response.payload['historyAll']);
   });
 
   test('queries all entries by default', () {
@@ -648,9 +637,8 @@ void testRealtimeEnterUpdateLeave(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
     clientIDClashMatrix =
-        response.payload['clientIDClashMatrix'] as List<Map<String, dynamic>>;
-    actionMatrix =
-        response.payload['actionMatrix'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['clientIDClashMatrix']);
+    actionMatrix = transformListResponse(response.payload['actionMatrix']);
   });
 
   void testMatrixEntry(
@@ -773,13 +761,12 @@ void testRealtimePresenceSubscription(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    allMessages = response.payload['allMessages'] as List<Map<String, dynamic>>;
-    enterMessages =
-        response.payload['enterMessages'] as List<Map<String, dynamic>>;
+    allMessages = transformListResponse(response.payload['allMessages']);
+    enterMessages = transformListResponse(response.payload['enterMessages']);
     enterUpdateMessages =
-        response.payload['enterUpdateMessages'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['enterUpdateMessages']);
     partialMessages =
-        response.payload['partialMessages'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['partialMessages']);
   });
 
   void _test(List<Map<String, dynamic>> messages) {

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -214,28 +214,19 @@ void testRealtimeEvents(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> channelStateChanges;
   late List<Map<String, dynamic>> filteredChannelStateChanges;
 
-  List<String> transformState(items) =>
-      List.from(items as List).map((t) => t as String).toList();
-
-  List<Map<String, dynamic>> transformStateChange(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    connectionStates = transformState(response.payload['connectionStates']);
-    connectionStateChanges = transformStateChange(
-      response.payload['connectionStateChanges'],
-    );
-    filteredConnectionStateChanges = transformStateChange(
-      response.payload['filteredConnectionStateChanges'],
-    );
-    channelStates = transformState(response.payload['channelStates']);
-    channelStateChanges = transformStateChange(
-      response.payload['channelStateChanges'],
-    );
-    filteredChannelStateChanges = transformStateChange(
-      response.payload['filteredChannelStateChanges'],
-    );
+    connectionStates = response.payload['connectionStates'] as List<String>;
+    connectionStateChanges = response.payload['connectionStateChanges']
+        as List<Map<String, dynamic>>;
+    filteredConnectionStateChanges =
+        response.payload['filteredConnectionStateChanges']
+            as List<Map<String, dynamic>>;
+    channelStates = response.payload['channelStates'] as List<String>;
+    channelStateChanges =
+        response.payload['channelStateChanges'] as List<Map<String, dynamic>>;
+    filteredChannelStateChanges = response
+        .payload['filteredChannelStateChanges'] as List<Map<String, dynamic>>;
   });
 
   group('realtime#channel#connection', () {
@@ -458,21 +449,22 @@ void testRealtimeHistory(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> historyWithStart;
   late List<Map<String, dynamic>> historyWithStartAndEnd;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
     paginatedResult =
         response.payload['paginatedResult'] as Map<String, dynamic>;
-    historyDefault = transform(response.payload['historyDefault']);
-    historyLimit4 = transform(response.payload['historyLimit4']);
-    historyLimit2 = transform(response.payload['historyLimit2']);
-    historyForwardLimit4 = transform(response.payload['historyForwardLimit4']);
-    historyWithStart = transform(response.payload['historyWithStart']);
-    historyWithStartAndEnd = transform(
-      response.payload['historyWithStartAndEnd'],
-    );
+    historyDefault =
+        response.payload['historyDefault'] as List<Map<String, dynamic>>;
+    historyLimit4 =
+        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
+    historyLimit2 =
+        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyForwardLimit4 =
+        response.payload['historyForwardLimit4'] as List<Map<String, dynamic>>;
+    historyWithStart =
+        response.payload['historyWithStart'] as List<Map<String, dynamic>>;
+    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
+        as List<Map<String, dynamic>>;
   });
 
   group('paginated result', () {
@@ -544,15 +536,16 @@ void testRealtimePresenceGet(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> membersClientId;
   late List<Map<String, dynamic>> membersConnectionId;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    membersInitial = transform(response.payload['membersInitial']);
-    membersDefault = transform(response.payload['membersDefault']);
-    membersClientId = transform(response.payload['membersClientId']);
-    membersConnectionId = transform(response.payload['membersConnectionId']);
+    membersInitial =
+        response.payload['membersInitial'] as List<Map<String, dynamic>>;
+    membersDefault =
+        response.payload['membersDefault'] as List<Map<String, dynamic>>;
+    membersClientId =
+        response.payload['membersClientId'] as List<Map<String, dynamic>>;
+    membersConnectionId =
+        response.payload['membersConnectionId'] as List<Map<String, dynamic>>;
   });
 
   group('realtime#channels#channel#presence#get', () {
@@ -590,23 +583,25 @@ void testRealtimePresenceHistory(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> historyWithStartAndEnd;
   late List<Map<String, dynamic>> historyAll;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    historyInitial = transform(response.payload['historyInitial']);
-    historyDefault = transform(response.payload['historyDefault']);
-    historyLimit4 = transform(response.payload['historyLimit4']);
-    historyLimit2 = transform(response.payload['historyLimit2']);
-    historyForwards = transform(response.payload['historyForwards']);
-    historyWithStart = transform(
-      response.payload['historyWithStart'],
-    ).reversed.toList();
-    historyWithStartAndEnd = transform(
-      response.payload['historyWithStartAndEnd'],
-    );
-    historyAll = transform(response.payload['historyAll']);
+    historyInitial =
+        response.payload['historyInitial'] as List<Map<String, dynamic>>;
+    historyDefault =
+        response.payload['historyDefault'] as List<Map<String, dynamic>>;
+    historyLimit4 =
+        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
+    historyLimit2 =
+        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyForwards =
+        response.payload['historyForwards'] as List<Map<String, dynamic>>;
+    historyWithStart =
+        (response.payload['historyWithStart'] as List<Map<String, dynamic>>)
+            .reversed
+            .toList();
+    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
+        as List<Map<String, dynamic>>;
+    historyAll = response.payload['historyAll'] as List<Map<String, dynamic>>;
   });
 
   test('queries all entries by default', () {
@@ -650,13 +645,12 @@ void testRealtimeEnterUpdateLeave(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> clientIDClashMatrix;
   late List<Map<String, dynamic>> actionMatrix;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    clientIDClashMatrix = transform(response.payload['clientIDClashMatrix']);
-    actionMatrix = transform(response.payload['actionMatrix']);
+    clientIDClashMatrix =
+        response.payload['clientIDClashMatrix'] as List<Map<String, dynamic>>;
+    actionMatrix =
+        response.payload['actionMatrix'] as List<Map<String, dynamic>>;
   });
 
   void testMatrixEntry(
@@ -777,15 +771,15 @@ void testRealtimePresenceSubscription(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> enterUpdateMessages;
   late List<Map<String, dynamic>> partialMessages;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    allMessages = transform(response.payload['allMessages']);
-    enterMessages = transform(response.payload['enterMessages']);
-    enterUpdateMessages = transform(response.payload['enterUpdateMessages']);
-    partialMessages = transform(response.payload['partialMessages']);
+    allMessages = response.payload['allMessages'] as List<Map<String, dynamic>>;
+    enterMessages =
+        response.payload['enterMessages'] as List<Map<String, dynamic>>;
+    enterUpdateMessages =
+        response.payload['enterUpdateMessages'] as List<Map<String, dynamic>>;
+    partialMessages =
+        response.payload['partialMessages'] as List<Map<String, dynamic>>;
   });
 
   void _test(List<Map<String, dynamic>> messages) {

--- a/test_integration/test_driver/test_implementation/rest_tests.dart
+++ b/test_integration/test_driver/test_implementation/rest_tests.dart
@@ -245,21 +245,22 @@ void testRestHistory(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> historyWithStart;
   late List<Map<String, dynamic>> historyWithStartAndEnd;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
     paginatedResult =
         response.payload['paginatedResult'] as Map<String, dynamic>;
-    historyDefault = transform(response.payload['historyDefault']);
-    historyLimit4 = transform(response.payload['historyLimit4']);
-    historyLimit2 = transform(response.payload['historyLimit2']);
-    historyForwardLimit4 = transform(response.payload['historyForwardLimit4']);
-    historyWithStart = transform(response.payload['historyWithStart']);
-    historyWithStartAndEnd = transform(
-      response.payload['historyWithStartAndEnd'],
-    );
+    historyDefault =
+        response.payload['historyDefault'] as List<Map<String, dynamic>>;
+    historyLimit4 =
+        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
+    historyLimit2 =
+        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyForwardLimit4 =
+        response.payload['historyForwardLimit4'] as List<Map<String, dynamic>>;
+    historyWithStart =
+        response.payload['historyWithStart'] as List<Map<String, dynamic>>;
+    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
+        as List<Map<String, dynamic>>;
   });
 
   group('paginated result', () {
@@ -333,17 +334,20 @@ void testRestPresenceGet(FlutterDriver Function() getDriver) {
   late List<Map<String, dynamic>> membersClientId;
   late List<Map<String, dynamic>> membersConnectionId;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    membersInitial = transform(response.payload['membersInitial']);
-    membersDefault = transform(response.payload['membersDefault']);
-    membersLimit4 = transform(response.payload['membersLimit4']);
-    membersLimit2 = transform(response.payload['membersLimit2']);
-    membersClientId = transform(response.payload['membersClientId']);
-    membersConnectionId = transform(response.payload['membersConnectionId']);
+    membersInitial =
+        response.payload['membersInitial'] as List<Map<String, dynamic>>;
+    membersDefault =
+        response.payload['membersDefault'] as List<Map<String, dynamic>>;
+    membersLimit4 =
+        response.payload['membersLimit4'] as List<Map<String, dynamic>>;
+    membersLimit2 =
+        response.payload['membersLimit2'] as List<Map<String, dynamic>>;
+    membersClientId =
+        response.payload['membersClientId'] as List<Map<String, dynamic>>;
+    membersConnectionId =
+        response.payload['membersConnectionId'] as List<Map<String, dynamic>>;
   });
 
   group('rest#channels#channel#presence#get', () {
@@ -379,9 +383,6 @@ void testRestPresenceHistory(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.restPresenceHistory);
   late TestControlResponseMessage response;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   late List<Map<String, dynamic>> historyInitial;
   late List<Map<String, dynamic>> historyDefault;
   late List<Map<String, dynamic>> historyLimit4;
@@ -393,18 +394,23 @@ void testRestPresenceHistory(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    historyInitial = transform(response.payload['historyInitial']);
-    historyDefault = transform(response.payload['historyDefault']);
-    historyLimit4 = transform(response.payload['historyLimit4']);
-    historyLimit2 = transform(response.payload['historyLimit2']);
-    historyForwards = transform(response.payload['historyForwards']);
-    historyWithStart = transform(
-      response.payload['historyWithStart'],
-    ).reversed.toList();
-    historyWithStartAndEnd = transform(
-      response.payload['historyWithStartAndEnd'],
-    );
-    historyAll = transform(response.payload['historyAll']);
+    historyInitial =
+        response.payload['historyInitial'] as List<Map<String, dynamic>>;
+    historyDefault =
+        response.payload['historyDefault'] as List<Map<String, dynamic>>;
+    historyLimit4 =
+        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
+    historyLimit2 =
+        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyForwards =
+        response.payload['historyForwards'] as List<Map<String, dynamic>>;
+    historyWithStart =
+        (response.payload['historyWithStart'] as List<Map<String, dynamic>>)
+            .reversed
+            .toList();
+    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
+        as List<Map<String, dynamic>>;
+    historyAll = response.payload['historyAll'] as List<Map<String, dynamic>>;
   });
 
   group('rest#channels#channel#presence#history', () {
@@ -448,12 +454,9 @@ void testCapabilityMatrix(FlutterDriver Function() getDriver) {
   late TestControlResponseMessage response;
   late List<Map<String, dynamic>> capabilityMatrix;
 
-  List<Map<String, dynamic>> transform(items) =>
-      List.from(items as List).map((t) => t as Map<String, dynamic>).toList();
-
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    capabilityMatrix = transform(response.payload['matrix']);
+    capabilityMatrix = response.payload['matrix'] as List<Map<String, dynamic>>;
   });
 
   test('capabilitySpec', () {

--- a/test_integration/test_driver/test_implementation/rest_tests.dart
+++ b/test_integration/test_driver/test_implementation/rest_tests.dart
@@ -33,10 +33,10 @@ void testRestEncryptedPublish(FlutterDriver Function() getDriver) {
 void testRestPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.restPublishSpec);
   late TestControlResponseMessage response;
-  late List messages;
-  late List messages2;
-  late List messages3;
-  late List messagesWithExtras;
+  late List<Map<String, dynamic>> messages;
+  late List<Map<String, dynamic>> messages2;
+  late List<Map<String, dynamic>> messages3;
+  late List<Map<String, dynamic>> messagesWithExtras;
   Map<String, dynamic>? exception;
   Map<String, dynamic>? exception2;
   Map<String, dynamic>? exception3;
@@ -44,10 +44,14 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    messages = response.payload['publishedMessages'] as List;
-    messages2 = response.payload['publishedMessages2'] as List;
-    messages3 = response.payload['publishedMessages3'] as List;
-    messagesWithExtras = response.payload['publishedExtras'] as List;
+    messages =
+        response.payload['publishedMessages'] as List<Map<String, dynamic>>;
+    messages2 =
+        response.payload['publishedMessages2'] as List<Map<String, dynamic>>;
+    messages3 =
+        response.payload['publishedMessages3'] as List<Map<String, dynamic>>;
+    messagesWithExtras =
+        response.payload['publishedExtras'] as List<Map<String, dynamic>>;
     exception = response.payload['exception'] as Map<String, dynamic>?;
     exception2 = response.payload['exception2'] as Map<String, dynamic>?;
     exception3 = response.payload['exception3'] as Map<String, dynamic>?;
@@ -111,7 +115,7 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
       ' from the clientId in the client options should result in a message'
       ' being rejected by the server.',
       () {
-        expect(response.payload['exception'], isA<Map>());
+        expect(response.payload['exception'], isA<Map<String, dynamic>>());
         // TODO as error details are incompatible from both libraries,
         //  it makes no sense to include below expect's
         //
@@ -169,22 +173,24 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
 void testRestEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.restEncryptedPublishSpec);
   late TestControlResponseMessage response;
-  late List historyOfEncryptedChannel;
-  late List historyOfPlaintextChannel;
-  late List historyOfEncryptedPushEnabledChannel;
-  late List historyOfPlaintextPushEnabledChannel;
+  late List<Map<String, dynamic>> historyOfEncryptedChannel;
+  late List<Map<String, dynamic>> historyOfPlaintextChannel;
+  late List<Map<String, dynamic>> historyOfEncryptedPushEnabledChannel;
+  late List<Map<String, dynamic>> historyOfPlaintextPushEnabledChannel;
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    historyOfEncryptedChannel =
-        response.payload['historyOfEncryptedChannel'] as List;
-    historyOfPlaintextChannel =
-        response.payload['historyOfPlaintextChannel'] as List;
+    historyOfEncryptedChannel = response.payload['historyOfEncryptedChannel']
+        as List<Map<String, dynamic>>;
+    historyOfPlaintextChannel = response.payload['historyOfPlaintextChannel']
+        as List<Map<String, dynamic>>;
     historyOfEncryptedPushEnabledChannel =
-        response.payload['historyOfEncryptedPushEnabledChannel'] as List;
+        response.payload['historyOfEncryptedPushEnabledChannel']
+            as List<Map<String, dynamic>>;
     historyOfPlaintextPushEnabledChannel =
-        response.payload['historyOfPlaintextPushEnabledChannel'] as List;
+        response.payload['historyOfPlaintextPushEnabledChannel']
+            as List<Map<String, dynamic>>;
   });
 
   group('RSL5', () {
@@ -258,7 +264,7 @@ void testRestHistory(FlutterDriver Function() getDriver) {
 
   group('paginated result', () {
     test('#items is a list', () {
-      expect(paginatedResult['items'], isA<List>());
+      expect(paginatedResult['items'], isA<List<dynamic>>());
     });
     test('#hasNext indicates whether there are more entries', () {
       expect(paginatedResult['hasNext'], false);

--- a/test_integration/test_driver/test_implementation/rest_tests.dart
+++ b/test_integration/test_driver/test_implementation/rest_tests.dart
@@ -44,14 +44,11 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    messages =
-        response.payload['publishedMessages'] as List<Map<String, dynamic>>;
-    messages2 =
-        response.payload['publishedMessages2'] as List<Map<String, dynamic>>;
-    messages3 =
-        response.payload['publishedMessages3'] as List<Map<String, dynamic>>;
+    messages = transformListResponse(response.payload['publishedMessages']);
+    messages2 = transformListResponse(response.payload['publishedMessages2']);
+    messages3 = transformListResponse(response.payload['publishedMessages3']);
     messagesWithExtras =
-        response.payload['publishedExtras'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['publishedExtras']);
     exception = response.payload['exception'] as Map<String, dynamic>?;
     exception2 = response.payload['exception2'] as Map<String, dynamic>?;
     exception3 = response.payload['exception3'] as Map<String, dynamic>?;
@@ -115,7 +112,7 @@ void testRestPublishSpec(FlutterDriver Function() getDriver) {
       ' from the clientId in the client options should result in a message'
       ' being rejected by the server.',
       () {
-        expect(response.payload['exception'], isA<Map<String, dynamic>>());
+        expect(response.payload['exception'], isA<Map<dynamic, dynamic>>());
         // TODO as error details are incompatible from both libraries,
         //  it makes no sense to include below expect's
         //
@@ -181,16 +178,14 @@ void testRestEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
 
-    historyOfEncryptedChannel = response.payload['historyOfEncryptedChannel']
-        as List<Map<String, dynamic>>;
-    historyOfPlaintextChannel = response.payload['historyOfPlaintextChannel']
-        as List<Map<String, dynamic>>;
-    historyOfEncryptedPushEnabledChannel =
-        response.payload['historyOfEncryptedPushEnabledChannel']
-            as List<Map<String, dynamic>>;
-    historyOfPlaintextPushEnabledChannel =
-        response.payload['historyOfPlaintextPushEnabledChannel']
-            as List<Map<String, dynamic>>;
+    historyOfEncryptedChannel =
+        transformListResponse(response.payload['historyOfEncryptedChannel']);
+    historyOfPlaintextChannel =
+        transformListResponse(response.payload['historyOfPlaintextChannel']);
+    historyOfEncryptedPushEnabledChannel = transformListResponse(
+        response.payload['historyOfEncryptedPushEnabledChannel']);
+    historyOfPlaintextPushEnabledChannel = transformListResponse(
+        response.payload['historyOfPlaintextPushEnabledChannel']);
   });
 
   group('RSL5', () {
@@ -249,18 +244,16 @@ void testRestHistory(FlutterDriver Function() getDriver) {
     response = await requestDataForTest(getDriver(), message);
     paginatedResult =
         response.payload['paginatedResult'] as Map<String, dynamic>;
-    historyDefault =
-        response.payload['historyDefault'] as List<Map<String, dynamic>>;
-    historyLimit4 =
-        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
-    historyLimit2 =
-        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyDefault = transformListResponse(response.payload['historyDefault']);
+    historyLimit4 = transformListResponse(response.payload['historyLimit4']);
+    historyLimit2 = transformListResponse(response.payload['historyLimit2']);
     historyForwardLimit4 =
-        response.payload['historyForwardLimit4'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyForwardLimit4']);
     historyWithStart =
-        response.payload['historyWithStart'] as List<Map<String, dynamic>>;
-    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
-        as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyWithStart']);
+    historyWithStartAndEnd = transformListResponse(
+      response.payload['historyWithStartAndEnd'],
+    );
   });
 
   group('paginated result', () {
@@ -336,18 +329,14 @@ void testRestPresenceGet(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    membersInitial =
-        response.payload['membersInitial'] as List<Map<String, dynamic>>;
-    membersDefault =
-        response.payload['membersDefault'] as List<Map<String, dynamic>>;
-    membersLimit4 =
-        response.payload['membersLimit4'] as List<Map<String, dynamic>>;
-    membersLimit2 =
-        response.payload['membersLimit2'] as List<Map<String, dynamic>>;
+    membersInitial = transformListResponse(response.payload['membersInitial']);
+    membersDefault = transformListResponse(response.payload['membersDefault']);
+    membersLimit4 = transformListResponse(response.payload['membersLimit4']);
+    membersLimit2 = transformListResponse(response.payload['membersLimit2']);
     membersClientId =
-        response.payload['membersClientId'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['membersClientId']);
     membersConnectionId =
-        response.payload['membersConnectionId'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['membersConnectionId']);
   });
 
   group('rest#channels#channel#presence#get', () {
@@ -394,23 +383,19 @@ void testRestPresenceHistory(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    historyInitial =
-        response.payload['historyInitial'] as List<Map<String, dynamic>>;
-    historyDefault =
-        response.payload['historyDefault'] as List<Map<String, dynamic>>;
-    historyLimit4 =
-        response.payload['historyLimit4'] as List<Map<String, dynamic>>;
-    historyLimit2 =
-        response.payload['historyLimit2'] as List<Map<String, dynamic>>;
+    historyInitial = transformListResponse(response.payload['historyInitial']);
+    historyDefault = transformListResponse(response.payload['historyDefault']);
+    historyLimit4 = transformListResponse(response.payload['historyLimit4']);
+    historyLimit2 = transformListResponse(response.payload['historyLimit2']);
     historyForwards =
-        response.payload['historyForwards'] as List<Map<String, dynamic>>;
-    historyWithStart =
-        (response.payload['historyWithStart'] as List<Map<String, dynamic>>)
-            .reversed
-            .toList();
-    historyWithStartAndEnd = response.payload['historyWithStartAndEnd']
-        as List<Map<String, dynamic>>;
-    historyAll = response.payload['historyAll'] as List<Map<String, dynamic>>;
+        transformListResponse(response.payload['historyForwards']);
+    historyWithStart = transformListResponse(
+      response.payload['historyWithStart'],
+    ).reversed.toList();
+    historyWithStartAndEnd = transformListResponse(
+      response.payload['historyWithStartAndEnd'],
+    );
+    historyAll = transformListResponse(response.payload['historyAll']);
   });
 
   group('rest#channels#channel#presence#history', () {
@@ -456,7 +441,7 @@ void testCapabilityMatrix(FlutterDriver Function() getDriver) {
 
   setUpAll(() async {
     response = await requestDataForTest(getDriver(), message);
-    capabilityMatrix = response.payload['matrix'] as List<Map<String, dynamic>>;
+    capabilityMatrix = transformListResponse(response.payload['matrix']);
   });
 
   test('capabilitySpec', () {

--- a/test_integration/test_driver/test_implementation/utils.dart
+++ b/test_integration/test_driver/test_implementation/utils.dart
@@ -94,7 +94,7 @@ void testAllPresenceMessagesHistory(Object messagesHistory) {
   }
 }
 
-int timestampSorter(Map a, Map b) {
+int timestampSorter(Map<String, dynamic> a, Map<String, dynamic> b) {
   if (DateTime.parse(a['timestamp'] as String).millisecondsSinceEpoch >
       DateTime.parse(b['timestamp'] as String).millisecondsSinceEpoch) {
     return 1;
@@ -103,7 +103,7 @@ int timestampSorter(Map a, Map b) {
   }
 }
 
-void checkMessageExtras(Map messageExtras) {
+void checkMessageExtras(Map<dynamic, dynamic> messageExtras) {
   expect(messageExtras['push']['notification']['title'], 'Hello from Ably!');
   expect(
     messageExtras['push']['notification']['body'],

--- a/test_integration/test_driver/test_implementation/utils.dart
+++ b/test_integration/test_driver/test_implementation/utils.dart
@@ -111,3 +111,8 @@ void checkMessageExtras(Map<dynamic, dynamic> messageExtras) {
   );
   expect(messageExtras['push']['data']['foo'], 'bar');
 }
+
+List<Map<String, dynamic>> transformListResponse(dynamic items) =>
+    List<dynamic>.from(items as List)
+        .map((t) => t as Map<String, dynamic>)
+        .toList();


### PR DESCRIPTION
This should solve https://github.com/ably/ably-flutter/issues/84. The issue was raised a while ago, and the `implicit dynamic` option was already deprecated, but it was replaced with `strict type checks`. The changes here are mostly cosmetic, but overall they remove ~200 lint warnings in the codebase and remove implicit dynamic typing, which is discouraged in Dart for a while. The changes include:

* Enabled `strict-casts` and `strict-inference` lint rules, as a replacement for `implicit-dynamic`. Also, removed `avoid_annotating_with_dynamic` and `avoid_types_on_closure_parameters` since they conflict with `strict-inference`
* Added declared types to all methods that used implicit dynamic values
* Widened the scope of `dynamic` variables where it was possible. There were some cases where the variable/method did not need `dynamic` at all, as it's type was declared during asignement
* Removed unnecessary cast methods like `transformState` or `transformStateChange`. With declared variable types, there's no need to use methods that cast variables to their type in cases like this, a simple `as` cast is enough, and reduces a lot of boilerplate code
* Added `void` return types for `Future` methods that do not return any value. Previously these methods returned `dynamic` which was always a `void` type