### PR TITLE
[ECO-4748] Adds privacy manifest for iOS plugin

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.29):
+  - Ably (1.2.30):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.29):
-    - Ably (= 1.2.29)
+    - Ably (= 1.2.30)
     - Flutter
   - AblyDeltaCodec (1.3.3)
   - device_info_plus (0.0.1):
@@ -44,11 +44,11 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/fluttertoast/ios"
 
 SPEC CHECKSUMS:
-  Ably: 2a5dc2bbb7a3fe65447f4791237264795c470b8e
-  ably_flutter: 673619b9109d14b770de602d84f70d6fbd0e91cc
+  Ably: 0022e87130c1a433cf63852ef09d0cdd7c19f028
+  ably_flutter: ff887dac49302494cc44704c630311c219f0d228
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
   fluttertoast: 6122fa75143e992b1d3470f61000f591a798cc58
   msgpack: c85f6251873059738472ae136951cec5f30f3251
@@ -56,4 +56,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 1e2c1b20be30d932ecf4aea37c7fa8602c49c7fa
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/ios/Resources/PrivacyInfo.xcprivacy
+++ b/ios/Resources/PrivacyInfo.xcprivacy
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSPrivacyTracking</key>
+    <false />
+    <key>NSPrivacyTrackingDomains</key>
+    <array />
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyCollectedDataType</key>
+        <string>NSPrivacyCollectedDataTypeDeviceID</string>
+        <key>NSPrivacyCollectedDataTypeLinked</key>
+        <true />
+        <key>NSPrivacyCollectedDataTypeTracking</key>
+        <true />
+        <key>NSPrivacyCollectedDataTypePurposes</key>
+        <array>
+          <string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+        </array>
+      </dict>
+    </array>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+  </dict>
+</plist>

--- a/ios/ably_flutter.podspec
+++ b/ios/ably_flutter.podspec
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Ably', '1.2.29'
+  s.dependency 'Ably', '1.2.30'
   s.platform = :ios
   s.ios.deployment_target  = '10.0'
 
@@ -28,5 +28,6 @@ Pod::Spec.new do |s|
     'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
     'GCC_PREPROCESSOR_DEFINITIONS' => "FLUTTER_PACKAGE_PLUGIN_VERSION=\\@\\\"#{flutter_package_plugin_version}\\\""
   }
+  s.resource_bundles = {'ably_flutter' => ['Resources/PrivacyInfo.xcprivacy']}
   s.swift_version = '5.0'
 end

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -1,9 +1,9 @@
 PODS:
-  - Ably (1.2.29):
+  - Ably (1.2.30):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
   - ably_flutter (1.2.29):
-    - Ably (= 1.2.29)
+    - Ably (= 1.2.30)
     - Flutter
   - AblyDeltaCodec (1.3.3)
   - Flutter (1.0.0)
@@ -26,12 +26,12 @@ EXTERNAL SOURCES:
     :path: Flutter
 
 SPEC CHECKSUMS:
-  Ably: 2a5dc2bbb7a3fe65447f4791237264795c470b8e
-  ably_flutter: 673619b9109d14b770de602d84f70d6fbd0e91cc
+  Ably: 0022e87130c1a433cf63852ef09d0cdd7c19f028
+  ably_flutter: ff887dac49302494cc44704c630311c219f0d228
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
-  Flutter: f04841e97a9d0b0a8025694d0796dd46242b2854
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   msgpack: c85f6251873059738472ae136951cec5f30f3251
 
 PODFILE CHECKSUM: f2c6cc511583caab2c65ac3f5766428391d93d34
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2


### PR DESCRIPTION
- Includes the same changes from our ably-cocoa repo [here](https://github.com/ably/ably-cocoa/pull/1900)
- Bumps cocoa dependency to v1.2.30