### PR TITLE
fix: add numbers strategy for Gson to prevent changing int to double

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.ToNumberPolicy;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
@@ -82,7 +83,11 @@ public class AblyMessageCodec extends StandardMessageCodec {
     }
 
     private Map<Byte, CodecPair> codecMap;
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new Gson()
+        .newBuilder()
+        .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+        .create();
+
     private final CipherParamsStorage cipherParamsStorage;
 
 


### PR DESCRIPTION
Resolves #461 

Fixes an issue where json decoding was inconsistent between underlying platforms (ios/android)

Note this change was already made and approved in #462 but the changes in the commit were subsequently overwritten in error during a merge conflict resolution.