### PR TITLE
Set Flutter CI version to ^3.0.0

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,21 +13,21 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.0.x"
+          flutter-version: '3.0.x'
           cache: true
 
       # This step requires fetch of test_integration packages because flutter format and
       # flutter analyze check test_integration package too
-      - name: "Install dependencies"
+      - name: 'Install dependencies'
         run: |
           flutter pub get
           cd test_integration && flutter pub get
 
-      - name: "Check formatting issues in the code"
+      - name: 'Check formatting issues in the code'
         run: flutter format --set-exit-if-changed .
 
-      - name: "Statically analyze the Dart code for any errors"
-        run: "flutter analyze --no-pub ."
+      - name: 'Statically analyze the Dart code for any errors'
+        run: 'flutter analyze --no-pub .'
 
-      - name: "Run unit tests"
+      - name: 'Run unit tests'
         run: flutter test --no-pub

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -8,26 +8,26 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-
       - name: Checkout
         uses: actions/checkout@v2
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: "3.0.x"
           cache: true
 
-      # This step requires fetch of test_integration packages because flutter format and 
+      # This step requires fetch of test_integration packages because flutter format and
       # flutter analyze check test_integration package too
-      - name: 'Install dependencies'
+      - name: "Install dependencies"
         run: |
           flutter pub get
           cd test_integration && flutter pub get
 
-      - name: 'Check formatting issues in the code'
+      - name: "Check formatting issues in the code"
         run: flutter format --set-exit-if-changed .
-        
-      - name: 'Statically analyze the Dart code for any errors'
-        run: 'flutter analyze --no-pub .'
 
-      - name: 'Run unit tests'
+      - name: "Statically analyze the Dart code for any errors"
+        run: "flutter analyze --no-pub ."
+
+      - name: "Run unit tests"
         run: flutter test --no-pub

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: "3.0.x"
           cache: true
 
       - name: Get Flutter Packages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.0.x"
+          flutter-version: '3.0.x'
           cache: true
 
       - name: Get Flutter Packages

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -9,28 +9,28 @@ jobs:
     strategy:
       matrix:
         device: # Device names must be shown in `xcrun simctl list devices`
-          - "iPhone 12" # we are not specifying the iOS version as it tends to change
+          - 'iPhone 12' # we are not specifying the iOS version as it tends to change
       fail-fast: false
-    runs-on: "macos-11"
+    runs-on: 'macos-11'
     steps:
-      - name: "List Simulators"
-        run: "xcrun simctl list devices"
+      - name: 'List Simulators'
+        run: 'xcrun simctl list devices'
 
-      - name: "Start Simulator"
+      - name: 'Start Simulator'
         run: xcrun simctl boot "${{ matrix.device }}"
 
       - uses: actions/checkout@v2
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.0.x"
+          flutter-version: '3.0.x'
           cache: true
 
       # test_integration package depends on ably_flutter, so before we run integration
       # tests it's best to perform dependency update in both packages, to make sure that
       # integration tests are run with exactly the same dependencies as specified in
       # current version of ably_flutter package
-      - name: "Run Flutter Driver tests"
+      - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
         run: |
           flutter pub get
@@ -42,21 +42,21 @@ jobs:
         api-level: [21, 29]
       fail-fast: false
 
-    runs-on: "ubuntu-latest"
+    runs-on: 'ubuntu-latest'
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-java@v1
         with:
-          java-version: "8.x"
+          java-version: '8.x'
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: "3.0.x"
+          flutter-version: '3.0.x'
           cache: true
 
-      - name: "Run Flutter Driver tests"
+      - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -9,27 +9,28 @@ jobs:
     strategy:
       matrix:
         device: # Device names must be shown in `xcrun simctl list devices`
-          - 'iPhone 12'  # we are not specifying the iOS version as it tends to change
+          - "iPhone 12" # we are not specifying the iOS version as it tends to change
       fail-fast: false
-    runs-on: 'macos-11'
+    runs-on: "macos-11"
     steps:
-      - name: 'List Simulators'
-        run: 'xcrun simctl list devices'
+      - name: "List Simulators"
+        run: "xcrun simctl list devices"
 
-      - name: 'Start Simulator'
+      - name: "Start Simulator"
         run: xcrun simctl boot "${{ matrix.device }}"
 
       - uses: actions/checkout@v2
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: "3.0.x"
           cache: true
 
-      # test_integration package depends on ably_flutter, so before we run integration 
+      # test_integration package depends on ably_flutter, so before we run integration
       # tests it's best to perform dependency update in both packages, to make sure that
-      # integration tests are run with exactly the same dependencies as specified in 
+      # integration tests are run with exactly the same dependencies as specified in
       # current version of ably_flutter package
-      - name: 'Run Flutter Driver tests'
+      - name: "Run Flutter Driver tests"
         timeout-minutes: 30
         run: |
           flutter pub get
@@ -41,20 +42,21 @@ jobs:
         api-level: [21, 29]
       fail-fast: false
 
-    runs-on: 'ubuntu-latest'
+    runs-on: "ubuntu-latest"
 
     steps:
       - uses: actions/checkout@v2
 
       - uses: actions/setup-java@v1
         with:
-          java-version: '8.x'
+          java-version: "8.x"
 
       - uses: subosito/flutter-action@v2
         with:
+          flutter-version: "3.0.x"
           cache: true
 
-      - name: 'Run Flutter Driver tests'
+      - name: "Run Flutter Driver tests"
         timeout-minutes: 30
         uses: reactivecircus/android-emulator-runner@v2
         with:

--- a/lib/src/platform/src/platform_object.dart
+++ b/lib/src/platform/src/platform_object.dart
@@ -42,7 +42,6 @@ abstract class PlatformObject {
       [final Map<String, dynamic>? argument]) async {
     final message = AblyMessage(
       message: argument ?? {},
-      handle: null,
     );
     return _platform.invokePlatformMethod<T>(method, message);
   }

--- a/lib/src/platform/src/streams_channel.dart
+++ b/lib/src/platform/src/streams_channel.dart
@@ -48,6 +48,9 @@ class StreamsChannel {
 
     late StreamController<T> controller;
     controller = StreamController<T>.broadcast(onListen: () async {
+      // We need to keep this null-asserted for backwards compatibility with
+      // Flutter versions before 3.0.0
+      // ignore: unnecessary_non_null_assertion
       ServicesBinding.instance!.defaultBinaryMessenger
           .setMessageHandler(handlerName, (reply) async {
         if (reply == null) {
@@ -78,6 +81,9 @@ class StreamsChannel {
         ));
       }
     }, onCancel: () async {
+      // We need to keep this null-asserted for backwards compatibility with
+      // Flutter versions before 3.0.0
+      // ignore: unnecessary_non_null_assertion
       ServicesBinding.instance!.defaultBinaryMessenger
           .setMessageHandler(handlerName, null);
       try {

--- a/lib/src/push_notifications/src/push.dart
+++ b/lib/src/push_notifications/src/push.dart
@@ -140,7 +140,7 @@ class Push extends PlatformObject {
     if (io.Platform.isAndroid) {
       return invoke(PlatformMethod.pushReset);
     } else {
-      return Future.value(null);
+      return Future.value();
     }
   }
 


### PR DESCRIPTION
Since `ably-flutter` is ready to be used with Flutter 3, I've updated the CI workflows to use stable Flutter versions 3.0.x. This is also a blocker for #401 because latest versions of `test` dependency requires Flutter 3 to run. I've also updated the formatting of YAML files to increase consistency