### PR TITLE
Added lint ignore on deprecated fields

### DIFF
--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -267,7 +267,10 @@ class Codec extends StandardMessageCodec {
     _writeToJson(jsonMap, TxClientOptions.realtimeRequestTimeout,
         v.realtimeRequestTimeout);
     _writeToJson(jsonMap, TxClientOptions.fallbackHosts, v.fallbackHosts);
-    _writeToJson(jsonMap, TxClientOptions.fallbackHostsUseDefault,
+    _writeToJson(
+        jsonMap,
+        TxClientOptions.fallbackHostsUseDefault,
+        // ignore: deprecated_member_use_from_same_package
         v.fallbackHostsUseDefault);
     _writeToJson(
         jsonMap, TxClientOptions.fallbackRetryTimeout, v.fallbackRetryTimeout);

--- a/test/models/client_options.dart
+++ b/test/models/client_options.dart
@@ -27,6 +27,7 @@ void main() {
     expect(clientOptions.httpMaxRetryCount, isNull);
     expect(clientOptions.realtimeRequestTimeout, isNull);
     expect(clientOptions.fallbackHosts, isNull);
+    // ignore: deprecated_member_use_from_same_package
     expect(clientOptions.fallbackHostsUseDefault, isNull);
     expect(clientOptions.fallbackRetryTimeout, isNull);
     expect(clientOptions.defaultTokenParams, isNull);


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/416. Altrought we're using the deprecated fields only inside `ably_flutter` package, the lint still produces an error on pub.dev, so we have to ignore those manually.