### PR TITLE
Replaced old dartdoc usage with new doc tool

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,15 +17,9 @@ jobs:
           flutter-version: '3.0.x'
           cache: true
 
-      - name: Get Flutter Packages
-        run: flutter pub get
-
-      - name: Install dartdoc global package via pub tool in the Flutter context
-        run: flutter pub global activate dartdoc
-
       - name: Build Documentation
         run: |
-          flutter pub global run dartdoc
+          dart doc
           ls -al doc/api
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
This should close https://github.com/ably/ably-flutter/issues/410. I've replaced the `dartdoc` usage as an external package with `dart doc` tool, which is now a part of Dart SDK.