### PR TITLE
[ECO-4807] fix: message extras decoding

### DIFF
--- a/lib/src/message/src/message_extras.dart
+++ b/lib/src/message/src/message_extras.dart
@@ -32,11 +32,14 @@ class MessageExtras with ObjectHash {
     // for example, when it's a CastMap, so we need to create a mutable
     // instance from the existing extras map
     final mutableExtrasMap = Map<String, dynamic>.from(extrasMap);
-    final deltaMap =
-        mutableExtrasMap.remove(TxMessageExtras.delta) as Map<String, dynamic>?;
+    final deltaMap = mutableExtrasMap.remove(TxMessageExtras.delta) as Map?;
+    final deltaExtras = (deltaMap == null)
+        ? null
+        : DeltaExtras.fromMap(Map<String, dynamic>.from(deltaMap));
+
     return MessageExtras._withDelta(
       mutableExtrasMap,
-      (deltaMap == null) ? null : DeltaExtras.fromMap(deltaMap),
+      deltaExtras,
     );
   }
 


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/523

By default `JsonObject` is deserializing into `Map<Object?, Object?>`, we need to do explicit cast to get `Map<String, dynamic>`