### PR TITLE
Fix realtime connection fields

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -116,7 +116,6 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     _map.put(PlatformConstants.PlatformMethod.connectionId, this::connectionId);
     _map.put(PlatformConstants.PlatformMethod.connectionKey, this::connectionKey);
     _map.put(PlatformConstants.PlatformMethod.connectionRecoveryKey, this::connectionRecoveryKey);
-    _map.put(PlatformConstants.PlatformMethod.connectionErrorReason, this::connectionErrorReason);
 
     // Push Notifications
     _map.put(PlatformConstants.PlatformMethod.pushActivate, this::pushActivate);
@@ -582,13 +581,6 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
     result.success(realtime.connection.recoveryKey);
   }
-
-  private void connectionErrorReason(@NonNull MethodCall methodCall, @NonNull MethodChannel.Result result) {
-    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
-    AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
-    result.success(realtime.connection.reason);
-  }
-
     private void time(@NonNull MethodChannel.Result result, AblyBase client) {
         Callback<Long> callback = new Callback<Long>() {
             @Override

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -112,6 +112,12 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
     _map.put(PlatformConstants.PlatformMethod.restAuthGetClientId,
             (methodCall, result) -> authMethodHandler.clientId(methodCall, result, AuthMethodHandler.Type.Rest));
 
+    // Connection specific handlers
+    _map.put(PlatformConstants.PlatformMethod.connectionId, this::connectionId);
+    _map.put(PlatformConstants.PlatformMethod.connectionKey, this::connectionKey);
+    _map.put(PlatformConstants.PlatformMethod.connectionRecoveryKey, this::connectionRecoveryKey);
+    _map.put(PlatformConstants.PlatformMethod.connectionErrorReason, this::connectionErrorReason);
+
     // Push Notifications
     _map.put(PlatformConstants.PlatformMethod.pushActivate, this::pushActivate);
     _map.put(PlatformConstants.PlatformMethod.pushDeactivate, this::pushDeactivate);
@@ -558,6 +564,30 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
         final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
         time(result, instanceStore.getRest(ablyMessage.handle));
     }
+
+  private void connectionId(@NonNull MethodCall methodCall, @NonNull MethodChannel.Result result) {
+    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
+    AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
+    result.success(realtime.connection.id);
+  }
+
+  private void connectionKey(@NonNull MethodCall methodCall, @NonNull MethodChannel.Result result) {
+    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
+    AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
+    result.success(realtime.connection.key);
+  }
+
+  private void connectionRecoveryKey(@NonNull MethodCall methodCall, @NonNull MethodChannel.Result result) {
+    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
+    AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
+    result.success(realtime.connection.recoveryKey);
+  }
+
+  private void connectionErrorReason(@NonNull MethodCall methodCall, @NonNull MethodChannel.Result result) {
+    final AblyFlutterMessage ablyMessage = (AblyFlutterMessage) methodCall.arguments;
+    AblyRealtime realtime = instanceStore.getRealtime(ablyMessage.handle);
+    result.success(realtime.connection.reason);
+  }
 
     private void time(@NonNull MethodChannel.Result result, AblyBase client) {
         Callback<Long> callback = new Callback<Long>() {

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -456,7 +456,18 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
           return token[0];
         };
       }
-      result.success(clientHandle.createRealtime(clientOptions.options, applicationContext));
+
+      final long realtimeInstanceHandle = clientHandle.createRealtime(clientOptions.options, applicationContext);
+      final Realtime realtime = instanceStore.getRealtime(realtimeInstanceHandle);
+      realtime.connection.on(new ConnectionStateListener() {
+        @Override
+        public void onConnectionStateChanged(ConnectionStateChange state) {
+          AblyFlutterMessage<String> channelMessage = new AblyFlutterMessage<>(realtime.connection.id, realtimeInstanceHandle);
+          methodChannel.invokeMethod(PlatformConstants.PlatformMethod.connectionIdUpdated, channelMessage);
+        }
+      });
+
+      result.success(realtimeInstanceHandle);
     } catch (final AblyException e) {
       handleAblyException(result, e);
     }

--- a/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMethodCallHandler.java
@@ -23,6 +23,7 @@ import io.ably.flutter.plugin.util.BiConsumer;
 import io.ably.lib.realtime.AblyRealtime;
 import io.ably.lib.realtime.Channel;
 import io.ably.lib.realtime.CompletionListener;
+import io.ably.lib.realtime.ConnectionStateListener;
 import io.ably.lib.realtime.Presence;
 import io.ably.lib.rest.AblyBase;
 import io.ably.lib.rest.AblyRest;
@@ -458,7 +459,7 @@ public class AblyMethodCallHandler implements MethodChannel.MethodCallHandler {
       }
 
       final long realtimeInstanceHandle = clientHandle.createRealtime(clientOptions.options, applicationContext);
-      final Realtime realtime = instanceStore.getRealtime(realtimeInstanceHandle);
+      final AblyRealtime realtime = instanceStore.getRealtime(realtimeInstanceHandle);
       realtime.connection.on(new ConnectionStateListener() {
         @Override
         public void onConnectionStateChanged(ConnectionStateChange state) {

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -81,6 +81,7 @@ final public class PlatformConstants {
         public static final String connectionId = "connectionId";
         public static final String connectionKey = "connectionKey";
         public static final String connectionRecoveryKey = "connectionRecoveryKey";
+        public static final String connectionIdUpdated = "connectionIdUpdated";
 
         public static final String pushActivate = "pushActivate";
         public static final String pushDeactivate = "pushDeactivate";

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -77,6 +77,12 @@ final public class PlatformConstants {
         public static final String realtimeAuthCreateTokenRequest = "realtimeAuthCreateTokenRequest";
         public static final String realtimeAuthRequestToken = "realtimeAuthRequestToken";
         public static final String realtimeAuthGetClientId = "realtimeAuthGetClientId";
+
+        public static final String connectionId = "connectionId";
+        public static final String connectionKey = "connectionKey";
+        public static final String connectionRecoveryKey = "connectionRecoveryKey";
+        public static final String connectionErrorReason = "connectionErrorReason";
+
         public static final String pushActivate = "pushActivate";
         public static final String pushDeactivate = "pushDeactivate";
         public static final String pushReset = "pushReset";

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -81,7 +81,6 @@ final public class PlatformConstants {
         public static final String connectionId = "connectionId";
         public static final String connectionKey = "connectionKey";
         public static final String connectionRecoveryKey = "connectionRecoveryKey";
-        public static final String connectionErrorReason = "connectionErrorReason";
 
         public static final String pushActivate = "pushActivate";
         public static final String pushDeactivate = "pushDeactivate";

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -614,14 +614,6 @@ static const FlutterHandler _connectionKey = ^void(AblyFlutter *const ably, Flut
     result(connectionKey);
 };
 
-static const FlutterHandler _connectionErrorReason = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
-    AblyFlutterMessage *const ablyMessage = call.arguments;
-    AblyInstanceStore *const instanceStore = [ably instanceStore];
-    ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
-    ARTErrorInfo* connectionError = [realtime.connection errorReason];
-    result(connectionError);
-};
-
 static const FlutterHandler _connectionRecoveryKey = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
     AblyInstanceStore *const instanceStore = [ably instanceStore];
@@ -776,7 +768,6 @@ static const FlutterHandler _realtimeAuthCreateTokenRequest = ^void(AblyFlutter 
         AblyPlatformMethod_connectionId:_connectionId,
         AblyPlatformMethod_connectionKey:_connectionKey,
         AblyPlatformMethod_connectionRecoveryKey:_connectionRecoveryKey,
-        AblyPlatformMethod_connectionErrorReason:_connectionErrorReason,
         // Push Notifications
         AblyPlatformMethod_pushActivate: PushHandlers.activate,
         AblyPlatformMethod_pushRequestPermission: PushHandlers.requestPermission,

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -264,10 +264,9 @@ static const FlutterHandler _createRealtime = ^void(AblyFlutter *const ably, Flu
     [instanceStore setRealtime:realtime with:handle];
 
     [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
-            AblyFlutterMessage *const message
-            = [[AblyFlutterMessage alloc] initWithMessage:[realtime.connection id] handle: handle];
-            [ably.channel invokeMethod:AblyPlatformMethod_connectionIdUpdated
-                               arguments:message]
+        AblyFlutterMessage *const message =
+              [[AblyFlutterMessage alloc] initWithMessage:[realtime.connection id] handle: handle];
+        [ably.channel invokeMethod:AblyPlatformMethod_connectionIdUpdated arguments:message];
     }];
 
     // Giving Ably client the deviceToken registered at device launch (didRegisterForRemoteNotificationsWithDeviceToken).
@@ -593,6 +592,7 @@ static const FlutterHandler _realtimeTime = ^void(AblyFlutter *const ably, Flutt
 
 static const FlutterHandler _restTime = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
+
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRest *const rest = [instanceStore restFrom:ablyMessage.handle];
     

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -586,7 +586,6 @@ static const FlutterHandler _realtimeTime = ^void(AblyFlutter *const ably, Flutt
 
 static const FlutterHandler _restTime = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
-    
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRest *const rest = [instanceStore restFrom:ablyMessage.handle];
     
@@ -603,7 +602,7 @@ static const FlutterHandler _connectionId = ^void(AblyFlutter *const ably, Flutt
     AblyFlutterMessage *const ablyMessage = call.arguments;
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
-    NSString *const connectionId = [realtime.connection.id];
+    NSString *const connectionId = [realtime.connection id];
     result(connectionId);
 };
 
@@ -611,15 +610,15 @@ static const FlutterHandler _connectionKey = ^void(AblyFlutter *const ably, Flut
     AblyFlutterMessage *const ablyMessage = call.arguments;
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
-    NSString *const connectionKey = [realtime.connection.key];
+    NSString *const connectionKey = [realtime.connection key];
     result(connectionKey);
 };
 
-static const FlutterHandler _connectionError = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
+static const FlutterHandler _connectionErrorReason = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
-    ARTErrorInfo* connectionError = [realtime.connection.reason];
+    ARTErrorInfo* connectionError = [realtime.connection errorReason];
     result(connectionError);
 };
 
@@ -627,7 +626,7 @@ static const FlutterHandler _connectionRecoveryKey = ^void(AblyFlutter *const ab
     AblyFlutterMessage *const ablyMessage = call.arguments;
     AblyInstanceStore *const instanceStore = [ably instanceStore];
     ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
-    NSString *const connectionRecoveryKey = [realtime.connection.recoveryKey];
+    NSString *const connectionRecoveryKey = [realtime.connection recoveryKey];
     result(connectionRecoveryKey);
 };
 

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -599,6 +599,38 @@ static const FlutterHandler _restTime = ^void(AblyFlutter *const ably, FlutterMe
     }];
 };
 
+static const FlutterHandler _connectionId = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const ablyMessage = call.arguments;
+    AblyInstanceStore *const instanceStore = [ably instanceStore];
+    ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
+    NSString *const connectionId = [realtime.connection.id];
+    result(connectionId);
+};
+
+static const FlutterHandler _connectionKey = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const ablyMessage = call.arguments;
+    AblyInstanceStore *const instanceStore = [ably instanceStore];
+    ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
+    NSString *const connectionKey = [realtime.connection.key];
+    result(connectionKey);
+};
+
+static const FlutterHandler _connectionError = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const ablyMessage = call.arguments;
+    AblyInstanceStore *const instanceStore = [ably instanceStore];
+    ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
+    ARTErrorInfo* connectionError = [realtime.connection.reason];
+    result(connectionError);
+};
+
+static const FlutterHandler _connectionRecoveryKey = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
+    AblyFlutterMessage *const ablyMessage = call.arguments;
+    AblyInstanceStore *const instanceStore = [ably instanceStore];
+    ARTRealtime *const realtime = [instanceStore realtimeFrom:ablyMessage.handle];
+    NSString *const connectionRecoveryKey = [realtime.connection.recoveryKey];
+    result(connectionRecoveryKey);
+};
+
 static const FlutterHandler _getNextPage = ^void(AblyFlutter *const ably, FlutterMethodCall *const call, const FlutterResult result) {
     AblyFlutterMessage *const ablyMessage = call.arguments;
     
@@ -741,6 +773,11 @@ static const FlutterHandler _realtimeAuthCreateTokenRequest = ^void(AblyFlutter 
         AblyPlatformMethod_releaseRealtimeChannel: _releaseRealtimeChannel,
         AblyPlatformMethod_realtimeTime:_realtimeTime,
         AblyPlatformMethod_restTime:_restTime,
+        // Connection fields
+        AblyPlatformMethod_connectionId:_connectionId;
+        AblyPlatformMethod_connectionKey:_connectionKey;
+        AblyPlatformMethod_connectionRecoveryKey:_connectionRecoveryKey;
+        AblyPlatformMethod_connectionErrorReason:_connectionErrorReason;
         // Push Notifications
         AblyPlatformMethod_pushActivate: PushHandlers.activate,
         AblyPlatformMethod_pushRequestPermission: PushHandlers.requestPermission,

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -774,10 +774,10 @@ static const FlutterHandler _realtimeAuthCreateTokenRequest = ^void(AblyFlutter 
         AblyPlatformMethod_realtimeTime:_realtimeTime,
         AblyPlatformMethod_restTime:_restTime,
         // Connection fields
-        AblyPlatformMethod_connectionId:_connectionId;
-        AblyPlatformMethod_connectionKey:_connectionKey;
-        AblyPlatformMethod_connectionRecoveryKey:_connectionRecoveryKey;
-        AblyPlatformMethod_connectionErrorReason:_connectionErrorReason;
+        AblyPlatformMethod_connectionId:_connectionId,
+        AblyPlatformMethod_connectionKey:_connectionKey,
+        AblyPlatformMethod_connectionRecoveryKey:_connectionRecoveryKey,
+        AblyPlatformMethod_connectionErrorReason:_connectionErrorReason,
         // Push Notifications
         AblyPlatformMethod_pushActivate: PushHandlers.activate,
         AblyPlatformMethod_pushRequestPermission: PushHandlers.requestPermission,

--- a/ios/Classes/AblyFlutter.m
+++ b/ios/Classes/AblyFlutter.m
@@ -263,6 +263,13 @@ static const FlutterHandler _createRealtime = ^void(AblyFlutter *const ably, Flu
     ARTRealtime *const realtime = [[ARTRealtime alloc] initWithOptions:options.clientOptions];
     [instanceStore setRealtime:realtime with:handle];
 
+    [realtime.connection on:^(ARTConnectionStateChange *stateChange) {
+            AblyFlutterMessage *const message
+            = [[AblyFlutterMessage alloc] initWithMessage:[realtime.connection id] handle: handle];
+            [ably.channel invokeMethod:AblyPlatformMethod_connectionIdUpdated
+                               arguments:message]
+    }];
+
     // Giving Ably client the deviceToken registered at device launch (didRegisterForRemoteNotificationsWithDeviceToken).
     // This is not an ideal solution. We save the deviceToken given in didRegisterForRemoteNotificationsWithDeviceToken and the
     // error in didFailToRegisterForRemoteNotificationsWithError and pass it to Ably in the first client that is first created.

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -79,6 +79,7 @@ extern NSString *const AblyPlatformMethod_realtimeAuthGetClientId;
 extern NSString *const AblyPlatformMethod_connectionId;
 extern NSString *const AblyPlatformMethod_connectionKey;
 extern NSString *const AblyPlatformMethod_connectionRecoveryKey;
+extern NSString *const AblyPlatformMethod_connectionIdUpdated;
 
 extern NSString *const AblyPlatformMethod_pushActivate;
 extern NSString *const AblyPlatformMethod_pushDeactivate;

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -75,6 +75,12 @@ extern NSString *const AblyPlatformMethod_realtimeAuthAuthorize;
 extern NSString *const AblyPlatformMethod_realtimeAuthCreateTokenRequest;
 extern NSString *const AblyPlatformMethod_realtimeAuthRequestToken;
 extern NSString *const AblyPlatformMethod_realtimeAuthGetClientId;
+
+extern NSString *const AblyPlatformMethod_connectionId;
+extern NSString *const AblyPlatformMethod_connectionKey;
+extern NSString *const AblyPlatformMethod_connectionRecoveryKey;
+extern NSString *const AblyPlatformMethod_connectionErrorReason;
+
 extern NSString *const AblyPlatformMethod_pushActivate;
 extern NSString *const AblyPlatformMethod_pushDeactivate;
 extern NSString *const AblyPlatformMethod_pushReset;

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -79,7 +79,6 @@ extern NSString *const AblyPlatformMethod_realtimeAuthGetClientId;
 extern NSString *const AblyPlatformMethod_connectionId;
 extern NSString *const AblyPlatformMethod_connectionKey;
 extern NSString *const AblyPlatformMethod_connectionRecoveryKey;
-extern NSString *const AblyPlatformMethod_connectionErrorReason;
 
 extern NSString *const AblyPlatformMethod_pushActivate;
 extern NSString *const AblyPlatformMethod_pushDeactivate;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -48,6 +48,7 @@ NSString *const AblyPlatformMethod_realtimeAuthGetClientId= @"realtimeAuthGetCli
 NSString *const AblyPlatformMethod_connectionId = @"connectionId";
 NSString *const AblyPlatformMethod_connectionKey = @"connectionKey";
 NSString *const AblyPlatformMethod_connectionRecoveryKey = @"connectionRecoveryKey";
+NSString *const AblyPlatformMethod_connectionIdUpdated = @"connectionIdUpdated";
 
 NSString *const AblyPlatformMethod_pushActivate= @"pushActivate";
 NSString *const AblyPlatformMethod_pushDeactivate= @"pushDeactivate";

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -44,6 +44,12 @@ NSString *const AblyPlatformMethod_realtimeAuthAuthorize= @"realtimeAuthAuthoriz
 NSString *const AblyPlatformMethod_realtimeAuthCreateTokenRequest= @"realtimeAuthCreateTokenRequest";
 NSString *const AblyPlatformMethod_realtimeAuthRequestToken= @"realtimeAuthRequestToken";
 NSString *const AblyPlatformMethod_realtimeAuthGetClientId= @"realtimeAuthGetClientId";
+
+NSString *const AblyPlatformMethod_connectionId = @"connectionId";
+NSString *const AblyPlatformMethod_connectionKey = @"connectionKey";
+NSString *const AblyPlatformMethod_connectionRecoveryKey = @"connectionRecoveryKey";
+NSString *const AblyPlatformMethod_connectionErrorReason = @"connectionErrorReason";
+
 NSString *const AblyPlatformMethod_pushActivate= @"pushActivate";
 NSString *const AblyPlatformMethod_pushDeactivate= @"pushDeactivate";
 NSString *const AblyPlatformMethod_pushReset= @"pushReset";

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -48,7 +48,6 @@ NSString *const AblyPlatformMethod_realtimeAuthGetClientId= @"realtimeAuthGetCli
 NSString *const AblyPlatformMethod_connectionId = @"connectionId";
 NSString *const AblyPlatformMethod_connectionKey = @"connectionKey";
 NSString *const AblyPlatformMethod_connectionRecoveryKey = @"connectionRecoveryKey";
-NSString *const AblyPlatformMethod_connectionErrorReason = @"connectionErrorReason";
 
 NSString *const AblyPlatformMethod_pushActivate= @"pushActivate";
 NSString *const AblyPlatformMethod_pushDeactivate= @"pushDeactivate";

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -76,6 +76,12 @@ class PlatformMethod {
       'realtimeAuthCreateTokenRequest';
   static const String realtimeAuthRequestToken = 'realtimeAuthRequestToken';
   static const String realtimeAuthGetClientId = 'realtimeAuthGetClientId';
+
+  static const String connectionId = 'connectionId';
+  static const String connectionKey = 'connectionKey';
+  static const String connectionRecoveryKey = 'connectionRecoveryKey';
+  static const String connectionErrorReason = 'connectionErrorReason';
+
   static const String pushActivate = 'pushActivate';
   static const String pushDeactivate = 'pushDeactivate';
   static const String pushReset = 'pushReset';

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -80,6 +80,7 @@ class PlatformMethod {
   static const String connectionId = 'connectionId';
   static const String connectionKey = 'connectionKey';
   static const String connectionRecoveryKey = 'connectionRecoveryKey';
+  static const String connectionIdUpdated = 'connectionIdUpdated';
 
   static const String pushActivate = 'pushActivate';
   static const String pushDeactivate = 'pushDeactivate';

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -80,7 +80,6 @@ class PlatformMethod {
   static const String connectionId = 'connectionId';
   static const String connectionKey = 'connectionKey';
   static const String connectionRecoveryKey = 'connectionRecoveryKey';
-  static const String connectionErrorReason = 'connectionErrorReason';
 
   static const String pushActivate = 'pushActivate';
   static const String pushDeactivate = 'pushDeactivate';

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -71,7 +71,7 @@ class AblyMethodCallHandler {
   }
 
   /// @nodoc
-  /// handles auth callback for realtime instances
+  /// handles connection id updated for realtime instances
   Future<Object?> onConnectionIdUpdated(AblyMessage<dynamic>? message) async {
     final updatedConnId = message!.message as String;
     final realtime = realtimeInstances[message.handle];

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -74,10 +74,11 @@ class AblyMethodCallHandler {
 
   /// @nodoc
   /// handles auth callback for realtime instances
-  Future<void> onConnectionIdUpdated(AblyMessage<dynamic>? message) async {
+  Future<Object?> onConnectionIdUpdated(AblyMessage<dynamic>? message) async {
     final updatedConnId = message!.message as String;
     final realtime = realtimeInstances[message.handle];
     realtime?.connection.id = updatedConnId;
+    return null;
   }
 
   final PushActivationEventsInternal _pushActivationEvents =

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -1,3 +1,5 @@
+import 'dart:ffi';
+
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
 import 'package:flutter/services.dart';
@@ -15,6 +17,8 @@ class AblyMethodCallHandler {
           return onAuthCallback(call.arguments as AblyMessage);
         case PlatformMethod.realtimeAuthCallback:
           return onRealtimeAuthCallback(call.arguments as AblyMessage?);
+        case PlatformMethod.connectionIdUpdated:
+          return onConnectionIdUpdated(call.arguments as AblyMessage?);
         case PlatformMethod.pushOnActivate:
           return _onPushOnActivate(call.arguments as ErrorInfo?);
         case PlatformMethod.pushOnDeactivate:
@@ -66,6 +70,14 @@ class AblyMethodCallHandler {
       );
     }
     return realtime.options.authCallback!(tokenParams);
+  }
+
+  /// @nodoc
+  /// handles auth callback for realtime instances
+  Future<void> onConnectionIdUpdated(AblyMessage<dynamic>? message) async {
+    final updatedConnId = message!.message as String;
+    final realtime = realtimeInstances[message.handle];
+    realtime?.connection.id = updatedConnId;
   }
 
   final PushActivationEventsInternal _pushActivationEvents =

--- a/lib/src/platform/src/method_call_handler.dart
+++ b/lib/src/platform/src/method_call_handler.dart
@@ -1,5 +1,3 @@
-import 'dart:ffi';
-
 import 'package:ably_flutter/ably_flutter.dart';
 import 'package:ably_flutter/src/platform/platform_internal.dart';
 import 'package:flutter/services.dart';

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -37,8 +37,7 @@ class Connection extends PlatformObject {
 
   /// A unique public identifier for this connection, used to identify this
   /// member.
-  Future<String?> get id async =>
-      invoke<String?>(PlatformMethod.connectionId);
+  Future<String?> get id => invoke<String?>(PlatformMethod.connectionId);
 
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
@@ -49,15 +48,22 @@ class Connection extends PlatformObject {
   /// to publish on behalf of this client. See the
   /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
   /// for more info.
-  Future<String?> get key async =>
-      invoke<String?>(PlatformMethod.connectionKey);
+  Future<String?> get key => invoke<String?>(PlatformMethod.connectionKey);
 
   /// The recovery key string can be used by another client to recover this
   /// connection's state in the recover client options property.
   ///
   /// See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options)
   /// for more information.
-  Future<String?> get recoveryKey async =>
+  @Deprecated('Use createRecoveryKey instead')
+  Future<String?> get recoveryKey => createRecoveryKey();
+
+  /// The createRecoveryKey returns key string can be used by another client to
+  /// recover this connection's state in the recover client options property.
+  ///
+  /// See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options)
+  /// for more information.
+  Future<String?> createRecoveryKey() =>
       invoke<String?>(PlatformMethod.connectionRecoveryKey);
 
   /// The serial number of the last message to be received on this connection,

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -24,7 +24,6 @@ class Connection extends PlatformObject {
     on().listen((event) {
       _state = event.current;
       _errorReason = event.reason;
-      invoke<String?>(PlatformMethod.connectionId).then((_id) => id = _id);
     });
   }
 

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -40,10 +40,6 @@ class Connection extends PlatformObject {
   /// member.
   String? id;
 
-  /// fetchId returns unique public identifier for this connection.
-  /// used to identify this member.
-  Future<String?> fetchId() => invoke<String?>(PlatformMethod.connectionId);
-
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
   ///
@@ -54,17 +50,6 @@ class Connection extends PlatformObject {
   /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
   /// for more info.
   String? key;
-
-  /// fetchKey returns a unique private connection key used to recover
-  /// or resume a connection, assigned by Ably.
-  ///
-  /// When recovering a connection explicitly, the `recoveryKey` is used in the
-  /// recover client options as it contains both the key and the last message
-  /// serial. This private connection key can also be used by other REST clients
-  /// to publish on behalf of this client. See the
-  /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
-  /// for more info.
-  Future<String?> fetchKey() => invoke<String?>(PlatformMethod.connectionKey);
 
   /// The recovery key string can be used by another client to recover this
   /// connection's state in the recover client options property.

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -37,7 +37,8 @@ class Connection extends PlatformObject {
 
   /// A unique public identifier for this connection, used to identify this
   /// member.
-  String? id;
+  Future<String?> get id async =>
+      invoke<String?>(PlatformMethod.connectionId);
 
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
@@ -48,14 +49,16 @@ class Connection extends PlatformObject {
   /// to publish on behalf of this client. See the
   /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
   /// for more info.
-  String? key;
+  Future<String?> get key async =>
+      invoke<String?>(PlatformMethod.connectionKey);
 
   /// The recovery key string can be used by another client to recover this
   /// connection's state in the recover client options property.
   ///
   /// See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options)
   /// for more information.
-  String? recoveryKey;
+  Future<String?> get recoveryKey async =>
+      invoke<String?>(PlatformMethod.connectionRecoveryKey);
 
   /// The serial number of the last message to be received on this connection,
   /// used automatically by the library when recovering or resuming a

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -24,6 +24,7 @@ class Connection extends PlatformObject {
     on().listen((event) {
       _state = event.current;
       _errorReason = event.reason;
+      invoke<String?>(PlatformMethod.connectionId).then((_id) => id = _id);
     });
   }
 
@@ -37,7 +38,7 @@ class Connection extends PlatformObject {
 
   /// A unique public identifier for this connection, used to identify this
   /// member.
-  Future<String?> get id => invoke<String?>(PlatformMethod.connectionId);
+  String? id;
 
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
@@ -56,7 +57,7 @@ class Connection extends PlatformObject {
   /// See [connection state recover options](https://ably.com/docs/realtime/connection#connection-state-recover-options)
   /// for more information.
   @Deprecated('Use createRecoveryKey instead')
-  Future<String?> get recoveryKey => createRecoveryKey();
+  String? recoveryKey;
 
   /// The createRecoveryKey returns key string can be used by another client to
   /// recover this connection's state in the recover client options property.

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -40,6 +40,10 @@ class Connection extends PlatformObject {
   /// member.
   String? id;
 
+  /// fetchId returns unique public identifier for this connection.
+  /// used to identify this member.
+  Future<String?> fetchId() => invoke<String?>(PlatformMethod.connectionId);
+
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
   ///
@@ -49,7 +53,18 @@ class Connection extends PlatformObject {
   /// to publish on behalf of this client. See the
   /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
   /// for more info.
-  Future<String?> get key => invoke<String?>(PlatformMethod.connectionKey);
+  String? key;
+
+  /// fetchKey returns a unique private connection key used to recover
+  /// or resume a connection, assigned by Ably.
+  ///
+  /// When recovering a connection explicitly, the `recoveryKey` is used in the
+  /// recover client options as it contains both the key and the last message
+  /// serial. This private connection key can also be used by other REST clients
+  /// to publish on behalf of this client. See the
+  /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
+  /// for more info.
+  Future<String?> fetchKey() => invoke<String?>(PlatformMethod.connectionKey);
 
   /// The recovery key string can be used by another client to recover this
   /// connection's state in the recover client options property.

--- a/test/models/client_options.dart
+++ b/test/models/client_options.dart
@@ -15,7 +15,7 @@ void main() {
     expect(clientOptions.realtimeHost, isNull);
     expect(clientOptions.port, isNull);
     expect(clientOptions.tlsPort, isNull);
-    expect(clientOptions.autoConnect, isNull);
+    expect(clientOptions.autcoConnect, isNull);
     expect(clientOptions.useBinaryProtocol, isNull);
     expect(clientOptions.queueMessages, isNull);
     expect(clientOptions.echoMessages, isNull);

--- a/test/models/client_options.dart
+++ b/test/models/client_options.dart
@@ -15,7 +15,7 @@ void main() {
     expect(clientOptions.realtimeHost, isNull);
     expect(clientOptions.port, isNull);
     expect(clientOptions.tlsPort, isNull);
-    expect(clientOptions.autcoConnect, isNull);
+    expect(clientOptions.autoConnect, isNull);
     expect(clientOptions.useBinaryProtocol, isNull);
     expect(clientOptions.queueMessages, isNull);
     expect(clientOptions.echoMessages, isNull);


### PR DESCRIPTION
- Fields available to use => Connection `id`, `key` and `recoveryKey`.
- Fixed #502 