### PR TITLE
[ECO-1780] Removes broken feature matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,10 +688,6 @@ You might also need to upgrade [gradle distribution](https://developer.android.c
 
 When increasing the version of `ably_flutter` in your `pubspec.yaml`, there may be breaking changes. To migrate code across these breaking changes, follow the [updating / migration guide](UPDATING.md).
 
-## Feature support
-
-See Ably [feature support matrix](https://ably.com/download/sdk-feature-support-matrix) for a list of features supported by this SDK.
-
 ## Known limitations
 
 ### Missing features


### PR DESCRIPTION
Removes broken feature matrix link - will be replaced in the future with an updated feature checklist.