### PR TITLE
[ECO-5606] fix: enforce `Locale.ROOT` for string formatting in `StreamsChannel`

### DIFF
--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -7,11 +7,6 @@ on:
 
 jobs:
   ios:
-    strategy:
-      matrix:
-        device: # Device names must be shown in `xcrun simctl list devices`
-          - 'iPhone 15' # we are not specifying the iOS version as it tends to change
-      fail-fast: false
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
@@ -22,7 +17,7 @@ jobs:
 
       - uses: subosito/flutter-action@v2
         with:
-          flutter-version: '3.24'
+          flutter-version: '3.29'
           cache: true
 
       # test_integration package depends on ably_flutter, so before we run integration

--- a/android/src/main/java/io/ably/flutter/plugin/StreamsChannel.java
+++ b/android/src/main/java/io/ably/flutter/plugin/StreamsChannel.java
@@ -20,11 +20,10 @@
 
 package io.ably.flutter.plugin;
 
-import android.annotation.SuppressLint;
-
 import androidx.annotation.UiThread;
 
 import java.nio.ByteBuffer;
+import java.util.Locale;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -160,7 +159,7 @@ final class StreamsChannel {
         }
 
         private void logError(long id, String message, Throwable e) {
-            Log.e(TAG + name, String.format("%s [id=%d]", message, id), e);
+            Log.e(TAG + name, String.format(Locale.ROOT, "%s [id=%d]", message, id), e);
         }
 
         private final class EventSinkImplementation implements EventChannel.EventSink {
@@ -169,10 +168,9 @@ final class StreamsChannel {
             final String name;
             final AtomicBoolean hasEnded = new AtomicBoolean(false);
 
-            @SuppressLint("DefaultLocale")
             private EventSinkImplementation(long id) {
                 this.id = id;
-                this.name = String.format("%s#%d", StreamsChannel.this.name, id);
+                this.name = String.format(Locale.ROOT, "%s#%d", StreamsChannel.this.name, id);
             }
 
             @Override


### PR DESCRIPTION
Resolves https://github.com/ably/ably-flutter/issues/580

- Updated `String.format` calls to use `Locale.ROOT` to ensure consistent formatting regardless of device locale configuration.
- Removed unnecessary `@SuppressLint` annotation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made text formatting for error messages and event names locale-independent so they display consistently across devices.

* **Chores**
  * Updated iOS integration CI to use Flutter 3.29 and removed the previous device matrix strategy.
  * Removed an unused lint annotation to streamline code hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->