### PR TITLE
fix(iOS): `transportParams` serialization

### DIFF
--- a/ios/Classes/codec/AblyFlutterReader.h
+++ b/ios/Classes/codec/AblyFlutterReader.h
@@ -9,6 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 +(ARTTokenDetails *)tokenDetailsFromDictionary: (NSDictionary *) dictionary;
 +(ARTTokenParams *)tokenParamsFromDictionary: (NSDictionary *) dictionary;
++(NSDictionary<NSString *, ARTStringifiable *> *)transportParamsFromDictionary: (NSDictionary *) dictionary;
 
 @end
 

--- a/ios/Classes/codec/AblyFlutterReader.m
+++ b/ios/Classes/codec/AblyFlutterReader.m
@@ -140,7 +140,9 @@ static AblyCodecDecoder readClientOptions = ^AblyFlutterClientOptions*(NSDiction
     READ_VALUE(clientOptions, idempotentRestPublishing, dictionary, TxClientOptions_idempotentRestPublishing);
     READ_VALUE(clientOptions, fallbackHosts, dictionary, TxClientOptions_fallbackHosts);
     READ_VALUE(clientOptions, fallbackHostsUseDefault, dictionary, TxClientOptions_fallbackHostsUseDefault);
-    READ_VALUE(clientOptions, transportParams, dictionary, TxClientOptions_transportParams);
+    ON_VALUE(^(const id value) {
+        clientOptions.transportParams = [AblyFlutterReader transportParamsFromDictionary: value];
+    }, dictionary, TxClientOptions_transportParams);
     ON_VALUE(^(const id value) {
         clientOptions.defaultTokenParams = [AblyFlutterReader tokenParamsFromDictionary: value];
     }, dictionary, TxClientOptions_defaultTokenParams);
@@ -243,6 +245,19 @@ static AblyCodecDecoder readTokenParams = ^ARTTokenParams*(NSDictionary *const d
         tokenParams.timestamp = [NSDate dateWithTimeIntervalSince1970:[value doubleValue]/1000];
     }, dictionary, TxTokenParams_timestamp);
     return tokenParams;
+}
+
+
++(NSDictionary<NSString *, ARTStringifiable *> *)transportParamsFromDictionary: (NSDictionary *) dictionary {
+    NSMutableDictionary<NSString *, ARTStringifiable *> *result = [NSMutableDictionary dictionary];
+
+    for (NSString *key in dictionary) {
+        NSString *value = dictionary[key];
+        ARTStringifiable *stringifiable = [[ARTStringifiable alloc] initWithString:value];
+        result[key] = stringifiable;
+    }
+
+    return [result copy];
 }
 
 static AblyCodecDecoder readChannelMessageExtras = ^id<ARTJsonCompatible>(NSDictionary *const dictionary) {


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/527

Fixed `transportParams` serialization logic, it returned `NSDictionary` with `NSString` values instead of `ARTStringifiable`.