### PR TITLE
Read authUrl as NSURL

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -23,7 +23,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     // https://github.com/ably/ably-java/
-    implementation 'io.ably:ably-android:1.2.27'
+    implementation 'io.ably:ably-android:1.2.28'
 
     // https://firebase.google.com/docs/cloud-messaging/android/client
     implementation 'com.google.firebase:firebase-messaging:23.0.4'

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -102,6 +102,10 @@ BLOCK(value); \
 ON_VALUE(^(const id value) {if(!([value isKindOfClass:[NSNull class]])) OBJECT.PROPERTY = value; }, DICTIONARY, JSON_KEY); \
 }
 
+#define READ_URL(OBJECT, PROPERTY, DICTIONARY, JSON_KEY) { \
+ON_VALUE(^(const id value) {if(!([value isKindOfClass:[NSNull class]])) OBJECT.PROPERTY = [NSURL URLWithString:value]; }, DICTIONARY, JSON_KEY); \
+}
+
 /**
  Where an NSNumber has been decoded and the property to be set is BOOL.
  */
@@ -111,9 +115,8 @@ ON_VALUE(^(const id number) {if(!([value isKindOfClass:[NSNull class]])) OBJECT.
 
 static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDictionary *const dictionary) {
     ARTClientOptions *const clientOptions = [ARTClientOptions new];
-
     // AuthOptions (super class of ClientOptions)
-    READ_VALUE(clientOptions, authUrl, dictionary, TxClientOptions_authUrl);
+    READ_URL(clientOptions, authUrl, dictionary, TxClientOptions_authUrl);
     READ_VALUE(clientOptions, authMethod, dictionary, TxClientOptions_authMethod);
     READ_VALUE(clientOptions, key, dictionary, TxClientOptions_key);
     ON_VALUE(^(const id value) { clientOptions.tokenDetails = [AblyFlutterReader tokenDetailsFromDictionary: value]; }, dictionary, TxClientOptions_tokenDetails);
@@ -159,8 +162,7 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
 
 static AblyCodecDecoder readAuthOptions = ^ARTAuthOptions*(NSDictionary *const dictionary) {
     ARTAuthOptions *const authOptions = [ARTAuthOptions new];
-    READ_VALUE(authOptions, authUrl, dictionary, TxAuthOptions_authUrl);
-    
+    READ_URL(authOptions, authUrl, dictionary, TxAuthOptions_authUrl);
     READ_VALUE(authOptions, authMethod, dictionary, TxAuthOptions_authMethod)
      
     ON_VALUE(^(const id value) { authOptions.tokenDetails = [AblyFlutterReader tokenDetailsFromDictionary: value]; }, dictionary, TxAuthOptions_tokenDetails);

--- a/test_integration/lib/config/test_factory.dart
+++ b/test_integration/lib/config/test_factory.dart
@@ -6,6 +6,7 @@ import 'package:ably_flutter_integration_test/test/crypto/crypto_generate_random
 import 'package:ably_flutter_integration_test/test/crypto/crypto_get_default_params.dart';
 import 'package:ably_flutter_integration_test/test/helpers_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime/realtime_auth_client_id_test.dart';
+import 'package:ably_flutter_integration_test/test/realtime/realtime_auth_url_test.dart';
 import 'package:ably_flutter_integration_test/test/realtime'
     '/realtime_authorize_test'
     '.dart';
@@ -68,6 +69,7 @@ final testFactory = <String, TestFactory>{
   TestName.realtimeTime: testRealtimeTime,
   TestName.realtimeAuthAuthorize: testRealtimeAuthroize,
   TestName.realtimeAuthClientId: testRealtimeAuthClientId,
+  TestName.realtimeWithAuthUrl: testCreateRealtimeWithAuthUrl,
 
   // rest tests
   TestName.restCapabilities: testRestCapabilities,

--- a/test_integration/lib/config/test_names.dart
+++ b/test_integration/lib/config/test_names.dart
@@ -36,6 +36,7 @@ class TestName {
   static const String realtimeCreateTokenRequest = 'realtimeCreateTokenRequest';
   static const String realtimeRequestToken = 'realtimeRequestToken';
   static const String realtimeAuthClientId = 'realtimeAuthClientId';
+  static const String realtimeWithAuthUrl = 'realtimeWithAuthUrl';
 
   // rest
   static const String restCapabilities = 'restCapabilities';

--- a/test_integration/lib/test/realtime/realtime_auth_url_test.dart
+++ b/test_integration/lib/test/realtime/realtime_auth_url_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter_integration_test/app_provisioning.dart';
 import 'package:ably_flutter_integration_test/factory/reporter.dart';
@@ -30,16 +32,16 @@ Future<Map<String, dynamic>> testCreateRealtimeWithAuthUrl({
       autoConnect: false,
       logLevel: LogLevel.verbose);
   final realtime = Realtime(options: options);
-  var connected = false;
+  final completer = Completer<void>();
   realtime.connection.on().listen((stateChange) {
-    if (stateChange.event == ConnectionEvent.connected) {
-      connected = true;
+    if (stateChange.current == ConnectionState.connected) {
+      completer.complete();
     }
   });
   await realtime.connect();
-  await Future<void>.delayed(const Duration(seconds: 5));
-  if (!connected) {
+  await completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
     throw Error();
-  }
+  });
+
   return {'handle': await realtime.handle};
 }

--- a/test_integration/lib/test/realtime/realtime_auth_url_test.dart
+++ b/test_integration/lib/test/realtime/realtime_auth_url_test.dart
@@ -1,4 +1,3 @@
-
 import 'dart:io';
 
 import 'package:ably_flutter/ably_flutter.dart';

--- a/test_integration/lib/test/realtime/realtime_auth_url_test.dart
+++ b/test_integration/lib/test/realtime/realtime_auth_url_test.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ffi';
 
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter_integration_test/app_provisioning.dart';
@@ -39,9 +40,12 @@ Future<Map<String, dynamic>> testCreateRealtimeWithAuthUrl({
     }
   });
   await realtime.connect();
-  await completer.future.timeout(const Duration(seconds: 30), onTimeout: () {
+  Future<Void> _onTimeout() {
     throw Error();
-  });
+  }
+
+  await completer.future
+      .timeout(const Duration(seconds: 30), onTimeout: _onTimeout);
 
   return {'handle': await realtime.handle};
 }

--- a/test_integration/lib/test/realtime/realtime_auth_url_test.dart
+++ b/test_integration/lib/test/realtime/realtime_auth_url_test.dart
@@ -37,7 +37,7 @@ Future<Map<String, dynamic>> testCreateRealtimeWithAuthUrl({
     }
   });
   await realtime.connect();
-  await Future<Duration>.delayed(const Duration(seconds: 5));
+  await Future<void>.delayed(const Duration(seconds: 5));
   if (!connected) {
     throw Error();
   }

--- a/test_integration/lib/test/realtime/realtime_auth_url_test.dart
+++ b/test_integration/lib/test/realtime/realtime_auth_url_test.dart
@@ -1,0 +1,42 @@
+
+import 'dart:io';
+
+import 'package:ably_flutter/ably_flutter.dart';
+import 'package:ably_flutter_integration_test/app_provisioning.dart';
+import 'package:ably_flutter_integration_test/factory/reporter.dart';
+
+//Make sure that creating realtime with authURL won't crash
+Future<Map<String, dynamic>> testCreateRealtimeWithAuthUrl({
+  required Reporter reporter,
+  Map<String, dynamic>? payload,
+}) async {
+  reporter.reportLog('init start');
+  final appKey = await AppProvisioning().provisionApp();
+
+  final clientOptionsForToken = ClientOptions(
+    key: appKey,
+    environment: 'sandbox',
+    logLevel: LogLevel.verbose,
+  );
+
+  final ablyForToken = Rest(
+    options: clientOptionsForToken,
+  );
+  final accessToken = await ablyForToken.auth.requestToken();
+
+  final Map<String, String> headers = {
+    HttpHeaders.authorizationHeader: "Bearer $accessToken",
+    HttpHeaders.contentTypeHeader: "application/json",
+    HttpHeaders.acceptLanguageHeader: "ios",
+  };
+  final options = ClientOptions(
+    authUrl: 'https://auth.ably.io/auth',
+    authHeaders: headers,
+    echoMessages: false,
+  );
+  final realtime = Realtime(options: options);
+  realtime.connection.on().listen((stateChange) {
+    print("Ably connection state changed: ${stateChange.event}");
+  });
+  return {'handle': await realtime.handle};
+}

--- a/test_integration/test_driver/test_implementation/realtime_tests.dart
+++ b/test_integration/test_driver/test_implementation/realtime_tests.dart
@@ -149,6 +149,19 @@ void testRealtimePublishSpec(FlutterDriver Function() getDriver) {
   });
 }
 
+void testRealtimeConnectWithAuthUrl(FlutterDriver Function() getDriver) {
+  const message = TestControlMessage(TestName.realtimeWithAuthUrl);
+  late TestControlResponseMessage response;
+  setUpAll(() async {
+    response = await requestDataForTest(getDriver(), message);
+  });
+
+  test('Connects to realtime with a valid handle', () {
+    expect(response.payload['handle'], isA<int>());
+    expect(response.payload['handle'], greaterThan(0));
+  });
+}
+
 void testRealtimeEncryptedPublishSpec(FlutterDriver Function() getDriver) {
   const message = TestControlMessage(TestName.realtimeEncryptedPublishSpec);
   late TestControlResponseMessage response;


### PR DESCRIPTION
`authUrl` was being read as string which wasn't treated as an error as type mismatch is allowed in Objective C. 

This PR fixes this using authURL as NSURL

Also it turned out that ably-java didn't like `authUrl` having token as query string parameter. That's why I made a change on ably-java and upgraded its version here 

Fixes https://github.com/ably/ably-flutter/issues/465