### PR TITLE
Fixed argument error in Swift implementation of Crypto.generateRandomKey

### DIFF
--- a/ios/Classes/handlers/CryptoHandlers.swift
+++ b/ios/Classes/handlers/CryptoHandlers.swift
@@ -24,8 +24,9 @@ public class CryptoHandlers: NSObject {
     
     @objc
     public static let generateRandomKey: FlutterHandler = { plugin, call, result in
-        let dictionary = call.arguments as! Dictionary<String, Any>
-        let keyLength = dictionary[TxCryptoGenerateRandomKey_keyLength] as! Int;
+        let ablyMessage = call.arguments as! AblyFlutterMessage
+        let message = ablyMessage.message as! Dictionary<String, Any>
+        let keyLength = message[TxCryptoGenerateRandomKey_keyLength] as! Int;
         result(ARTCrypto.generateRandomKey(UInt(keyLength)));
     }
 }


### PR DESCRIPTION
I've made a small regression when merging https://github.com/ably/ably-flutter/pull/371 and this PR should fix it. One of the methods in `Crypto` was not updated, causing errors with crypto key generation. It wasn't identified in tests, since I just recently added tests for `Crypto` module in https://github.com/ably/ably-flutter/pull/372.