### PR TITLE
feat: add clientId switch to the example app

### DIFF
--- a/example/lib/ui/ably_service.dart
+++ b/example/lib/ui/ably_service.dart
@@ -4,16 +4,17 @@ import 'package:ably_flutter_example/push_notifications/push_notification_servic
 import 'package:ably_flutter_example/ui/api_key_service.dart';
 
 class AblyService {
+  final String clientId;
   late final ably.Realtime realtime;
   late final ably.Rest rest;
   late final PushNotificationService pushNotificationService;
   late final ApiKeyProvision apiKeyProvision;
 
-  AblyService({required this.apiKeyProvision}) {
+  AblyService({required this.apiKeyProvision, required this.clientId}) {
     realtime = ably.Realtime(
       options: ably.ClientOptions(
         key: apiKeyProvision.key,
-        clientId: Constants.clientId,
+        clientId: clientId,
         logLevel: ably.LogLevel.verbose,
         environment: apiKeyProvision.source == ApiKeySource.env
             ? null
@@ -24,7 +25,7 @@ class AblyService {
     rest = ably.Rest(
       options: ably.ClientOptions(
         key: apiKeyProvision.key,
-        clientId: Constants.clientId,
+        clientId: clientId,
         logLevel: ably.LogLevel.verbose,
         environment: apiKeyProvision.source == ApiKeySource.env
             ? null

--- a/example/lib/ui/realtime_presence_sliver.dart
+++ b/example/lib/ui/realtime_presence_sliver.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:ably_flutter/ably_flutter.dart' as ably;
-import 'package:ably_flutter_example/constants.dart';
 import 'package:ably_flutter_example/ui/paginated_result_viewer.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
 import 'package:flutter/material.dart';
@@ -97,7 +96,7 @@ class RealtimePresenceSliver extends HookWidget {
   Widget updateRealtimePresence() => TextButton(
         onPressed: () async {
           await channel.presence
-              .updateClient(Constants.clientId, _nextPresenceData);
+              .updateClient(realtime.options.clientId!, _nextPresenceData);
         },
         child: const Text('Update'),
       );

--- a/example/lib/ui/system_details_sliver.dart
+++ b/example/lib/ui/system_details_sliver.dart
@@ -1,5 +1,4 @@
 import 'package:ably_flutter/ably_flutter.dart' as ably;
-import 'package:ably_flutter_example/constants.dart';
 import 'package:ably_flutter_example/ui/api_key_service.dart';
 import 'package:ably_flutter_example/ui/text_row.dart';
 import 'package:flutter/material.dart';
@@ -7,10 +6,12 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 
 // ignore: must_be_immutable
 class SystemDetailsSliver extends HookWidget {
-  ApiKeyProvision apiKeyProvision;
+  final ApiKeyProvision apiKeyProvision;
+  final String clientId;
 
-  SystemDetailsSliver({
+  const SystemDetailsSliver({
     required this.apiKeyProvision,
+    required this.clientId,
     Key? key,
   }) : super(key: key);
 
@@ -34,7 +35,7 @@ class SystemDetailsSliver extends HookWidget {
         ),
         TextRow('Running on', platformVersion.value),
         TextRow('Ably version', ablyVersion.value),
-        TextRow('Ably Client ID', Constants.clientId),
+        TextRow('Ably Client ID', clientId),
         TextRow('Ably API key', hideApiKeySecret(apiKeyProvision.key)),
         if (apiKeyProvision.source != ApiKeySource.env)
           RichText(


### PR DESCRIPTION
Sometimes it's useful to check how the app behaves when the `clientId` changes during the app lifecycle.