### PR TITLE
Expose error info in AblyException toString

### DIFF
--- a/lib/src/error/src/ably_exception.dart
+++ b/lib/src/error/src/ably_exception.dart
@@ -31,7 +31,7 @@ class AblyException implements Exception {
 
   @override
   String toString() {
-    if(errorInfo != null){
+    if (errorInfo != null) {
       return 'AblyException ($errorInfo)';
     }
 

--- a/lib/src/error/src/ably_exception.dart
+++ b/lib/src/error/src/ably_exception.dart
@@ -32,11 +32,11 @@ class AblyException implements Exception {
   @override
   String toString() {
     if (errorInfo != null) {
-      return 'AblyException ($errorInfo)';
+      return 'AblyException: ($errorInfo)';
     }
 
     if (message == null) {
-      return 'AblyException (${(code == null) ? "" : '$code '})';
+      return 'AblyException: (${(code == null) ? "" : '$code '})';
     }
 
     return 'AblyException: $message (${(code == null) ? "" : '$code '})';

--- a/lib/src/error/src/ably_exception.dart
+++ b/lib/src/error/src/ably_exception.dart
@@ -31,9 +31,14 @@ class AblyException implements Exception {
 
   @override
   String toString() {
+    if(errorInfo != null){
+      return 'AblyException ($errorInfo)';
+    }
+
     if (message == null) {
       return 'AblyException (${(code == null) ? "" : '$code '})';
     }
+
     return 'AblyException: $message (${(code == null) ? "" : '$code '})';
   }
 }

--- a/lib/src/error/src/ably_exception.dart
+++ b/lib/src/error/src/ably_exception.dart
@@ -31,14 +31,20 @@ class AblyException implements Exception {
 
   @override
   String toString() {
+    final buffer = StringBuffer('AblyException:');
+
     if (errorInfo != null) {
-      return 'AblyException: ($errorInfo)';
+      buffer.write(' errorInfo=($errorInfo)');
     }
 
-    if (message == null) {
-      return 'AblyException: (${(code == null) ? "" : '$code '})';
+    if (message != null) {
+      buffer.write(' message=($message)');
     }
 
-    return 'AblyException: $message (${(code == null) ? "" : '$code '})';
+    if (code != null) {
+      buffer.write(' code=($code)');
+    }
+
+    return buffer.toString();
   }
 }


### PR DESCRIPTION
Exposing full 'ErrorInfo' contents in 'AblyException.toString()' primarily to expose 'href'

Resolves #441 