### PR TITLE
Added support for iOS 15 notification scheduledDeliverySettings

### DIFF
--- a/ios/Classes/codec/encoders/PushNotificationEncoders.swift
+++ b/ios/Classes/codec/encoders/PushNotificationEncoders.swift
@@ -73,10 +73,9 @@ public class PushNotificationEncoders: NSObject {
         if #available(iOS 13.0, *) {
             dictionary[TxUNNotificationSettings_announcementSetting] = settings.announcementSetting.toString()
         }
-        // TODO Use this once Xcode 13 is used (iOS15 is released/ supported)
-//        if #available(iOS 15.0, *) {
-//            dictionary[TxUNNotificationSettings_scheduledDeliverySetting] = settings.scheduledDeliverySetting.toString()
-//        }
+        if #available(iOS 15.0, *) {
+           dictionary[TxUNNotificationSettings_scheduledDeliverySetting] = settings.scheduledDeliverySetting.toString()
+        }
         
         return dictionary;
     }

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -828,6 +828,9 @@ class Codec extends StandardMessageCodec {
                 as bool,
         announcementSetting: _decodeUNNotificationSetting(
             jsonMap[TxUNNotificationSettings.announcementSetting] as String),
+        scheduledDeliverySetting: _decodeUNNotificationSetting(
+            jsonMap[TxUNNotificationSettings.scheduledDeliverySetting]
+                as String),
       );
 
   UNShowPreviewsSetting _decodeUNShowPreviewsSetting(String setting) {

--- a/lib/src/push_notifications/src/ios_notification_settings.dart
+++ b/lib/src/push_notifications/src/ios_notification_settings.dart
@@ -65,6 +65,7 @@ class UNNotificationSettings {
   bool providesAppNotificationSettings;
   UNNotificationSetting soundSetting;
   UNShowPreviewsSetting showPreviewsSetting;
+  UNNotificationSetting scheduledDeliverySetting;
 
   /// Users do not create this class. Call [Push.getNotificationSettings]
   /// instead.
@@ -81,5 +82,6 @@ class UNNotificationSettings {
     required this.providesAppNotificationSettings,
     required this.showPreviewsSetting,
     required this.soundSetting,
+    required this.scheduledDeliverySetting,
   });
 }


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/389. I've implemented support for additional notification param introduced in iOS 15.

I haven't foud anything else that we should do for iOS 15 compatibility.