### PR TITLE
fix: add missing warn logLevel serialization

### DIFF
--- a/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
+++ b/android/src/main/java/io/ably/flutter/plugin/AblyMessageCodec.java
@@ -398,6 +398,8 @@ public class AblyMessageCodec extends StandardMessageCodec {
                 return Log.INFO;
             case PlatformConstants.TxLogLevelEnum.error:
                 return Log.ERROR;
+            case PlatformConstants.TxLogLevelEnum.warn:
+                return Log.WARN;
             default:
                 throw SerializationException.forEnum(logLevelString, Log.class);
         }


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging capabilities by adding support for the `warn` log level in the codec's logging mechanism.

- **Bug Fixes**
	- Improved handling of log levels to ensure accurate processing of the `warn` log level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->