### PR TITLE
Removed unnecessary serialization of MessageExtras

### DIFF
--- a/lib/src/message/src/message_extras.dart
+++ b/lib/src/message/src/message_extras.dart
@@ -28,9 +28,6 @@ class MessageExtras with ObjectHash {
   /// the data type, runtime
   static MessageExtras? fromMap(Map<String, dynamic>? extrasMap) {
     if (extrasMap == null) return null;
-    extrasMap = Map.castFrom<dynamic, dynamic, String, dynamic>(
-      json.decode(json.encode(extrasMap)) as Map,
-    );
     final deltaMap =
         extrasMap.remove(TxMessageExtras.delta) as Map<String, dynamic>?;
     return MessageExtras._withDelta(


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/133. I've investigated the use of deep copy in this case, and I can't understand why the object has to be copied before use. Here's an example of how the extras object looks like without any processing:

| ![Zrzut ekranu 2022-05-9 o 17 52 00](https://user-images.githubusercontent.com/9201746/167458127-3873969a-1a47-4e8e-a545-49aa487e0d69.png)  | ![Zrzut ekranu 2022-05-9 o 17 52 31](https://user-images.githubusercontent.com/9201746/167458691-380d0e71-7c3a-4f8c-a018-dfea9aa39c3c.png)
|:---:|:---:|
| `extrasMap` before cast | `extrasMap` after deserialization and cast

I think the case made sense before static types were introduced, and the `extrasMap` type was `Map<dynamic, dynamic>`, but right now, since the type is set to `Map<String, dynamic>` I don't think it's necessary to use casts and deep copy here.




