### PR TITLE
Added .pubignore to disable publishing tests to pub.dev

### DIFF
--- a/.pubignore
+++ b/.pubignore
@@ -1,0 +1,4 @@
+# Test suite is not published for pub.dev
+# See <https://github.com/ably/ably-flutter/issues/400#issuecomment-1129236627>
+test/
+test_integration/


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/400. I've added a `.pubignore` file to skip `test` and `integration_test` packages when publishing to pub.dev. This was the easiest way to resolve the problem mentioned in https://github.com/ably/ably-flutter/issues/400#issuecomment-1129236627, and pub.dev doesn't really give us any benefit for publishing the package with test suite included.