### PR TITLE
Release/1.2.38

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.38](https://github.com/ably/ably-flutter/tree/v1.2.38)
+
+[Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.37...v1.2.38)
+
+- Fixed NullPointerException [\#568](https://github.com/ably/ably-flutter/pull/568)
+
 ## [1.2.37](https://github.com/ably/ably-flutter/tree/v1.2.37)
 
 [Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.36...v1.2.37)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  ably_flutter: ^1.2.37
+  ably_flutter: ^1.2.38
 ```
 
 ### Import the package

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.33):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.37):
+  - ably_flutter (1.2.38):
     - Ably (= 1.2.33)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -13,7 +13,9 @@ PODS:
     - Flutter
   - fluttertoast (0.0.2):
     - Flutter
+    - Toast
   - msgpack (0.4.0)
+  - Toast (4.0.0)
 
 DEPENDENCIES:
   - ably_flutter (from `.symlinks/plugins/ably_flutter/ios`)
@@ -27,6 +29,7 @@ SPEC REPOS:
     - Ably
     - AblyDeltaCodec
     - msgpack
+    - Toast
 
 EXTERNAL SOURCES:
   ably_flutter:
@@ -42,14 +45,15 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1d78e5dec56db6d2cf91b10d14fea796ce591bae
-  ably_flutter: b7240352d43f256235bd2d69029ca2cec7e83e30
+  ably_flutter: 67f5bc5b988b42f81e17b40e7f5e979763436a2f
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
-  device_info_plus: 97af1d7e84681a90d0693e63169a5d50e0839a0d
+  device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
-  flutter_local_notifications: 4cde75091f6327eb8517fa068a0a5950212d2086
-  fluttertoast: 21eecd6935e7064cc1fcb733a4c5a428f3f24f0f
+  flutter_local_notifications: 0c0b1ae97e741e1521e4c1629a459d04b9aec743
+  fluttertoast: 6122fa75143e992b1d3470f61000f591a798cc58
   msgpack: c85f6251873059738472ae136951cec5f30f3251
+  Toast: 91b396c56ee72a5790816f40d3a94dd357abc196
 
 PODFILE CHECKSUM: 1e2c1b20be30d932ecf4aea37c7fa8602c49c7fa
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/Ably/Ably.framework",
 				"${BUILT_PRODUCTS_DIR}/AblyDeltaCodec/AblyDeltaCodec.framework",
+				"${BUILT_PRODUCTS_DIR}/Toast/Toast.framework",
 				"${BUILT_PRODUCTS_DIR}/ably_flutter/ably_flutter.framework",
 				"${BUILT_PRODUCTS_DIR}/device_info_plus/device_info_plus.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_local_notifications/flutter_local_notifications.framework",
@@ -234,6 +235,7 @@
 			outputPaths = (
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Ably.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/AblyDeltaCodec.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Toast.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ably_flutter.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/device_info_plus.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_local_notifications.framework",

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.37"
+    version: "1.2.38"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ably_flutter
 description: A wrapper around Ably's Cocoa and Java client library SDKs, providing iOS and Android support.
-version: 1.2.37
+version: 1.2.38
 repository: https://github.com/ably/ably-flutter
 
 environment:

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.33):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.37):
+  - ably_flutter (1.2.38):
     - Ably (= 1.2.33)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -27,11 +27,11 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1d78e5dec56db6d2cf91b10d14fea796ce591bae
-  ably_flutter: b7240352d43f256235bd2d69029ca2cec7e83e30
+  ably_flutter: 67f5bc5b988b42f81e17b40e7f5e979763436a2f
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   msgpack: c85f6251873059738472ae136951cec5f30f3251
 
 PODFILE CHECKSUM: f2c6cc511583caab2c65ac3f5766428391d93d34
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.15.2

--- a/test_integration/pubspec.lock
+++ b/test_integration/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.37"
+    version: "1.2.38"
   analyzer:
     dependency: transitive
     description:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the changelog with details for version 1.2.38, including a bug fix.
  - Updated the README to reference the latest package version in usage examples.

- **Chores**
  - Bumped the package version to 1.2.38.
  - Ensured the Toast framework is properly embedded in the iOS project build configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->