### PR TITLE
ci: GHA workflow security cleanup

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: '3.24'
           cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,6 +11,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,11 +10,11 @@ jobs:
       deployments: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: '3.24'
           cache: true
@@ -30,14 +30,14 @@ jobs:
           ls -al doc/api
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 # v1.7.0
         with:
           aws-region: eu-west-2
           role-to-assume: arn:aws:iam::${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}:role/ably-sdk-builds-ably-flutter
           role-session-name: "${{ github.run_id }}-${{ github.run_number }}"
 
       - name: Upload Documentation
-        uses: ably/sdk-upload-action@v1
+        uses: ably/sdk-upload-action@8c6179796fc7ee8fc9bb28d5223ffef005b985cc # v1.3.0
         with:
           sourcePath: doc/api
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -13,7 +13,10 @@ jobs:
   build:
     permissions:
       contents: read
+      deployments: write
+      id-token: write
     uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-flutter
-    secrets: inherit
+    secrets:
+      ABLY_AWS_ACCOUNT_ID_SDK: ${{ secrets.ABLY_AWS_ACCOUNT_ID_SDK }}

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -6,8 +6,13 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: read
     uses: ably/features/.github/workflows/sdk-features.yml@main
     with:
       repository-name: ably-flutter

--- a/.github/workflows/features.yml
+++ b/.github/workflows/features.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     permissions:
       contents: read
-    uses: ably/features/.github/workflows/sdk-features.yml@main
+    uses: ably/features/.github/workflows/sdk-features.yml@6b3fc7a8ede2ebdd7a6325314f3a96c6466f1453 # main
     with:
       repository-name: ably-flutter
     secrets: inherit

--- a/.github/workflows/flutter_example_app.yaml
+++ b/.github/workflows/flutter_example_app.yaml
@@ -11,11 +11,11 @@ jobs:
   ios:
     runs-on: "macos-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: "3.24"
           cache: true
@@ -28,16 +28,16 @@ jobs:
   android:
     runs-on: "ubuntu-latest"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: "temurin"
           java-version: "17"
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: "3.29"
           cache: true

--- a/.github/workflows/flutter_example_app.yaml
+++ b/.github/workflows/flutter_example_app.yaml
@@ -9,6 +9,8 @@ jobs:
     runs-on: "macos-latest"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:
@@ -24,6 +26,8 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/flutter_example_app.yaml
+++ b/.github/workflows/flutter_example_app.yaml
@@ -4,6 +4,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ios:
     runs-on: "macos-latest"

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:
@@ -60,6 +62,8 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ios:
     runs-on: macos-latest

--- a/.github/workflows/flutter_integration.yaml
+++ b/.github/workflows/flutter_integration.yaml
@@ -12,11 +12,11 @@ jobs:
   ios:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: '3.29'
           cache: true
@@ -64,11 +64,11 @@ jobs:
       fail-fast: false
     steps:
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
         with:
           distribution: "temurin"
           java-version: "17"
@@ -79,14 +79,14 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: '3.29'
           cache: true
 
       - name: 'Run Flutter Driver tests'
         timeout-minutes: 30
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
           api-level: ${{ matrix.api-level }}
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/ios_unit_tests.yml
+++ b/.github/workflows/ios_unit_tests.yml
@@ -12,11 +12,11 @@ jobs:
   ios-unit-tests:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2.23.0
         with:
           flutter-version: '3.29'
           cache: true

--- a/.github/workflows/ios_unit_tests.yml
+++ b/.github/workflows/ios_unit_tests.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: subosito/flutter-action@v2
         with:

--- a/.github/workflows/ios_unit_tests.yml
+++ b/.github/workflows/ios_unit_tests.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   ios-unit-tests:
     runs-on: macos-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
   publish:
     permissions:
       id-token: write # Required for authentication using OIDC
-    uses: dart-lang/setup-dart/.github/workflows/publish.yml@v1
+    uses: dart-lang/setup-dart/.github/workflows/publish.yml@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
     with:
       environment: 'pub.dev'
       # working-directory: path/to/package/within/repository


### PR DESCRIPTION
Routine hygiene pass over the GitHub Actions workflows in this repo, based on an automated audit. The changes are split into four commits, one per finding type.

- **Disable credential persistence on checkout** — every `actions/checkout` step now sets `persist-credentials: false`. None of these jobs push back to the repo, so leaving the `GITHUB_TOKEN` in the runner's git config after checkout serves no purpose.
- **Declare minimum permissions** — each workflow now sets an explicit `permissions:` block (top-level `contents: read`) so jobs no longer receive the default broad `GITHUB_TOKEN` scopes. Where a job legitimately needs more (e.g. `id-token: write` for OIDC, `deployments: write` for docs/features uploads), it keeps a job-level override.
- **Pin actions to commit SHAs** — third-party `uses:` references (`actions/checkout`, `actions/setup-java`, `subosito/flutter-action`, `aws-actions/configure-aws-credentials`, `ably/sdk-upload-action`, `reactivecircus/android-emulator-runner`, and the reusable workflows `ably/features` and `dart-lang/setup-dart`) are pinned to a specific commit SHA with the original tag retained as a trailing comment. This prevents an upstream tag from being silently re-pointed.
- **Stop inheriting all secrets into the features workflow** — the `features.yml` call to `ably/features/.../sdk-features.yml` previously used `secrets: inherit`, which forwards every repo/org secret. It now forwards only `ABLY_AWS_ACCOUNT_ID_SDK`, the single secret the called workflow declares.

No behaviour changes are expected; this is a hardening-only PR.