### PR TITLE
[ECO-4629] fix: propagate id and key fields for connection object for Android and iOS

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.ably.flutter.plugin.dto.EnrichedConnectionStateChange;
 import io.ably.flutter.plugin.generated.PlatformConstants;
 import io.ably.flutter.plugin.types.SerializationException;
 import io.ably.flutter.plugin.types.PlatformClientOptions;
@@ -30,7 +31,6 @@ import io.ably.lib.realtime.ChannelState;
 import io.ably.lib.realtime.ChannelStateListener;
 import io.ably.lib.realtime.ConnectionEvent;
 import io.ably.lib.realtime.ConnectionState;
-import io.ably.lib.realtime.ConnectionStateListener;
 import io.ably.lib.rest.Auth;
 import io.ably.lib.rest.Auth.TokenDetails;
 import io.ably.lib.rest.DeviceDetails;
@@ -186,7 +186,7 @@ public class AblyMessageCodec extends StandardMessageCodec {
             return PlatformConstants.CodecTypes.tokenParams;
         } else if (value instanceof AsyncPaginatedResult) {
             return PlatformConstants.CodecTypes.paginatedResult;
-        } else if (value instanceof ConnectionStateListener.ConnectionStateChange) {
+        } else if (value instanceof EnrichedConnectionStateChange) {
             return PlatformConstants.CodecTypes.connectionStateChange;
         } else if (value instanceof ChannelStateListener.ChannelStateChange) {
             return PlatformConstants.CodecTypes.channelStateChange;
@@ -821,14 +821,16 @@ public class AblyMessageCodec extends StandardMessageCodec {
         return jsonMap;
     }
 
-    private Map<String, Object> encodeConnectionStateChange(ConnectionStateListener.ConnectionStateChange c) {
+    private Map<String, Object> encodeConnectionStateChange(EnrichedConnectionStateChange c) {
         if (c == null) return null;
         final HashMap<String, Object> jsonMap = new HashMap<>();
-        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.current, encodeConnectionState(c.current));
-        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.previous, encodeConnectionState(c.previous));
-        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.event, encodeConnectionEvent(c.event));
-        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.retryIn, c.retryIn);
-        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.reason, encodeErrorInfo(c.reason));
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.current, encodeConnectionState(c.stateChange.current));
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.previous, encodeConnectionState(c.stateChange.previous));
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.event, encodeConnectionEvent(c.stateChange.event));
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.retryIn, c.stateChange.retryIn);
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.reason, encodeErrorInfo(c.stateChange.reason));
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.connectionId, c.connectionId);
+        writeValueToJson(jsonMap, PlatformConstants.TxConnectionStateChange.connectionKey,c.connectionKey);
         return jsonMap;
     }
 

--- a/android/src/main/java/io/ably/flutter/plugin/dto/EnrichedConnectionStateChange.java
+++ b/android/src/main/java/io/ably/flutter/plugin/dto/EnrichedConnectionStateChange.java
@@ -1,0 +1,15 @@
+package io.ably.flutter.plugin.dto;
+
+import io.ably.lib.realtime.ConnectionStateListener;
+
+public class EnrichedConnectionStateChange {
+    public final ConnectionStateListener.ConnectionStateChange stateChange;
+    public final String connectionId;
+    public final String connectionKey;
+
+    public EnrichedConnectionStateChange(ConnectionStateListener.ConnectionStateChange stateChange, String connectionId, String connectionKey) {
+        this.stateChange = stateChange;
+        this.connectionId = connectionId;
+        this.connectionKey = connectionKey;
+    }
+}

--- a/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
+++ b/android/src/main/java/io/ably/flutter/plugin/generated/PlatformConstants.java
@@ -309,6 +309,8 @@ final public class PlatformConstants {
         public static final String event = "event";
         public static final String retryIn = "retryIn";
         public static final String reason = "reason";
+        public static final String connectionId = "connectionId";
+        public static final String connectionKey = "connectionKey";
     }
 
     static final public class TxChannelStateChange {

--- a/ios/Classes/AblyFlutterStreamHandler.h
+++ b/ios/Classes/AblyFlutterStreamHandler.h
@@ -2,7 +2,19 @@
 @import Flutter;
 #import "AblyFlutter.h"
 
+@class ARTConnectionStateChange;
+
 NS_ASSUME_NONNULL_BEGIN
+
+@interface _AblyConnectionStateChange : NSObject
+
+@property(nonatomic, readonly) ARTConnectionStateChange *value;
+@property(nonatomic, readonly) NSString *connectionId;
+@property(nonatomic, readonly) NSString *connectionKey;
+
+- (instancetype)initWithStateChange:(ARTConnectionStateChange *)stateChange connectionId:(NSString *)connectionId connectionKey:(NSString *)connectionKey;
+
+@end
 
 @interface AblyFlutterStreamHandler : NSObject<FlutterStreamHandler>
 

--- a/ios/Classes/AblyFlutterStreamHandler.m
+++ b/ios/Classes/AblyFlutterStreamHandler.m
@@ -5,6 +5,20 @@
 #import "AblyFlutterMessage.h"
 #import "codec/AblyPlatformConstants.h"
 
+@implementation _AblyConnectionStateChange
+
+- (instancetype)initWithStateChange:(ARTConnectionStateChange *)stateChange connectionId:(NSString *)connectionId connectionKey:(NSString *)connectionKey {
+    self = [super init];
+    if (self) {
+        _value = stateChange;
+        _connectionId = connectionId;
+        _connectionKey = connectionKey;
+    }
+    return self;
+}
+
+@end
+
 @implementation AblyFlutterStreamHandler{
     ARTEventListener *listener;
 }
@@ -42,7 +56,8 @@
                              details:eventName
                     ]);
                 } else {
-                    emitter(stateChange);
+                    _AblyConnectionStateChange * const _stateChange = [[_AblyConnectionStateChange alloc] initWithStateChange:stateChange connectionId:realtime.connection.id connectionKey:realtime.connection.key];
+                    emitter(_stateChange);
                 }
             }];
         } else if ([AblyPlatformMethod_onRealtimeChannelStateChanged isEqual: eventName]) {

--- a/ios/Classes/codec/AblyFlutterWriter.m
+++ b/ios/Classes/codec/AblyFlutterWriter.m
@@ -5,6 +5,7 @@
 #import "AblyFlutterMessage.h"
 #import "AblyFlutterReader.h"
 #import "AblyPlatformConstants.h"
+#import "AblyFlutterStreamHandler.h"
 
 
 NS_ASSUME_NONNULL_BEGIN
@@ -21,7 +22,7 @@ NS_ASSUME_NONNULL_END
         return CodecTypeAblyMessage;
     }else if([value isKindOfClass:[ARTErrorInfo class]]){
         return CodecTypeErrorInfo;
-    }else if([value isKindOfClass:[ARTConnectionStateChange class]]){
+    } else if([value isKindOfClass:[_AblyConnectionStateChange class]]){
         return CodecTypeConnectionStateChange;
     }else if([value isKindOfClass:[ARTChannelStateChange class]]){
         return CodecTypeChannelStateChange;
@@ -207,19 +208,21 @@ static AblyCodecEncoder encodeErrorInfo = ^NSMutableDictionary*(ARTErrorInfo *co
     }
 }
 
-static AblyCodecEncoder encodeConnectionStateChange = ^NSMutableDictionary*(ARTConnectionStateChange *const stateChange) {
+static AblyCodecEncoder encodeConnectionStateChange = ^NSMutableDictionary*(_AblyConnectionStateChange *const stateChange) {
     NSMutableDictionary<NSString *, NSObject *> *dictionary = [[NSMutableDictionary alloc] init];
     WRITE_VALUE(dictionary,
                 TxConnectionStateChange_current,
-                [AblyFlutterWriter encodeConnectionState: [stateChange current]]);
+                [AblyFlutterWriter encodeConnectionState: [stateChange.value current]]);
     WRITE_VALUE(dictionary,
                 TxConnectionStateChange_previous,
-                [AblyFlutterWriter encodeConnectionState: [stateChange previous]]);
+                [AblyFlutterWriter encodeConnectionState: [stateChange.value previous]]);
     WRITE_VALUE(dictionary,
                 TxConnectionStateChange_event,
-                [AblyFlutterWriter encodeConnectionEvent: [stateChange event]]);
-    WRITE_VALUE(dictionary, TxConnectionStateChange_retryIn, [stateChange retryIn]?@((int)([stateChange retryIn] * 1000)):nil);
-    WRITE_VALUE(dictionary, TxConnectionStateChange_reason, encodeErrorInfo([stateChange reason]));
+                [AblyFlutterWriter encodeConnectionEvent: [stateChange.value event]]);
+    WRITE_VALUE(dictionary, TxConnectionStateChange_retryIn, [stateChange.value retryIn]?@((int)([stateChange.value retryIn] * 1000)):nil);
+    WRITE_VALUE(dictionary, TxConnectionStateChange_reason, encodeErrorInfo([stateChange.value reason]));
+    WRITE_VALUE(dictionary, TxConnectionStateChange_connectionId, stateChange.connectionId);
+    WRITE_VALUE(dictionary, TxConnectionStateChange_connectionKey, stateChange.connectionKey);
     return dictionary;
 };
 

--- a/ios/Classes/codec/AblyPlatformConstants.h
+++ b/ios/Classes/codec/AblyPlatformConstants.h
@@ -283,6 +283,8 @@ extern NSString *const TxConnectionStateChange_previous;
 extern NSString *const TxConnectionStateChange_event;
 extern NSString *const TxConnectionStateChange_retryIn;
 extern NSString *const TxConnectionStateChange_reason;
+extern NSString *const TxConnectionStateChange_connectionId;
+extern NSString *const TxConnectionStateChange_connectionKey;
 
 // key constants for ChannelStateChange
 extern NSString *const TxChannelStateChange_current;

--- a/ios/Classes/codec/AblyPlatformConstants.m
+++ b/ios/Classes/codec/AblyPlatformConstants.m
@@ -252,6 +252,8 @@ NSString *const TxConnectionStateChange_previous = @"previous";
 NSString *const TxConnectionStateChange_event = @"event";
 NSString *const TxConnectionStateChange_retryIn = @"retryIn";
 NSString *const TxConnectionStateChange_reason = @"reason";
+NSString *const TxConnectionStateChange_connectionId = @"connectionId";
+NSString *const TxConnectionStateChange_connectionKey = @"connectionKey";
 
 // key constants for ChannelStateChange
 NSString *const TxChannelStateChange_current = @"current";

--- a/lib/src/generated/platform_constants.dart
+++ b/lib/src/generated/platform_constants.dart
@@ -311,6 +311,8 @@ class TxConnectionStateChange {
   static const String event = 'event';
   static const String retryIn = 'retryIn';
   static const String reason = 'reason';
+  static const String connectionId = 'connectionId';
+  static const String connectionKey = 'connectionKey';
 }
 
 class TxChannelStateChange {

--- a/lib/src/platform/src/codec.dart
+++ b/lib/src/platform/src/codec.dart
@@ -129,7 +129,8 @@ class Codec extends StandardMessageCodec {
 
       // Events - Connection
       CodecTypes.connectionStateChange:
-          _CodecPair<ConnectionStateChange>(null, _decodeConnectionStateChange),
+          _CodecPair<EnrichedConnectionStateChange>(
+              null, _decodeConnectionStateChange),
 
       // Events - Channel
       CodecTypes.channelStateChange:
@@ -1096,9 +1097,14 @@ class Codec extends StandardMessageCodec {
   /// @nodoc
   /// Decodes value [jsonMap] to [ConnectionStateChange]
   /// returns null if [jsonMap] is null
-  ConnectionStateChange _decodeConnectionStateChange(
+  EnrichedConnectionStateChange _decodeConnectionStateChange(
     Map<String, dynamic> jsonMap,
   ) {
+    final connectionId =
+        _readFromJson<String>(jsonMap, TxConnectionStateChange.connectionId);
+    final connectionKey =
+        _readFromJson<String>(jsonMap, TxConnectionStateChange.connectionKey);
+
     final current = _decodeConnectionState(
         _readFromJson<String>(jsonMap, TxConnectionStateChange.current));
     final previous = _decodeConnectionState(
@@ -1112,12 +1118,16 @@ class Codec extends StandardMessageCodec {
       TxConnectionStateChange.reason,
     ));
     final reason = (errorInfo == null) ? null : _decodeErrorInfo(errorInfo);
-    return ConnectionStateChange(
-      current: current,
-      previous: previous,
-      event: event,
-      retryIn: retryIn,
-      reason: reason,
+    return EnrichedConnectionStateChange(
+      stateChange: ConnectionStateChange(
+        current: current,
+        previous: previous,
+        event: event,
+        retryIn: retryIn,
+        reason: reason,
+      ),
+      connectionId: connectionId,
+      connectionKey: connectionKey,
     );
   }
 

--- a/lib/src/platform/src/realtime/connection.dart
+++ b/lib/src/platform/src/realtime/connection.dart
@@ -13,6 +13,10 @@ class Connection extends PlatformObject {
 
   ErrorInfo? _errorReason;
 
+  String? _id;
+
+  String? _key;
+
   /// @nodoc
   /// Instantiates a connection with [realtime] client instance.
   ///
@@ -21,9 +25,11 @@ class Connection extends PlatformObject {
   Connection(this.realtime)
       : _state = ConnectionState.initialized,
         super() {
-    on().listen((event) {
-      _state = event.current;
-      _errorReason = event.reason;
+    _onConnectionStateChange().listen((event) {
+      _state = event.stateChange.current;
+      _errorReason = event.stateChange.reason;
+      _id = event.connectionId;
+      _key = event.connectionKey;
     });
   }
 
@@ -37,7 +43,7 @@ class Connection extends PlatformObject {
 
   /// A unique public identifier for this connection, used to identify this
   /// member.
-  String? id;
+  String? get id => _id;
 
   /// A unique private connection key used to recover or resume a connection,
   /// assigned by Ably.
@@ -48,7 +54,7 @@ class Connection extends PlatformObject {
   /// to publish on behalf of this client. See the
   /// [publishing over REST on behalf of a realtime client docs](https://ably.com/docs/rest/channels#publish-on-behalf)
   /// for more info.
-  String? key;
+  String? get key => _key;
 
   /// The recovery key string can be used by another client to recover this
   /// connection's state in the recover client options property.
@@ -69,13 +75,18 @@ class Connection extends PlatformObject {
   /// The current [ConnectionState] of the connection.
   ConnectionState get state => _state;
 
+  /// @nodoc
+  Stream<EnrichedConnectionStateChange> _onConnectionStateChange() =>
+      listen<EnrichedConnectionStateChange>(
+        PlatformMethod.onRealtimeConnectionStateChanged,
+      );
+
   /// Stream of connection events with specified [ConnectionEvent] type.
   Stream<ConnectionStateChange> on([ConnectionEvent? connectionEvent]) =>
-      listen<ConnectionStateChange>(
-        PlatformMethod.onRealtimeConnectionStateChanged,
-      ).where((connectionStateChange) =>
-          connectionEvent == null ||
-          connectionStateChange.event == connectionEvent);
+      _onConnectionStateChange().map((event) => event.stateChange).where(
+          (connectionStateChange) =>
+              connectionEvent == null ||
+              connectionStateChange.event == connectionEvent);
 
   /// Causes the connection to close, entering the [ConnectionState.closing]
   /// state.

--- a/lib/src/realtime/src/connection_state_change.dart
+++ b/lib/src/realtime/src/connection_state_change.dart
@@ -35,3 +35,20 @@ class ConnectionStateChange {
     this.retryIn,
   });
 }
+
+/// @nodoc
+@immutable
+class EnrichedConnectionStateChange {
+  /// @nodoc
+  final ConnectionStateChange stateChange;
+
+  /// @nodoc
+  final String? connectionId;
+
+  /// @nodoc
+  final String? connectionKey;
+
+  /// @nodoc
+  const EnrichedConnectionStateChange(
+      {required this.stateChange, this.connectionId, this.connectionKey});
+}


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/502
Jira issue [ECO-4629](https://ably.atlassian.net/browse/ECO-4629) 

Add `key` and `id` to `ConnectionStateChange` event, updated example app

[ECO-4629]: https://ably.atlassian.net/browse/ECO-4629?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ