### PR TITLE
Fix for running didFinishLaunchingWithOptions

### DIFF
--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -767,7 +767,7 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutter *const ably, Flutt
         PushHandlers.pushNotificationTapLaunchedAppFromTerminatedData = notification;
     }
     
-    return NO;
+    return YES;
 }
 
 #pragma mark - Push Notifications Registration - UIApplicationDelegate
@@ -785,7 +785,7 @@ static const FlutterHandler _getFirstPage = ^void(AblyFlutter *const ably, Flutt
 
 - (BOOL)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     [_pushNotificationEventHandlers application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-    return NO;
+    return YES;
 }
 
 @end


### PR DESCRIPTION
Added fix for running `didFinishLaunchingWithOptions` in other registered plugins like uni_links.

Problem:

Since `didFinishLaunchingWithOptions` was returning NO, other plugins such as `uni_links`, also get the `initialAppLink` from `didFinishLaunchingWithOptions` were not able to run the function. This resulted in initialAppLink being `null` always.