### PR TITLE
fix: serialization for push notification

### DIFF
--- a/lib/src/push_notifications/src/notification.dart
+++ b/lib/src/push_notifications/src/notification.dart
@@ -26,6 +26,6 @@ class Notification {
   /// Creates an instance from the map.
   factory Notification.fromMap(Map<String, dynamic> map) => Notification(
         body: map[TxNotification.body] as String?,
-        title: map[TxNotification.title] as String,
+        title: map[TxNotification.title] as String? ?? '',
       );
 }


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/532

made `title` optional according to [FCM docs](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage.Notification)