### PR TITLE
ci: update platform versions

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -9,9 +9,9 @@ jobs:
     strategy:
       matrix:
         device: # Device names must be shown in `xcrun simctl list devices`
-          - 'iPhone 12' # we are not specifying the iOS version as it tends to change
+          - 'iPhone 14' # we are not specifying the iOS version as it tends to change
       fail-fast: false
-    runs-on: 'macos-11'
+    runs-on: 'macos-latest'
     steps:
       - name: 'List Simulators'
         run: 'xcrun simctl list devices'
@@ -42,7 +42,7 @@ jobs:
         api-level: [24, 29]
       fail-fast: false
 
-    runs-on: 'macos-11'
+    runs-on: 'macos-latest'
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
fixes some issues with no longer supported versions

android CI is still broken even after these changes, but this at least gets iOS running again