### PR TITLE
Replaced silent serialization errors with exceptions

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -56,7 +56,6 @@ public class AblyMessageCodec extends StandardMessageCodec {
   }
 
   private static class CodecPair<T> {
-    private static final String TAG = CodecPair.class.getName();
     final CodecEncoder<T> encoder;
     final CodecDecoder<T> decoder;
 
@@ -67,16 +66,14 @@ public class AblyMessageCodec extends StandardMessageCodec {
 
     Map<String, Object> encode(final Object value) {
       if (this.encoder == null) {
-        Log.w(TAG, "Encoder is null");
-        return null;
+        throw SerializationException.forEncoder(value.getClass());
       }
       return this.encoder.encode((T) value);
     }
 
     T decode(Map<String, Object> jsonMap) {
       if (this.decoder == null) {
-        Log.w(TAG, "Decoder is null");
-        return null;
+        throw SerializationException.forDecoder(jsonMap);
       }
       return this.decoder.decode(jsonMap);
     }

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import io.ably.flutter.plugin.generated.PlatformConstants;
+import io.ably.flutter.plugin.types.SerializationException;
 import io.ably.flutter.plugin.types.PlatformClientOptions;
 import io.ably.flutter.plugin.util.CipherParamsStorage;
 import io.ably.flutter.plugin.util.Consumer;
@@ -346,7 +347,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case PlatformConstants.TxLogLevelEnum.error:
         return Log.ERROR;
       default:
-        return Log.WARN;
+        throw SerializationException.forEnum(logLevelString, Log.class);
     }
   }
 
@@ -461,7 +462,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case PlatformConstants.TxEnumConstants.presenceSubscribe:
         return ChannelMode.presence_subscribe;
       default:
-        return null;
+        throw SerializationException.forEnum(mode, ChannelMode.class);
     }
   }
 
@@ -644,7 +645,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case failed:
         return PlatformConstants.TxEnumConstants.failed;
       default:
-        return null;
+        throw SerializationException.forEnum(state, String.class);
     }
   }
 
@@ -669,7 +670,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case update:
         return PlatformConstants.TxEnumConstants.update;
       default:
-        return null;
+        throw SerializationException.forEnum(event, String.class);
     }
   }
 
@@ -690,7 +691,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case suspended:
         return PlatformConstants.TxEnumConstants.suspended;
       default:
-        return null;
+        throw SerializationException.forEnum(state, String.class);
     }
   }
 
@@ -713,7 +714,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case update:
         return PlatformConstants.TxEnumConstants.update;
       default:
-        return null;
+        throw SerializationException.forEnum(event, String.class);
     }
   }
 
@@ -801,7 +802,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case FAILED:
         return PlatformConstants.TxDevicePushStateEnum.failed;
       default:
-        return null;
+        throw SerializationException.forEnum(state, String.class);
     }
   }
 
@@ -874,7 +875,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
       case update:
         return PlatformConstants.TxEnumConstants.update;
       default:
-        return null;
+        throw SerializationException.forEnum(action, String.class);
     }
   }
 

--- a/android/src/main/java/io/ably/flutter/plugin/types/SerializationException.java
+++ b/android/src/main/java/io/ably/flutter/plugin/types/SerializationException.java
@@ -12,4 +12,12 @@ public class SerializationException extends RuntimeException {
     public static SerializationException forEnum(Object value, Class type) {
         return new SerializationException(value.toString() + " can't be encoded/decoded to " + type.toString());
     }
+
+    public static SerializationException forEncoder(Class type) {
+        return new SerializationException("No encoder found for " + type.toString());
+    }
+
+    public static SerializationException forDecoder(Object value) {
+        return new SerializationException("No decoder found for value " + value.toString());
+    }
 }

--- a/android/src/main/java/io/ably/flutter/plugin/types/SerializationException.java
+++ b/android/src/main/java/io/ably/flutter/plugin/types/SerializationException.java
@@ -1,0 +1,15 @@
+package io.ably.flutter.plugin.types;
+
+/**
+ * Thrown during object serialization
+ */
+public class SerializationException extends RuntimeException {
+
+    public SerializationException(String message) {
+        super(message);
+    }
+
+    public static SerializationException forEnum(Object value, Class type) {
+        return new SerializationException(value.toString() + " can't be encoded/decoded to " + type.toString());
+    }
+}


### PR DESCRIPTION
This closes https://github.com/ably/ably-flutter/issues/149. Previously, serialization of enums and values without assigned encoder/decoder failed silently, returning `null` when proper value was not found. I've replaced these `null` returns with thrown exceptions, so it's clear that an error has occurred, and should be fixed