### PR TITLE
Release/1.2.39

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.39](https://github.com/ably/ably-flutter/tree/v1.2.39)
+
+[Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.38...v1.2.39)
+
+- Added ability to opt out of iOS push notifications [\#560](https://github.com/ably/ably-flutter/pull/560)
+
 ## [1.2.38](https://github.com/ably/ably-flutter/tree/v1.2.38)
 
 [Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.37...v1.2.38)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In `pubspec.yaml` file:
 
 ```yaml
 dependencies:
-  ably_flutter: ^1.2.38
+  ably_flutter: ^1.2.39
 ```
 
 ### Import the package

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.33):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.38):
+  - ably_flutter (1.2.39):
     - Ably (= 1.2.33)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -45,7 +45,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1d78e5dec56db6d2cf91b10d14fea796ce591bae
-  ably_flutter: 67f5bc5b988b42f81e17b40e7f5e979763436a2f
+  ably_flutter: faa19330c0be51991d44a8e57b68016e3d264cbd
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   device_info_plus: e5c5da33f982a436e103237c0c85f9031142abed
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.38"
+    version: "1.2.39"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ably_flutter
 description: A wrapper around Ably's Cocoa and Java client library SDKs, providing iOS and Android support.
-version: 1.2.38
+version: 1.2.39
 repository: https://github.com/ably/ably-flutter
 
 environment:

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.33):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.38):
+  - ably_flutter (1.2.39):
     - Ably (= 1.2.33)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1d78e5dec56db6d2cf91b10d14fea796ce591bae
-  ably_flutter: 67f5bc5b988b42f81e17b40e7f5e979763436a2f
+  ably_flutter: faa19330c0be51991d44a8e57b68016e3d264cbd
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   msgpack: c85f6251873059738472ae136951cec5f30f3251

--- a/test_integration/pubspec.lock
+++ b/test_integration/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.38"
+    version: "1.2.39"
   analyzer:
     dependency: transitive
     description:


### PR DESCRIPTION
- Added ability to opt out of iOS push notifications [\#560](https://github.com/ably/ably-flutter/pull/560)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated changelog with details for version 1.2.39, highlighting the new ability to opt out of iOS push notifications.
  - Updated README to reference the latest package version in usage examples.

- **Chores**
  - Bumped package version to 1.2.39 in configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->