### PR TITLE
Updated Android CI to Java 11

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -47,9 +47,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
-          java-version: '8.x'
+          distribution: 'temurin'
+          java-version: '11'
 
       - uses: subosito/flutter-action@v2
         with:


### PR DESCRIPTION
This should fix https://github.com/ably/ably-flutter/issues/417. Updated version of `setup-java` step to `v3` and changed JDK used for Android from 1.8 to 11 (release from Temurin OpenJDK builds)