### PR TITLE
Release/1.2.44

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.44](https://github.com/ably/ably-flutter/tree/v1.2.44)
+
+[Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.43...v1.2.44)
+
+- Fix exceptions when FlutterEngine is suspended during event emission [#595](https://github.com/ably/ably-flutter/pull/595)
+
 ## [1.2.43](https://github.com/ably/ably-flutter/tree/v1.2.43)
 
 [Full Changelog](https://github.com/ably/ably-flutter/compare/v1.2.42...v1.2.43)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Add the Ably Flutter package to your project by including it in your `pubspec.ya
 
 ```yaml
 dependencies:
-  ably_flutter: ^1.2.43
+  ably_flutter: ^1.2.44
 ```
 
 Once added to your dependencies, import it in your Dart code:

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.53):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.43):
+  - ably_flutter (1.2.44):
     - Ably (= 1.2.53)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -42,7 +42,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1756d6590a572809c10fc4bcc32e05fe9e7867d7
-  ably_flutter: 004a547347b332d8e99148d6f8c76be67c9c1071
+  ably_flutter: 95785161fc2858c7be524af4334925d30682b3b0
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   device_info_plus: 71ffc6ab7634ade6267c7a93088ed7e4f74e5896
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.43"
+    version: "1.2.44"
   args:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: ably_flutter
 description: A wrapper around Ably's Cocoa and Java client library SDKs, providing iOS and Android support.
-version: 1.2.43
+version: 1.2.44
 repository: https://github.com/ably/ably-flutter
 
 environment:

--- a/test_integration/ios/Podfile.lock
+++ b/test_integration/ios/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - Ably (1.2.53):
     - AblyDeltaCodec (= 1.3.3)
     - msgpack (= 0.4.0)
-  - ably_flutter (1.2.43):
+  - ably_flutter (1.2.44):
     - Ably (= 1.2.53)
     - Flutter
   - AblyDeltaCodec (1.3.3)
@@ -27,7 +27,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Ably: 1756d6590a572809c10fc4bcc32e05fe9e7867d7
-  ably_flutter: 004a547347b332d8e99148d6f8c76be67c9c1071
+  ably_flutter: 95785161fc2858c7be524af4334925d30682b3b0
   AblyDeltaCodec: add5d06a756b3581b12aab5b5500a320b8c55bea
   Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   msgpack: c85f6251873059738472ae136951cec5f30f3251

--- a/test_integration/pubspec.lock
+++ b/test_integration/pubspec.lock
@@ -15,7 +15,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.2.43"
+    version: "1.2.44"
   analyzer:
     dependency: transitive
     description:


### PR DESCRIPTION
- Fix exceptions when FlutterEngine is suspended during event emission [#595](https://github.com/ably/ably-flutter/pull/595)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed exceptions when FlutterEngine is suspended during event emission.

* **Chores**
  * Improved iOS integration test workflow with more reliable simulator boot and staged test steps.

* **Platform Requirements**
  * Raised minimum iOS deployment target to iOS 12.0; added runtime Info.plist flags for improved input and frame behavior.

* **Documentation**
  * Updated README and changelog; bumped package version to 1.2.44.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->