### PR TITLE
Integration tests for History with AuthCallback

### DIFF
--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -34,40 +34,44 @@ typedef TestFactory = Future<Map<String, dynamic>> Function({
 
 final testFactory = <String, TestFactory>{
   // platform and app key tests
-  TestName.platformAndAblyVersion: testPlatformAndAblyVersion,
   TestName.appKeyProvisioning: testAppKeyProvision,
-  // rest tests
-  TestName.restPublish: testRestPublish,
-  TestName.restEncryptedPublish: testRestEncryptedPublish,
-  TestName.restPublishSpec: testRestPublishSpec,
-  TestName.restEncryptedPublishSpec: testRestEncryptedPublishSpec,
-  TestName.restCapabilities: testRestCapabilities,
-  TestName.restHistory: testRestHistory,
-  TestName.restHistoryWithAuthCallback: testRestHistoryWithAuthCallback,
-  TestName.restTime: testRestTime,
-  TestName.restPublishWithAuthCallback: testRestPublishWithAuthCallback,
-  TestName.restPresenceGet: testRestPresenceGet,
-  TestName.restPresenceHistory: testRestPresenceHistory,
+  TestName.platformAndAblyVersion: testPlatformAndAblyVersion,
+
+  // crypto tests
+  TestName.cryptoEnsureSupportedKeyLength: testCryptoEnsureSupportedKeyLength,
+  TestName.cryptoGenerateRandomKey: testCryptoGenerateRandomKey,
+  TestName.cryptoGetDefaultParams: testCryptoGetDefaultParams,
+
   // realtime tests
-  TestName.realtimePublish: testRealtimePublish,
   TestName.realtimeEncryptedPublish: testRealtimeEncryptedPublish,
-  TestName.realtimePublishSpec: testRealtimePublishSpec,
   TestName.realtimeEncryptedPublishSpec: testRealtimeEncryptedPublishSpec,
   TestName.realtimeEvents: testRealtimeEvents,
-  TestName.realtimeSubscribe: testRealtimeSubscribe,
-  TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,
   TestName.realtimeHistory: testRealtimeHistory,
   TestName.realtimeHistoryWithAuthCallback: testRealtimeHistoryWithAuthCallback,
-  TestName.realtimeTime: testRealtimeTime,
-  TestName.realtimePresenceGet: testRealtimePresenceGet,
-  TestName.realtimePresenceHistory: testRealtimePresenceHistory,
   TestName.realtimePresenceEnterUpdateLeave:
       testRealtimePresenceEnterUpdateLeave,
+  TestName.realtimePresenceGet: testRealtimePresenceGet,
+  TestName.realtimePresenceHistory: testRealtimePresenceHistory,
   TestName.realtimePresenceSubscribe: testRealtimePresenceSubscribe,
-  // crypto tests
-  TestName.cryptoGenerateRandomKey: testCryptoGenerateRandomKey,
-  TestName.cryptoEnsureSupportedKeyLength: testCryptoEnsureSupportedKeyLength,
-  TestName.cryptoGetDefaultParams: testCryptoGetDefaultParams,
+  TestName.realtimePublish: testRealtimePublish,
+  TestName.realtimePublishSpec: testRealtimePublishSpec,
+  TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,
+  TestName.realtimeSubscribe: testRealtimeSubscribe,
+  TestName.realtimeTime: testRealtimeTime,
+
+  // rest tests
+  TestName.restCapabilities: testRestCapabilities,
+  TestName.restEncryptedPublish: testRestEncryptedPublish,
+  TestName.restEncryptedPublishSpec: testRestEncryptedPublishSpec,
+  TestName.restHistory: testRestHistory,
+  TestName.restHistoryWithAuthCallback: testRestHistoryWithAuthCallback,
+  TestName.restPresenceGet: testRestPresenceGet,
+  TestName.restPresenceHistory: testRestPresenceHistory,
+  TestName.restPublish: testRestPublish,
+  TestName.restPublishSpec: testRestPublishSpec,
+  TestName.restPublishWithAuthCallback: testRestPublishWithAuthCallback,
+  TestName.restTime: testRestTime,
+
   // helper tests
   TestName.testHelperUnhandledExceptionTest: testHelperUnhandledException,
 };

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -8,6 +8,7 @@ import 'package:ably_flutter_integration_test/test/helpers_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_encrypted_publish_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_events_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_history_test.dart';
+import 'package:ably_flutter_integration_test/test/realtime/realtime_history_with_auth_callback_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_presence_enter_update_leave.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_presence_get.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_presence_history_test.dart';
@@ -56,6 +57,7 @@ final testFactory = <String, TestFactory>{
   TestName.realtimeSubscribe: testRealtimeSubscribe,
   TestName.realtimePublishWithAuthCallback: testRealtimePublishWithAuthCallback,
   TestName.realtimeHistory: testRealtimeHistory,
+  TestName.realtimeHistoryWithAuthCallback: testRealtimeHistoryWithAuthCallback,
   TestName.realtimeTime: testRealtimeTime,
   TestName.realtimePresenceGet: testRealtimePresenceGet,
   TestName.realtimePresenceHistory: testRealtimePresenceHistory,

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -19,6 +19,7 @@ import 'package:ably_flutter_integration_test/test/realtime/realtime_time_test.d
 import 'package:ably_flutter_integration_test/test/rest/rest_capability_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_encrypted_publish_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_history_test.dart';
+import 'package:ably_flutter_integration_test/test/rest/rest_history_with_auth_callback_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_presence_get_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_presence_history_test.dart';
 import 'package:ably_flutter_integration_test/test/rest/rest_publish_test.dart';
@@ -41,6 +42,7 @@ final testFactory = <String, TestFactory>{
   TestName.restEncryptedPublishSpec: testRestEncryptedPublishSpec,
   TestName.restCapabilities: testRestCapabilities,
   TestName.restHistory: testRestHistory,
+  TestName.restHistoryWithAuthCallback: testRestHistoryWithAuthCallback,
   TestName.restTime: testRestTime,
   TestName.restPublishWithAuthCallback: testRestPublishWithAuthCallback,
   TestName.restPresenceGet: testRestPresenceGet,

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -16,11 +16,12 @@ class TestName {
   static const String restEncryptedPublishSpec = 'restEncryptedPublishSpec';
   static const String restCapabilities = 'restCapabilities';
   static const String restHistory = 'restHistory';
+  static const String restHistoryWithAuthCallback =
+      'restHistoryWithAuthCallback';
   static const String restTime = 'restTime';
   static const String restPublishWithAuthCallback =
       'restPublishWithAuthCallback';
 
-  // TODO(tiholic) handle restHistoryWithAuthCallback
   static const String restPresenceGet = 'restPresenceGet';
   static const String restPresenceHistory = 'restPresenceHistory';
 

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -3,53 +3,57 @@
 /// dependencies and can be imported in driver test files.
 
 class TestName {
-  static const String platformAndAblyVersion = 'platformAndAblyVersion';
+  // platform and key
   static const String appKeyProvisioning = 'appKeyProvisioning';
+  static const String platformAndAblyVersion = 'platformAndAblyVersion';
 
+  // crypto
+  static const String cryptoEnsureSupportedKeyLength =
+      'cryptoEnsureSupportedKeyLength';
+  static const String cryptoGenerateRandomKey = 'cryptoGenerateRandomKey';
+  static const String cryptoGetDefaultParams = 'cryptoGetDefaultParams';
+
+  // realtime
+  static const String realtimeEncryptedPublish = 'realtimeEncryptedPublish';
+  static const String realtimeEncryptedPublishSpec =
+      'realtimeEncryptedPublishSpec';
+  static const String realtimeEvents = 'realtimeEvents';
+  static const String realtimeHistory = 'realtimeHistory';
+  static const String realtimeHistoryWithAuthCallback =
+      'realtimeHistoryWithAuthCallback';
+  static const String realtimePresenceEnterUpdateLeave =
+      'realtimePresenceEnterUpdateLeave';
+  static const String realtimePresenceGet = 'realtimePresenceGet';
+  static const String realtimePresenceHistory = 'realtimePresenceHistory';
+  static const String realtimePresenceSubscribe = 'realtimePresenceSubscribe';
+  static const String realtimePublish = 'realtimePublish';
+  static const String realtimePublishSpec = 'realtimePublishSpec';
+  static const String realtimePublishWithAuthCallback =
+      'realtimePublishWithAuthCallback';
+  static const String realtimeSubscribe = 'realtimeSubscribe';
+  static const String realtimeTime = 'realtimeTime';
+
+  // rest
+  static const String restCapabilities = 'restCapabilities';
+  static const String restEncryptedPublish = 'restEncryptedPublish';
+  static const String restEncryptedPublishSpec = 'restEncryptedPublishSpec';
+  static const String restHistory = 'restHistory';
+  static const String restHistoryWithAuthCallback =
+      'restHistoryWithAuthCallback';
+  static const String restPresenceGet = 'restPresenceGet';
+  static const String restPresenceHistory = 'restPresenceHistory';
+  static const String restPublish = 'restPublish';
+  static const String restPublishSpec = 'restPublishSpec';
+  static const String restPublishWithAuthCallback =
+      'restPublishWithAuthCallback';
+  static const String restTime = 'restTime';
+
+  // helpers
   static const String testHelperFlutterErrorTest = 'testHelperFlutterErrorTest';
   static const String testHelperUnhandledExceptionTest =
       'testHelperUnhandledExceptionTest';
 
-  static const String restPublish = 'restPublish';
-  static const String restEncryptedPublish = 'restEncryptedPublish';
-  static const String restPublishSpec = 'restPublishSpec';
-  static const String restEncryptedPublishSpec = 'restEncryptedPublishSpec';
-  static const String restCapabilities = 'restCapabilities';
-  static const String restHistory = 'restHistory';
-  static const String restHistoryWithAuthCallback =
-      'restHistoryWithAuthCallback';
-  static const String restTime = 'restTime';
-  static const String restPublishWithAuthCallback =
-      'restPublishWithAuthCallback';
-
-  static const String restPresenceGet = 'restPresenceGet';
-  static const String restPresenceHistory = 'restPresenceHistory';
-
-  static const String realtimePublish = 'realtimePublish';
-  static const String realtimeEncryptedPublish = 'realtimeEncryptedPublish';
-  static const String realtimePublishSpec = 'realtimePublishSpec';
-  static const String realtimeEncryptedPublishSpec =
-      'realtimeEncryptedPublishSpec';
-  static const String realtimeEvents = 'realtimeEvents';
-  static const String realtimeSubscribe = 'realtimeSubscribe';
-  static const String realtimeHistory = 'realtimeHistory';
-  static const String realtimeHistoryWithAuthCallback =
-      'realtimeHistoryWithAuthCallback';
-  static const String realtimeTime = 'realtimeTime';
-  static const String realtimePublishWithAuthCallback =
-      'realtimePublishWithAuthCallback';
-  static const String realtimePresenceGet = 'realtimePresenceGet';
-  static const String realtimePresenceHistory = 'realtimePresenceHistory';
-  static const String realtimePresenceEnterUpdateLeave =
-      'realtimePresenceEnterUpdateLeave';
-  static const String realtimePresenceSubscribe = 'realtimePresenceSubscribe';
-
-  static const String cryptoGenerateRandomKey = 'cryptoGenerateRandomKey';
-  static const String cryptoEnsureSupportedKeyLength =
-      'cryptoEnsureSupportedKeyLength';
-  static const String cryptoGetDefaultParams = 'cryptoGetDefaultParams';
-
-  // This is not a test, but a way to retrieve
   // more information of failures from any of the tests cases
+  // This is not a test, but a way to retrieve
   static const String getFlutterErrors = 'getFlutterErrors';
 }

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -53,7 +53,7 @@ class TestName {
   static const String testHelperUnhandledExceptionTest =
       'testHelperUnhandledExceptionTest';
 
-  // more information of failures from any of the tests cases
   // This is not a test, but a way to retrieve
+  // more information of failures from any of the tests cases
   static const String getFlutterErrors = 'getFlutterErrors';
 }

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -33,6 +33,8 @@ class TestName {
   static const String realtimeEvents = 'realtimeEvents';
   static const String realtimeSubscribe = 'realtimeSubscribe';
   static const String realtimeHistory = 'realtimeHistory';
+  static const String realtimeHistoryWithAuthCallback =
+      'realtimeHistoryWithAuthCallback';
   static const String realtimeTime = 'realtimeTime';
   static const String realtimePublishWithAuthCallback =
       'realtimePublishWithAuthCallback';
@@ -41,7 +43,6 @@ class TestName {
   static const String realtimePresenceEnterUpdateLeave =
       'realtimePresenceEnterUpdateLeave';
   static const String realtimePresenceSubscribe = 'realtimePresenceSubscribe';
-// TODO(tiholic) handle realtimeHistoryWithAuthCallback
 
   static const String cryptoGenerateRandomKey = 'cryptoGenerateRandomKey';
   static const String cryptoEnsureSupportedKeyLength =

--- a/test_integration/lib/test/realtime/realtime_history_with_auth_callback_test.dart
+++ b/test_integration/lib/test/realtime/realtime_history_with_auth_callback_test.dart
@@ -1,0 +1,36 @@
+import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/app_provisioning.dart';
+import 'package:ably_flutter_integration_test/config/test_constants.dart';
+import 'package:ably_flutter_integration_test/factory/reporter.dart';
+import 'package:ably_flutter_integration_test/utils/realtime.dart';
+
+Future<Map<String, dynamic>> testRealtimeHistoryWithAuthCallback({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  var authCallbackInvoked = false;
+
+  final realtime = Realtime(
+    options: ClientOptions(
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+      authCallback: (params) async {
+        authCallbackInvoked = true;
+        return TokenRequest.fromMap(
+          await AppProvisioning().getTokenRequest(),
+        );
+      },
+    ),
+  );
+
+  final channel = realtime.channels.get('test');
+  await publishMessages(channel);
+
+  await channel.history();
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
+
+  return {
+    'handle': await realtime.handle,
+    'authCallbackInvoked': authCallbackInvoked,
+  };
+}

--- a/test_integration/lib/test/rest/rest_history_with_auth_callback_test.dart
+++ b/test_integration/lib/test/rest/rest_history_with_auth_callback_test.dart
@@ -1,0 +1,36 @@
+import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/app_provisioning.dart';
+import 'package:ably_flutter_integration_test/config/test_constants.dart';
+import 'package:ably_flutter_integration_test/factory/reporter.dart';
+import 'package:ably_flutter_integration_test/utils/rest.dart';
+
+Future<Map<String, dynamic>> testRestHistoryWithAuthCallback({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  var authCallbackInvoked = false;
+
+  final rest = Rest(
+    options: ClientOptions(
+      clientId: 'someClientId',
+      logLevel: LogLevel.verbose,
+      authCallback: (params) async {
+        authCallbackInvoked = true;
+        return TokenRequest.fromMap(
+          await AppProvisioning().getTokenRequest(),
+        );
+      },
+    ),
+  );
+
+  final channel = rest.channels.get('test');
+  await publishMessages(channel);
+
+  await channel.history();
+  await Future<void>.delayed(TestConstants.publishToHistoryDelay);
+
+  return {
+    'handle': await rest.handle,
+    'authCallbackInvoked': authCallbackInvoked
+  };
+}

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -505,6 +505,17 @@ void testRealtimeHistory(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRealtimeHistoryWithAuthCallback(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.realtimeHistoryWithAuthCallback);
+  late TestControlResponseMessage response;
+  setUpAll(
+      () async => response = await requestDataForTest(getDriver(), message));
+
+  test('auth callback is invoked', () {
+    expect(response.payload['authCallbackInvoked'], isTrue);
+  });
+}
+
 void testRealtimeTime(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeTime);
   late TestControlResponseMessage response;

--- a/test_integration/test_driver/test_implementation/rest_tests.dart
+++ b/test_integration/test_driver/test_implementation/rest_tests.dart
@@ -299,6 +299,17 @@ void testRestHistory(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRestHistoryWithAuthCallback(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.restHistoryWithAuthCallback);
+  late TestControlResponseMessage response;
+  setUpAll(
+      () async => response = await requestDataForTest(getDriver(), message));
+
+  test('auth callback is invoked', () {
+    expect(response.payload['authCallbackInvoked'], isTrue);
+  });
+}
+
 void testRestTime(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.restTime);
   late TestControlResponseMessage response;

--- a/test_integration/test_driver/tests_config.dart
+++ b/test_integration/test_driver/tests_config.dart
@@ -21,6 +21,8 @@ final _tests =
     'should publish': testRestPublish,
     'should publish encrypted': testRestEncryptedPublish,
     'should retrieve history': testRestHistory,
+    'should retrieve history with auth callback':
+        testRestHistoryWithAuthCallback,
     'should retrieve time': testRestTime,
     'conforms to publish spec': testRestPublishSpec,
     'conforms to publish spec when encrypted': testRestEncryptedPublishSpec,
@@ -37,6 +39,8 @@ final _tests =
     'should subscribe to connection and channel': testRealtimeEvents,
     'should subscribe to messages': testRealtimeSubscribe,
     'should retrieve history': testRealtimeHistory,
+    'should retrieve history with auth callback':
+        testRealtimeHistoryWithAuthCallback,
     'should retrieve time': testRealtimeTime,
     'realtime#channels#channel#presence#get': testRealtimePresenceGet,
     'realtime#channels#channel#presence#history': testRealtimePresenceHistory,


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/87. I've added new tests to cover the cases of fetching history when AuthCallback is used in `ClientOptions`