### PR TITLE
[ECO-4875] fix: out of sync message handlers

### DIFF
--- a/lib/src/platform/src/streams_channel.dart
+++ b/lib/src/platform/src/streams_channel.dart
@@ -40,7 +40,7 @@ class StreamsChannel {
   /// The message codec used by this channel, not null.
   final MethodCodec codec;
 
-  int _lastId = 0;
+  static int _lastId = 0;
 
   /// @nodoc
   /// Registers a listener on platform side and manages the listener


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/531

Makes `StreamsChannel#_lastId` field static, because:

During hot reloading, the Ably instance can be recreated. `StreamsChannel#_lastId` field is used to create IDs for platform-specific subscriptions, which are used on iOS and Android. Code that used to register subscription handler is a singleton, so two Ably instances overwrite each other, causing the platform implementation to be out of sync with the Flutter message handler.