### PR TITLE
Update ably-android to 1.2.14

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     // https://github.com/ably/ably-java/
-    implementation 'io.ably:ably-android:1.2.14'
+    implementation 'io.ably:ably-android:1.2.15'
 
     // https://firebase.google.com/docs/cloud-messaging/android/client
     implementation 'com.google.firebase:firebase-messaging:23.0.4'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     // https://github.com/ably/ably-java/
-    implementation 'io.ably:ably-android:1.2.12'
+    implementation 'io.ably:ably-android:1.2.14'
 
     // https://firebase.google.com/docs/cloud-messaging/android/client
     implementation 'com.google.firebase:firebase-messaging:23.0.4'


### PR DESCRIPTION
As was suggested by @QuintinWillison - I've updated the ably-android dependency to the 1.2.14 version (Readme for [ably-java](https://github.com/ably/ably-java) says that the `io.ably:ably-android:1.2.15` should be available, but it looks like it has not been deployed yet).