### PR TITLE
Updated ably-java to 1.2.12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     // https://github.com/ably/ably-java/
-    implementation 'io.ably:ably-android:1.2.11'
+    implementation 'io.ably:ably-android:1.2.12'
 
     // https://firebase.google.com/docs/cloud-messaging/android/client
     implementation 'com.google.firebase:firebase-messaging:23.0.0'


### PR DESCRIPTION
This should close #385. The `ably-java` update only contains bugfixes, so it shouldn't affect Flutter SDK in any way.