### PR TITLE
setOnBackgroundMessage() is now a Future<void> that will await for the function to complete.

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -28,10 +28,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   charcode:
     dependency: transitive
     description:
@@ -52,10 +52,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   crypto:
     dependency: "direct main"
     description:
@@ -218,14 +218,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -238,18 +230,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
@@ -367,6 +359,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
   win32:
     dependency: transitive
     description:
@@ -392,5 +392,5 @@ packages:
     source: hosted
     version: "5.3.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=2.8.0"

--- a/lib/src/platform/src/background_android_isolate_platform.dart
+++ b/lib/src/platform/src/background_android_isolate_platform.dart
@@ -22,12 +22,14 @@ class BackgroundIsolateAndroidPlatform {
         case PlatformMethod.pushOnBackgroundMessage:
           return _onPushBackgroundMessage(call.arguments as RemoteMessage);
         default:
-          throw PlatformException(code: 'invalid_method', message: 'No such method ${call.method}');
+          throw PlatformException(
+              code: 'invalid_method', message: 'No such method ${call.method}');
       }
     });
   }
 
-  static final BackgroundIsolateAndroidPlatform _platform = BackgroundIsolateAndroidPlatform._internal();
+  static final BackgroundIsolateAndroidPlatform _platform =
+      BackgroundIsolateAndroidPlatform._internal();
 
   /// @nodoc
   /// Singleton instance of BackgroundIsolateAndroidPlatform
@@ -37,15 +39,19 @@ class BackgroundIsolateAndroidPlatform {
   /// A method channel used to communicate with the user's app isolate
   /// we explicitly launched when a RemoteMessage is received.
   /// Used only on Android.
-  final MethodChannel _methodChannel = MethodChannel('io.ably.flutter.plugin.background', StandardMethodCodec(Codec()));
+  final MethodChannel _methodChannel = MethodChannel(
+      'io.ably.flutter.plugin.background', StandardMethodCodec(Codec()));
 
-  final PushNotificationEventsInternal _pushNotificationEvents = Push.notificationEvents as PushNotificationEventsInternal;
+  final PushNotificationEventsInternal _pushNotificationEvents =
+      Push.notificationEvents as PushNotificationEventsInternal;
 
-  Future<void> _onPushBackgroundMessage(RemoteMessage remoteMessage) async => _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
+  Future<void> _onPushBackgroundMessage(RemoteMessage remoteMessage) async =>
+      _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
 
   /// @nodoc
   /// Equivalent of [Platform.invokePlatformMethod] which cannot be used here
   /// because we may not be able to acquire [Platform] instance here, so we
   /// need to use a raw [MethodChannel] communication
-  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async => _methodChannel.invokeMethod<T>(method, arguments);
+  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async =>
+      _methodChannel.invokeMethod<T>(method, arguments);
 }

--- a/lib/src/platform/src/background_android_isolate_platform.dart
+++ b/lib/src/platform/src/background_android_isolate_platform.dart
@@ -20,7 +20,8 @@ class BackgroundIsolateAndroidPlatform {
     _methodChannel.setMethodCallHandler((call) async {
       switch (call.method) {
         case PlatformMethod.pushOnBackgroundMessage:
-          return _onPushBackgroundMessage(call.arguments as RemoteMessage);
+          await _onPushBackgroundMessage(call.arguments as RemoteMessage);
+          return;
         default:
           throw PlatformException(
               code: 'invalid_method', message: 'No such method ${call.method}');

--- a/lib/src/platform/src/background_android_isolate_platform.dart
+++ b/lib/src/platform/src/background_android_isolate_platform.dart
@@ -20,17 +20,14 @@ class BackgroundIsolateAndroidPlatform {
     _methodChannel.setMethodCallHandler((call) async {
       switch (call.method) {
         case PlatformMethod.pushOnBackgroundMessage:
-          await _onPushBackgroundMessage(call.arguments as RemoteMessage);
-          return;
+          return _onPushBackgroundMessage(call.arguments as RemoteMessage);
         default:
-          throw PlatformException(
-              code: 'invalid_method', message: 'No such method ${call.method}');
+          throw PlatformException(code: 'invalid_method', message: 'No such method ${call.method}');
       }
     });
   }
 
-  static final BackgroundIsolateAndroidPlatform _platform =
-      BackgroundIsolateAndroidPlatform._internal();
+  static final BackgroundIsolateAndroidPlatform _platform = BackgroundIsolateAndroidPlatform._internal();
 
   /// @nodoc
   /// Singleton instance of BackgroundIsolateAndroidPlatform
@@ -40,19 +37,15 @@ class BackgroundIsolateAndroidPlatform {
   /// A method channel used to communicate with the user's app isolate
   /// we explicitly launched when a RemoteMessage is received.
   /// Used only on Android.
-  final MethodChannel _methodChannel = MethodChannel(
-      'io.ably.flutter.plugin.background', StandardMethodCodec(Codec()));
+  final MethodChannel _methodChannel = MethodChannel('io.ably.flutter.plugin.background', StandardMethodCodec(Codec()));
 
-  final PushNotificationEventsInternal _pushNotificationEvents =
-      Push.notificationEvents as PushNotificationEventsInternal;
+  final PushNotificationEventsInternal _pushNotificationEvents = Push.notificationEvents as PushNotificationEventsInternal;
 
-  Future<void> _onPushBackgroundMessage(RemoteMessage remoteMessage) async =>
-      _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
+  Future<void> _onPushBackgroundMessage(RemoteMessage remoteMessage) async => _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
 
   /// @nodoc
   /// Equivalent of [Platform.invokePlatformMethod] which cannot be used here
   /// because we may not be able to acquire [Platform] instance here, so we
   /// need to use a raw [MethodChannel] communication
-  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async =>
-      _methodChannel.invokeMethod<T>(method, arguments);
+  Future<T?> invokeMethod<T>(String method, [dynamic arguments]) async => _methodChannel.invokeMethod<T>(method, arguments);
 }

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -26,16 +26,13 @@ class AblyMethodCallHandler {
         case PlatformMethod.pushOnBackgroundMessage:
           return _onPushBackgroundMessage(call.arguments as RemoteMessage);
         case PlatformMethod.pushOnShowNotificationInForeground:
-          return _pushNotificationEvents
-              .showNotificationInForeground(call.arguments as RemoteMessage);
+          return _pushNotificationEvents.showNotificationInForeground(call.arguments as RemoteMessage);
         case PlatformMethod.pushOnNotificationTap:
           return _onNotificationTap(call.arguments as RemoteMessage);
         case PlatformMethod.pushOpenSettingsFor:
           return _onOpenSettingsFor();
         default:
-          throw PlatformException(
-              code: 'Received invalid method channel call from Platform side',
-              message: 'No such method ${call.method}');
+          throw PlatformException(code: 'Received invalid method channel call from Platform side', message: 'No such method ${call.method}');
       }
     });
   }
@@ -68,10 +65,8 @@ class AblyMethodCallHandler {
     return realtime.options.authCallback!(tokenParams);
   }
 
-  final PushActivationEventsInternal _pushActivationEvents =
-      Push.activationEvents as PushActivationEventsInternal;
-  final PushNotificationEventsInternal _pushNotificationEvents =
-      Push.notificationEvents as PushNotificationEventsInternal;
+  final PushActivationEventsInternal _pushActivationEvents = Push.activationEvents as PushActivationEventsInternal;
+  final PushNotificationEventsInternal _pushNotificationEvents = Push.notificationEvents as PushNotificationEventsInternal;
 
   Future<Object?> _onPushOnActivate(ErrorInfo? error) async {
     _pushActivationEvents.onActivateStreamController.add(error);
@@ -94,13 +89,12 @@ class AblyMethodCallHandler {
   }
 
   Future<Object?> _onPushBackgroundMessage(RemoteMessage remoteMessage) async {
-    _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
+    await _pushNotificationEvents.handleBackgroundMessage(remoteMessage);
     return null;
   }
 
   Future<Object?> _onNotificationTap(RemoteMessage remoteMessage) async {
-    _pushNotificationEvents.onNotificationTapStreamController
-        .add(remoteMessage);
+    _pushNotificationEvents.onNotificationTapStreamController.add(remoteMessage);
     return null;
   }
 

--- a/lib/src/platform/src/push_notification_events_internal.dart
+++ b/lib/src/platform/src/push_notification_events_internal.dart
@@ -83,7 +83,11 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
   /// Handles a RemoteMessage passed from the platform side.
   Future<void> handleBackgroundMessage(RemoteMessage remoteMessage) async {
     if (_onBackgroundMessage != null) {
-      await _onBackgroundMessage!(remoteMessage);
+      dynamic onBackgroundMessageResult = _onBackgroundMessage!(remoteMessage);
+      // ^^^ _onBackgroundMessage() can return void or Future<void>
+      if (onBackgroundMessageResult is Future) {        
+        await onBackgroundMessageResult; // if it returns a Future we await on it.
+      }
     } else {
       // ignore:avoid_print
       print('Received RemoteMessage but no handler was set. '

--- a/lib/src/platform/src/push_notification_events_internal.dart
+++ b/lib/src/platform/src/push_notification_events_internal.dart
@@ -14,34 +14,28 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
 
   /// @nodoc
   /// Invoked when pushOnShowNotificationInForeground platform method is called.
-  Future<bool> Function(RemoteMessage message)?
-      onShowNotificationInForegroundHandler;
+  Future<bool> Function(RemoteMessage message)? onShowNotificationInForegroundHandler;
 
   /// @nodoc
   /// Exposes stream of received [RemoteMessage] objects.
   ///
   /// New message is emitted after pushOnMessage platform method is called
-  StreamController<RemoteMessage> onMessageStreamController =
-      StreamController();
+  StreamController<RemoteMessage> onMessageStreamController = StreamController();
 
   /// @nodoc
   /// Controller used to indicate notification was tapped.
-  StreamController<RemoteMessage> onNotificationTapStreamController =
-      StreamController();
+  StreamController<RemoteMessage> onNotificationTapStreamController = StreamController();
 
   BackgroundMessageHandler? _onBackgroundMessage;
 
   @override
-  Future<RemoteMessage?> get notificationTapLaunchedAppFromTerminated =>
-      Platform().invokePlatformMethod<RemoteMessage>(
-          PlatformMethod.pushNotificationTapLaunchedAppFromTerminated);
+  Future<RemoteMessage?> get notificationTapLaunchedAppFromTerminated => Platform().invokePlatformMethod<RemoteMessage>(PlatformMethod.pushNotificationTapLaunchedAppFromTerminated);
 
   @override
   Stream<RemoteMessage> get onMessage => onMessageStreamController.stream;
 
   @override
-  Stream<RemoteMessage> get onNotificationTap =>
-      onNotificationTapStreamController.stream;
+  Stream<RemoteMessage> get onNotificationTap => onNotificationTapStreamController.stream;
 
   @override
   void setOnOpenSettings(VoidCallback callback) {
@@ -49,8 +43,7 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
   }
 
   @override
-  void setOnShowNotificationInForeground(
-      Future<bool> Function(RemoteMessage message) callback) {
+  void setOnShowNotificationInForeground(Future<bool> Function(RemoteMessage message) callback) {
     onShowNotificationInForegroundHandler = callback;
   }
 
@@ -83,7 +76,7 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
   /// Handles a RemoteMessage passed from the platform side.
   Future<void> handleBackgroundMessage(RemoteMessage remoteMessage) async {
     if (_onBackgroundMessage != null) {
-      dynamic onBackgroundMessageResult = _onBackgroundMessage!(remoteMessage);
+      final onBackgroundMessageResult = _onBackgroundMessage!(remoteMessage);
       // ^^^ _onBackgroundMessage() can return void or Future<void>
       if (onBackgroundMessageResult is Future) {
         await onBackgroundMessageResult; // if it returns a Future we await on it.

--- a/lib/src/platform/src/push_notification_events_internal.dart
+++ b/lib/src/platform/src/push_notification_events_internal.dart
@@ -81,9 +81,9 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
 
   /// @nodoc
   /// Handles a RemoteMessage passed from the platform side.
-  void handleBackgroundMessage(RemoteMessage remoteMessage) {
+  Future<void> handleBackgroundMessage(RemoteMessage remoteMessage) async {
     if (_onBackgroundMessage != null) {
-      _onBackgroundMessage!(remoteMessage);
+      await _onBackgroundMessage!(remoteMessage);
     } else {
       // ignore:avoid_print
       print('Received RemoteMessage but no handler was set. '

--- a/lib/src/platform/src/push_notification_events_internal.dart
+++ b/lib/src/platform/src/push_notification_events_internal.dart
@@ -85,7 +85,7 @@ class PushNotificationEventsInternal implements PushNotificationEvents {
     if (_onBackgroundMessage != null) {
       dynamic onBackgroundMessageResult = _onBackgroundMessage!(remoteMessage);
       // ^^^ _onBackgroundMessage() can return void or Future<void>
-      if (onBackgroundMessageResult is Future) {        
+      if (onBackgroundMessageResult is Future) {
         await onBackgroundMessageResult; // if it returns a Future we await on it.
       }
     } else {

--- a/lib/src/push_notifications/src/push_notification_events.dart
+++ b/lib/src/push_notifications/src/push_notification_events.dart
@@ -4,7 +4,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 
 /// Type definition for a callback invoked when background push message
 /// is received.
-typedef BackgroundMessageHandler = Future<void> Function(RemoteMessage message);
+typedef BackgroundMessageHandler = dynamic Function(RemoteMessage message);
 
 /// Push Notification events, such as message arriving or notification tap.
 abstract class PushNotificationEvents {

--- a/lib/src/push_notifications/src/push_notification_events.dart
+++ b/lib/src/push_notifications/src/push_notification_events.dart
@@ -4,7 +4,7 @@ import 'package:ably_flutter/ably_flutter.dart';
 
 /// Type definition for a callback invoked when background push message
 /// is received.
-typedef BackgroundMessageHandler = void Function(RemoteMessage message);
+typedef BackgroundMessageHandler = Future<void> Function(RemoteMessage message);
 
 /// Push Notification events, such as message arriving or notification tap.
 abstract class PushNotificationEvents {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,10 +5,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      sha256: "947bfcf187f74dbc5e146c9eb9c0f10c9f8b30743e341481c1e2ed3ecc18c20c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.11.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,10 +21,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.3.0"
   clock:
     dependency: transitive
     description:
@@ -37,10 +37,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.17.2"
   fake_async:
     dependency: "direct dev"
     description:
@@ -67,14 +67,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  js:
-    dependency: transitive
-    description:
-      name: js
-      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.6.5"
   lints:
     dependency: transitive
     description:
@@ -87,34 +79,34 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.13"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.5.0"
   meta:
     dependency: "direct main"
     description:
       name: meta
-      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.0"
+    version: "1.9.1"
   path:
     dependency: transitive
     description:
       name: path
-      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -124,10 +116,10 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      sha256: "53e943d4206a5e30df338fd4c6e7a077e02254531b138a15aec3bd143c1a8b3c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.10.0"
   stack_trace:
     dependency: transitive
     description:
@@ -164,10 +156,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
       url: "https://pub.dev"
     source: hosted
-    version: "0.4.16"
+    version: "0.6.0"
   vector_math:
     dependency: transitive
     description:
@@ -176,6 +168,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.4-beta"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=3.1.0-185.0.dev <4.0.0"
   flutter: ">=2.5.0"


### PR DESCRIPTION
This is in regards to this issue here:
https://github.com/ably/ably-flutter/issues/496

If a setOnBackgroundMessage() was fired and if it took to long to complete the isolate on Android would end before the code was completed.  This was extra annoying if you were trying to debug a background messsage or if it used other packages that used async/await.  Those items just wouldn't fire. 

Now all code will complete before the isolate dismisses itself. 
